### PR TITLE
Add blog footer CTA

### DIFF
--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -5,6 +5,7 @@ import { serialize } from "next-mdx-remote/serialize";
 import { MDXRemote } from "next-mdx-remote";
 import Footer from "../../shared/footer";
 import Nav from "../../shared/nav";
+import Callout from "../../shared/Callout";
 import { Wrapper } from "../../shared/blog";
 import { highlight } from "../../utils/code";
 
@@ -53,6 +54,12 @@ export default function BlogLayout(props) {
             <span>{scope.img ? "/03" : "/02"}</span>
           </div>
         </Main>
+        <Callout
+          small="But, what is Inngest?"
+          heading="Inngest is serverless event mesh"
+          link="/?ref=blog-footer"
+          cta="Learn more >"
+        />
         <Footer />
       </Wrapper>
     </>
@@ -81,7 +88,7 @@ const Main = styled.div`
 
   main {
     max-width: 980px;
-    margin: 0 auto;
+    margin: 0 auto 4rem;
   }
 
   p {

--- a/shared/Callout.tsx
+++ b/shared/Callout.tsx
@@ -4,9 +4,11 @@ import Button from "./Button";
 type Props = {
   small?: string;
   heading?: string;
+  cta?: string;
+  link?: string;
 };
 
-const Callout: React.FC<Props> = ({ small, heading }) => {
+const Callout: React.FC<Props> = ({ small, heading, cta, link }) => {
   return (
     <div className="grid">
       <Content className="bg-primary">
@@ -14,8 +16,8 @@ const Callout: React.FC<Props> = ({ small, heading }) => {
           <span>{small || "Now with zero yaml ;-)"}</span>
           <h2>{heading || "Deploy a serverless function in minutes."}</h2>
         </div>
-        <Button kind="black" href="/sign-up">
-          {">"}_ Start building
+        <Button kind="black" href={link || "/sign-up"}>
+          {cta || ">_ Start building"}
         </Button>
       </Content>
     </div>
@@ -53,7 +55,8 @@ const Content = styled.div`
     font-size: 20px;
   }
 
-  button:hover, a:hover {
+  button:hover,
+  a:hover {
     background: var(--black);
     border-color: var(--black);
     box-shadow: 0 5px 25px rgba(var(--black-rgb), 0.6) !important;
@@ -75,5 +78,4 @@ const Content = styled.div`
     grid-template-columns: 1fr;
     grid-gap: 1rem;
   }
-
 `;


### PR DESCRIPTION
Links to the homepage w/ a `?ref=blog-footer` attribution. I chose homepage over the docs b/c I think the homepage currently captures more about what Inngest is for people landing directly on our blog from an external link.

**Feedback on copy apprecaited!**

![image](https://user-images.githubusercontent.com/1509457/155355654-71a254de-b816-4ec9-b631-49846c6803a5.png)
