### PR TITLE
Add light/dark mode toggle to docs

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,12 +7,6 @@ import "../styles/globals.css";
 import PageBanner from "../shared/PageBanner";
 
 function MyApp({ Component, pageProps }) {
-  // useEffect(() => {
-  //   // Ensure we persist the html and body classes set in _document on the client side
-  //   const isDark =
-  //     typeof pageProps.isDarkMode === "undefined" ? true : pageProps.isDarkMode;
-  //   document.body.className = isDark ? "dark-mode" : "light-mode";
-  // });
   return (
     <>
       <Head>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -2,15 +2,25 @@ import Document, { Html, Head, Main, NextScript } from "next/document";
 
 export default class MyDocument extends Document {
   render(props) {
-    const pageProps = props?.__NEXT_DATA__?.props?.pageProps;
-    const isDarkMode =
-      typeof pageProps?.isDarkMode !== "undefined"
-        ? pageProps.isDarkMode
-        : true;
     return (
-      <Html className={pageProps?.htmlClassName || ""}>
+      <Html>
         <Head />
-        <body className={isDarkMode ? "dark-mode" : "light-mode"}>
+        <body>
+          <script
+            type="text/javascript"
+            dangerouslySetInnerHTML={{
+              __html: `
+               (function(){
+                 const hasLightMode = document.location.pathname.indexOf("/docs") === 0;
+                 const mode = window.localStorage.getItem("screen-mode");
+                 if (hasLightMode && mode) {
+                  console.log("Set mode to", mode);
+                  document.body.className = mode + "-mode";
+                 }
+               })();
+              `,
+            }}
+          />
           <Main />
           <NextScript />
         </body>

--- a/shared/Docs/DocsNav.tsx
+++ b/shared/Docs/DocsNav.tsx
@@ -55,9 +55,9 @@ const DocsNav: React.FC<{ categories: Categories }> = ({ categories }) => {
               <DocsNavItem key={`cat-${idx}`} category={c} />
             ))}
           </NavList>
-          {/* <div>
+          <div>
             <ScreenModeToggle />
-          </div> */}
+          </div>
         </Nav>
         <CTAContainer>
           <a

--- a/shared/ScreenModeToggle.tsx
+++ b/shared/ScreenModeToggle.tsx
@@ -1,33 +1,85 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 
 import { titleCase } from "./util";
 
 const ScreenModeToggle: React.FC = () => {
+  const [isOpen, setOpen] = useState(false);
   const [mode, setMode] = useState("dark");
-  const toggleDarkMode = () => {
-    setMode(mode === "dark" ? "light" : "dark");
-    document.body.className = document.body.className.includes("dark")
-      ? "light-mode"
-      : "dark-mode";
+
+  const getOppositeMode = (mode: string): "light" | "dark" =>
+    mode === "light" ? "dark" : "light";
+  const getCurrentMode = () =>
+    document.body.className.includes("dark") ? "dark" : "light";
+
+  const updateModeAndSave = (newMode: "light" | "dark") => {
+    // const newMode = getOppositeMode(getCurrentMode());
+    document.body.className = `${newMode}-mode`;
+    setMode(newMode);
+    console.log("Update to ", newMode);
+    window.localStorage.setItem("screen-mode", newMode);
   };
+  useEffect(() => {
+    const savedMode = window.localStorage.getItem("screen-mode");
+    if (savedMode) {
+      setMode(savedMode);
+    }
+  });
+  const options = mode === "light" ? ["light", "dark"] : ["dark", "light"];
   return (
-    <ToggleButton mode={mode} onClick={() => toggleDarkMode()}>
+    <ToggleButton mode={mode} isOpen={isOpen} onClick={() => setOpen(!isOpen)}>
       {titleCase(mode)}
+      <span className="screen-mode-options">
+        {options.map((option) => (
+          <span
+            key={option}
+            className={`screen-mode-option ${option}`}
+            onClick={() => updateModeAndSave(option as "light" | "dark")}
+          >
+            {titleCase(option)}
+          </span>
+        ))}
+      </span>
     </ToggleButton>
   );
 };
 
-const ToggleButton = styled.button<{ mode: string }>`
+const ToggleButton = styled.button<{ mode: string; isOpen: boolean }>`
+  position: relative;
   padding: 0.1em 0.6em;
-  border: 1px solid var(--color-iris-60);
-  border-radius: var(--border-radius);
+  border: var(--button-border-width) solid var(--color-iris-60);
+  border-radius: 6px;
   color: var(--color-iris-60);
   background-color: transparent;
 
-  &:hover {
+  /* &:hover {
     background-color: ${({ mode }) =>
-      mode === "dark" ? "var(--bg-color-l)" : "var(--bg-color-d)"};
+    mode === "dark" ? "var(--bg-color-l)" : "var(--bg-color-d)"};
+  } */
+
+  .screen-mode-options {
+    display: ${({ isOpen }) => (isOpen ? "block" : "none")};
+    position: absolute;
+    top: calc(-1 * var(--button-border-width));
+    left: calc(-1 * var(--button-border-width));
+    right: calc(-1 * var(--button-border-width));
+    width: calc(100% + 2 * var(--button-border-width));
+    overflow: hidden;
+    background: var(--bg-color);
+    border: var(--button-border-width) solid var(--color-iris-60);
+    border-radius: 6px;
+  }
+  .screen-mode-option {
+    display: block;
+    padding: 0.1em 0.6em;
+    border-radius: 4px;
+
+    &.dark {
+      background: var(--bg-color-d);
+    }
+    &.light {
+      background: var(--bg-color-l);
+    }
   }
 `;
 


### PR DESCRIPTION
This is the MVP for this only working on the docs pages for now as their confirmed to have a clean light mode.

In the future we should support `prefers-color-scheme`, potentially with: https://github.com/donavon/use-dark-mode
![Screen Cast 2022-04-22 at 4 17 45 PM](https://user-images.githubusercontent.com/1509457/164787831-c712a910-fc36-489b-8c9d-ca2eff292bca.gif)

