### PR TITLE
Disable failing library build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build
-build: get-library generate-library
+build: #get-library generate-library
 	yarn build
 
 .PHONY: dirty


### PR DESCRIPTION
After https://github.com/inngest/library/pull/1, the build is failing, so we'll disable it for now until we fix it up.