### PR TITLE
Send anon ID to oauth redirect

### DIFF
--- a/pages/sign-up.tsx
+++ b/pages/sign-up.tsx
@@ -18,7 +18,7 @@ const SignUp = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>(null);
 
-  const anonID = window.localStorage.getItem("inngest-anon-id") || "";
+  const anonID = globalThis?.localStorage?.getItem("inngest-anon-id") || "";
 
   const handleSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();


### PR DESCRIPTION
This lets us inspect and store the anon-id via api.inngest.com cookies,
which are then read on registering and sent during the
attribution/signup events.