### PR TITLE
Ensure Anonymous ID is set wherever it's used

### DIFF
--- a/pages/sign-up.tsx
+++ b/pages/sign-up.tsx
@@ -20,8 +20,6 @@ const SignUp = () => {
   const [error, setError] = useState<string>(null);
   const { anonId } = useAnonId();
 
-  const anonID = globalThis?.localStorage?.getItem("inngest-anon-id") || "";
-
   const handleSubmit = async (e: React.SyntheticEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -34,7 +32,7 @@ const SignUp = () => {
         headers: {
           "content-type": "application/json",
         },
-        body: JSON.stringify({ email, password, anon_id: anonID }),
+        body: JSON.stringify({ email, password, anon_id: anonId }),
       });
     } catch (e) {
       setError("There was an error signing you up.  Please try again.");
@@ -75,7 +73,10 @@ const SignUp = () => {
       <Content className="grid section-header">
         <div className="col-2" />
         <div className="signup col-4">
-          <Button href={apiURL(`/v1/login/oauth/github/redirect?anonid=${anonID}`)} kind="black">
+          <Button
+            href={apiURL(`/v1/login/oauth/github/redirect?anonid=${anonId}`)}
+            kind="black"
+          >
             <img
               src="https://app.inngest.com/assets/gh-mark.png"
               alt="GitHub"
@@ -86,7 +87,10 @@ const SignUp = () => {
             </span>
           </Button>
 
-          <Button href={apiURL(`/v1/login/oauth/google/redirect?anonid=${anonID}`)} kind="black">
+          <Button
+            href={apiURL(`/v1/login/oauth/google/redirect?anonid=${anonId}`)}
+            kind="black"
+          >
             <img
               src="https://app.inngest.com/assets/icons/google.svg"
               alt="Google"

--- a/shared/trackingHooks.tsx
+++ b/shared/trackingHooks.tsx
@@ -1,6 +1,7 @@
 import deterministicSplit from "deterministic-split";
 import { useEffect, useMemo } from "react";
 import { useLocalStorage } from "react-use";
+import { v4 as uuid } from "uuid";
 
 /**
  * AB experiments with keys as experiment names and values as the variants.
@@ -13,11 +14,19 @@ const abExperiments = {
 /**
  * Fetch and return the user's anonymous ID.
  */
-export const useAnonId = () => {
-  const [anonId] = useLocalStorage<string>("inngest-anon-id");
-
+export const useAnonId = (): { anonId: string; existing: boolean } => {
+  const [anonId, setAnonId] = useLocalStorage<string>("inngest-anon-id");
+  if (!anonId) {
+    const id = uuid();
+    setAnonId(id);
+    return {
+      anonId: id,
+      existing: false,
+    };
+  }
   return {
     anonId,
+    existing: false,
   };
 };
 


### PR DESCRIPTION
## Description

Prior to this change, anon id was always `""` on the sign up page links in production.

* This fixes an issue where anon id was unreadable on the sign up page (#147)
* This picks some code from #148 to centralize anon id fetching and setting