### PR TITLE
Add non-blocking broken link checker

### DIFF
--- a/.github/workflows/on-cf-build.yml
+++ b/.github/workflows/on-cf-build.yml
@@ -14,4 +14,4 @@ jobs:
           project: 'website'
           commitHash: ${{ github.sha }}
       - if: steps.deployment.outputs.success == 'true'
-        run: npx broken-link-checker ${{ steps.deployment.outputs.url }} --recursive --host-requests 10 --requests 10 --follow
+        run: npx broken-link-checker ${{ steps.deployment.outputs.url }} --recursive --host-requests 10 --requests 10 --follow --exclude '${{ steps.deployment.outputs.url }}/test/'


### PR DESCRIPTION
Had a chat about product/onboarding with a friend and he stumbled across a broken link. Thought I'd add a check to see how many we have and there are _a few_.

https://github.com/inngest/website/runs/8179365285?check_suite_focus=true

**226 broken!**

This should run for every deployment (both prod and preview), but doesn't stop the build from happening. It's something we can clean up as we go and then shift it to a pre-deploy thing once we've fixed everything.