### PR TITLE
Add Docker and Docker Buildx install instructions

### DIFF
--- a/pages/docs/_docs/1-getting-started/01-installation.mdx
+++ b/pages/docs/_docs/1-getting-started/01-installation.mdx
@@ -18,7 +18,7 @@ Check if you have Docker installed by running `docker version`.
 
 If you don't, we'd recommend installing [Docker Desktop](https://docs.docker.com/desktop/). It's available for [Mac](https://docs.docker.com/desktop/install/mac-install/), [Mac on Apple silicon](https://docs.docker.com/desktop/mac/apple-silicon/), [Linux](https://docs.docker.com/desktop/install/linux-install/), or [Windows](https://docs.docker.com/desktop/install/windows-install/), and will automatically install the Docker Buildx plugin.
 
----
+<br/>
 </details>
 
 <details>
@@ -38,9 +38,7 @@ mkdir -p ~/.docker/cli-plugins \
   && chmod +x ~/.docker/cli-plugins/docker-buildx
 ```
 
----
-
-
+<br/>
 </details>
 
 <h2 className="pt-4">Installing via NPM</h2>


### PR DESCRIPTION
Adds some simple instructions (mainly pointing at Docker docs) for prerequisites of Docker and Docker Buildx. We can link to this from the error message when Docker/Buildx isn't usable.