### PR TITLE
Remove trailing slash from redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,7 +4,7 @@
 /docs/event-http-api-and-libraries /docs/sending-data-via-http 301
 /docs/using-the-inngest-cli /docs/cloud/using-the-inngest-cli 302
 /docs/function-ide-guide /docs/cloud/function-ide-guide 302
-/docs/quick-start /docs/ 302
+/docs/quick-start /docs 302
 
 /docs/installation /docs/cli/installation 302
 /docs/deploy/nextjs /docs/frameworks/nextjs 302


### PR DESCRIPTION
## Description

It was forcing 2 redirects: a 302 then a 308.