### PR TITLE
Remove logo link in nav on sign up page

### DIFF
--- a/shared/nav.tsx
+++ b/shared/nav.tsx
@@ -26,9 +26,13 @@ const NavContent: React.FC<Props> = (props: Props) => {
   return (
     <Container className={`max-w-5xl mx-auto ${show && "show"}`}>
       <div className="px-4 lg:px-0">
-        <a href="/?ref=nav">
+        {props.nolinks ? (
           <Logo width={115} className="logo" />
-        </a>
+        ) : (
+          <a href="/?ref=nav">
+            <Logo width={115} className="logo" />
+          </a>
+        )}
       </div>
 
       {!props.nolinks && (
@@ -142,14 +146,16 @@ const NavContent: React.FC<Props> = (props: Props) => {
         >
           Log in
         </StyledLink>
-        <Button
-          href="/sign-up?ref=nav"
-          className="button"
-          kind="primary"
-          style={{ padding: "0.4rem 1rem" }}
-        >
-          Start building →
-        </Button>
+        {!props.nolinks && (
+          <Button
+            href="/sign-up?ref=nav"
+            className="button"
+            kind="primary"
+            style={{ padding: "0.4rem 1rem" }}
+          >
+            Start building →
+          </Button>
+        )}
       </div>
 
       {!props.nolinks && (


### PR DESCRIPTION
## Description

Vercel requested the logo to not be clickable to break the add integration install flow. It's a requirement that the user cannot escape the auth flow when installing.

It also is probably a good idea to focus the user for signups originating from the Inngest website as the user can still click the back button.

[Slack convo](https://inngest.slack.com/archives/C04603NUZ7A/p1666042221623339?thread_ts=1666023825.748489&cid=C04603NUZ7A)