### PR TITLE
Fix/GitHub btn wrap

### DIFF
--- a/shared/Home/DevUI.tsx
+++ b/shared/Home/DevUI.tsx
@@ -141,7 +141,6 @@ export default function DevUI() {
               className="group inline-flex gap-2.5 items-center rounded-full text-sm font-medium pl-6 pr-5 py-2  bg-indigo-500 hover:bg-indigo-400 transition-all text-white"
             >
               View and star <Github />
-              {/* <ArrowRight className="group-hover:translate-x-1.5 relative top-px transition-transform duration-150 " /> */}
             </a>
           </div>
         </div>


### PR DESCRIPTION
![IMG_1056](https://user-images.githubusercontent.com/1478864/205129442-8d124015-49e6-451e-a915-345cdf7c938b.PNG)
The wording is too long for the GitHub button on mobile. Proposing we swap the text to a simpler version:
<img width="500" alt="CleanShot 2022-12-01 at 18 16 31@2x" src="https://user-images.githubusercontent.com/1478864/205129756-ea26b6d7-81a8-4ee4-916b-bb65c656ea7d.png">
