### PR TITLE
Increase free plan to 10k fn runs/mo.

### DIFF
--- a/pages/pricing.tsx
+++ b/pages/pricing.tsx
@@ -61,7 +61,7 @@ const PLANS: Plan[] = [
       },
       {
         icon: Language,
-        quantity: "1,000",
+        quantity: "10,000",
         text: "function runs/month",
       },
       {


### PR DESCRIPTION
## Description

PLG and market into show that 1k / month is too small to really do anything.