### PR TITLE
Fix docs to patterns navigation bug

### DIFF
--- a/shared/Docs/Header.tsx
+++ b/shared/Docs/Header.tsx
@@ -19,12 +19,12 @@ import { headerLinks } from "./Navigation";
 function TopLevelNavItem({ href, children }) {
   return (
     <li>
-      <Link
+      <a
         href={href}
         className="text-sm leading-5 text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
       >
         {children}
-      </Link>
+      </a>
     </li>
   );
 }


### PR DESCRIPTION
Temporarily swap the header navigation links from `<Link>` to `<a>` to prevent a visual bug when navigating from the light themed docs to the patterns pages.