### PR TITLE
Update docs with new SDK error handling

### DIFF
--- a/pages/docs/functions/retries.mdx
+++ b/pages/docs/functions/retries.mdx
@@ -1,37 +1,74 @@
-# Retries and failures
+# Handling Errors & Retries
 
 When functions fail, Inngest can retry them automatically. Whether Inngest retries your function is determined by _how_ it fails.
 
-## Failure detection
+## Types of failures
 
 There are two ways that functions are determined to have failed:
 
-* A function throws an error:
+* A function throws an error. ✅ This **_will_** be retried.
 
-```js
-export default inngest.createFunction("My Function", "demo/some.event", ({ event }) => {
-  throw new Error("Something failed!")
-})
+```ts
+export default inngest.createFunction("Import item data", "import.requested", ({ event }) => {
+  throw new Error("Failed to fetch item from ecommerce API");
+});
 ```
 
-* A function returns a non-`2xx` status code with it's response:
+* A function throws a non-retriable error. ❌ This **_will not_** be retried.
 
-```js
-export default inngest.createFunction("My Function", "demo/some.event", ({ event }) => {
-  const result = somethingElse()
-  return {
-    status: result.ok ? 200 : 500,
-    body: { message: result.ok ? "success" : "failure" }
+```ts
+import { NonRetriableError } from "inngest";
+
+export default inngest.createFunction("Mark store as imported", "import.completed", ({ event }) => {
+  try {
+    const result = await database.updateStore({ id: event.data.storeId }, { imported: true });
+    return result.ok === true;
+  } catch (err) {
+    // Passing the original error via `cause` enables you to view the error in function logs
+    throw new NonRetriableError("Store not found", { cause: err });
   }
-})
+});
+```
+
+## Errors within steps
+
+Errors thrown within steps also determine how each step will or will not be retried. It follows the same logic as above, but it works on a per-step basis:
+
+```ts
+import { NonRetriableError } from "inngest";
+
+export default inngest.createStepFunction(
+  "Import store items",
+  "ecommerce/import.required",
+  ({ event, tools }) => {
+
+    const items = tools.run("Get Items from API", async () => {
+      // Third party APIs can often fail (e.g. because of a network or rate limit issue),
+      // if this call fails, Inngest will attempt to retry this step
+      return await ecommerceAPI.getItems(event.data.itemIds);
+    });
+
+    const store = tools.run("Get store in database", async () => {
+      try {
+        return await database.getStore(event.data.storeId);
+      } catch (err) {
+        // Store was not found, so we should not retry this step
+        throw new NonRetriableError("Could not find store in database", { cause: err });
+      }
+    });
+
+    // This step will never be run if the NonRetriableError throws once in the above step
+    tools.run("Import items for store", () => { /* ... */})
+  }
+);
 ```
 
 ## Retry policies
 
-By default, each function is retried 3 times using [exponential backoff](https://github.com/inngest/inngest/blob/main/pkg/backoff/backoff.go) with jitter. Retries can be customized using the `status` or `statusCode` response:
+By default, each function is retried 3 times using [exponential backoff](https://github.com/inngest/inngest/blob/main/pkg/backoff/backoff.go) with jitter.
 
-* `2xx` - Successful: this is not a failure, no retry is necessary
-* `4xx` - Bad request: **this step will not be retried**, as this error is irrecovarble
-* `5xx` - Server error: something temporarily failed.  **This will be retried according to the retry policy (3 times, by default)**.
+* **Successful** - No error thrown. This will not be retried.
+* **Non-retriable error** - A `NonRetriableError` was thrown (think: `404`). This will not be retried.
+* **Error** - Any error was thrown indicating a potentially temporary failure (think: `500`). **This will be retried according to the retry policy (3 times, by default)**.
 
-We're currently working on implementing custom retry policies per step for step functions, documented [in this issue](https://github.com/inngest/inngest/issues/117).
+_Note - We're planning to enable customization of the retry policy and timing in a future release._


### PR DESCRIPTION
## Description

We no longer support the `status` responses, so we now tell user to use errors to tell us how something has failed and whether to re-try it.

### Related to

* https://github.com/inngest/inngest-js/pull/81
* https://github.com/inngest/inngest-js/pull/73