### PR TITLE
Add more detail to errors within steps

### DIFF
--- a/pages/docs/functions/retries.mdx
+++ b/pages/docs/functions/retries.mdx
@@ -6,7 +6,7 @@ When functions fail, Inngest can retry them automatically. Whether Inngest retri
 
 There are two ways that functions are determined to have failed:
 
-* A function throws an error. ✅ This **_will_** be retried.
+* A function throws an error. ✅ This **_will_** be retried ([see retry policies](#retry-policies))
 
 ```ts
 export default inngest.createFunction("Import item data", "import.requested", ({ event }) => {
@@ -32,7 +32,7 @@ export default inngest.createFunction("Mark store as imported", "import.complete
 
 ## Errors within steps
 
-Errors thrown within steps also determine how each step will or will not be retried. It follows the same logic as above, but it works on a per-step basis:
+Steps are individually retried. That means Inngest will handle the type of error, just as above, but on the per-step basis.
 
 ```ts
 import { NonRetriableError } from "inngest";
@@ -42,7 +42,7 @@ export default inngest.createStepFunction(
   "ecommerce/import.required",
   ({ event, tools }) => {
 
-    const items = tools.run("Get Items from API", async () => {
+    const items = tools.run("Get items from API", async () => {
       // Third party APIs can often fail (e.g. because of a network or rate limit issue),
       // if this call fails, Inngest will attempt to retry this step
       return await ecommerceAPI.getItems(event.data.itemIds);
@@ -52,16 +52,59 @@ export default inngest.createStepFunction(
       try {
         return await database.getStore(event.data.storeId);
       } catch (err) {
-        // Store was not found, so we should not retry this step
+        // Store was not found - the step and function should not be retried
         throw new NonRetriableError("Could not find store in database", { cause: err });
       }
     });
 
-    // This step will never be run if the NonRetriableError throws once in the above step
+    // If either of the above steps
     tools.run("Import items for store", () => { /* ... */})
   }
 );
 ```
+
+To illustrate how this logic might work, let's use the above code and explain how the two types of errors will be handled across the life of an entire function run:
+
+**Scenario**: The API has a major outage and all 3 attempts of the first step fail:
+
+```plaintext
+┌ Function: "Import store items" triggered by new "ecommerce/import.required" event
+├─┬ Step: "Get items from API" started
+│ ├ Attempt 1: ❌ Error thrown
+│ ├ Attempt 2: ❌ Error thrown
+│ └ Attempt 3: ❌ Error thrown
+├── Step: "Get store in database" skipped
+├── Step: "Import items for store" skipped
+└ ❌ Function run failed
+```
+
+**Scenario**: The API responds perfectly, but somehow the user has since deleted the "store" from the database:
+
+```plaintext
+┌ Function: "Import store items" triggered by new "ecommerce/import.required" event
+├─┬ Step: "Get items from API" started
+│ └ Attempt 1: ✅ Successful
+├─┬ Step: "Get store in database" started
+│ └ Attempt 1: ❌ NonRetriableError thrown
+├── Step: "Import items for store" skipped
+└ ❌ Function run failed
+```
+
+**Scenario**: The API has a minor blip, but it's retried and everything else runs smoothly:
+
+```plaintext
+┌ Function: "Import store items" triggered by new "ecommerce/import.required" event
+├─┬ Step: "Get items from API" started
+│ ├ Attempt 1: ❌ Error thrown
+│ ├ Attempt 2: ✅ Successful
+├─┬ Step: "Get store in database" started
+│ └ Attempt 1: ✅ Successful
+├─┬ Step: "Import items for store" skipped
+│ └ Attempt 1: ✅ Successful
+└ ✅ Function run successful
+```
+
+
 
 ## Retry policies
 


### PR DESCRIPTION
## Description

Follows #320 and [the discussion](https://github.com/inngest/website/pull/320#discussion_r1072534059) to make it super clear how errors within steps are handled.

Direct link:  https://website-git-docs-add-more-detail-to-errors-within-steps-inngest.vercel.app/docs/functions/retries