### PR TITLE
Add Nuxt framework serving docs

### DIFF
--- a/pages/docs/sdk/serve.mdx
+++ b/pages/docs/sdk/serve.mdx
@@ -133,7 +133,7 @@ export default serve(
 );
 ```
 
-## Framework: Nuxt
+## Framework: Nuxt <VersionBadge version="v0.9.2+" />
 
 Inngest has first class support for [Nuxt server routes](https://nuxt.com/docs/guide/directory-structure/server#server-routes), allowing you to easily create the Inngest API.
 Add the following within `./server/api/inngest.ts`:

--- a/shared/Docs/mdx.tsx
+++ b/shared/Docs/mdx.tsx
@@ -188,3 +188,11 @@ export function Property({ name, type, children }) {
     </li>
   );
 }
+
+export function VersionBadge({ version }: { version: `v${string}` }) {
+  return (
+    <div className="inline-flex items-center px-3 py-0.5 rounded-full text-xs font-medium leading-4 bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200">
+      <span>{version}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Add docs for serving Nuxt. Can be merged when inngest/inngest-js#89 is merged.

## Related

- inngest/inngest-js#89