### PR TITLE
Hide Front-end eng role on careers page

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -37,7 +37,7 @@ export async function getStaticProps() {
 }
 
 const getCode = ({ pathname }) => {
-  return `inngest.send({
+  return `await inngest.send({
   name: "website/page.not.found",
   data: {
     path: "${pathname}"

--- a/pages/careers/[role].tsx
+++ b/pages/careers/[role].tsx
@@ -30,7 +30,8 @@ export async function getStaticProps({ params }) {
 
 export async function getStaticPaths() {
   const roles = await loadMarkdownFilesMetadata(dir);
-  const paths = roles.map((role) => `/careers/${role.slug}`);
+  const visibleRoles = roles.filter((r) => !r.hidden);
+  const paths = visibleRoles.map((role) => `/careers/${role.slug}`);
   return { paths, fallback: false };
 }
 

--- a/pages/careers/_roles/front-end-engineer.mdx
+++ b/pages/careers/_roles/front-end-engineer.mdx
@@ -1,4 +1,5 @@
 ---
+hidden: true
 title: Front-end Engineer
 location: Remote - Americas/Europe
 date: 2022-12-21

--- a/pages/careers/index.tsx
+++ b/pages/careers/index.tsx
@@ -14,9 +14,10 @@ type RoleMetadata = Role & MDXFileMetadata;
 
 export async function getStaticProps({ params }) {
   const roles = await loadMarkdownFilesMetadata<Role>("careers/_roles");
+  const visibleRoles = roles.filter((r) => !r.hidden);
   return {
     props: {
-      roles: JSON.stringify(roles),
+      roles: JSON.stringify(visibleRoles),
       meta: {
         title: `Careers at Inngest`,
         description: `We're hiring!`,


### PR DESCRIPTION
### Description

Hide the role as we don't need any more applications right now.