### PR TITLE
Prioritize v2 examples and remove `inngest@next` prompts

### DIFF
--- a/pages/docs/functions/index.mdx
+++ b/pages/docs/functions/index.mdx
@@ -128,25 +128,6 @@ The Inngest SDK lets you strictly type all of your code against your real produc
 - Give you instant feedback as to whether your code will run as intended
 
 <CodeGroup forceTabs filename="inngest/client.ts">
-```typescript {{ title: "v1" }}
-import { Inngest } from "inngest";
-
-type AppUserCreated = {
-  name: "app/user.created";
-  data: {
-    email: string;
-  };
-  user: {
-    id: string;
-  };
-};
-
-type Events = {
-  "app/user.created": AppUserCreated;
-};
-
-export const inngest = new Inngest<Events>({ name: "My App" });
-```
 ```typescript {{ title: "v2" }}
 import { EventSchemas, Inngest } from "inngest";
 
@@ -167,6 +148,25 @@ export const inngest = new Inngest({
   name: "My App",
   schemas: new EventSchemas().fromRecord<Events>(),
 });
+```
+```typescript {{ title: "v1" }}
+import { Inngest } from "inngest";
+
+type AppUserCreated = {
+  name: "app/user.created";
+  data: {
+    email: string;
+  };
+  user: {
+    id: string;
+  };
+};
+
+type Events = {
+  "app/user.created": AppUserCreated;
+};
+
+export const inngest = new Inngest<Events>({ name: "My App" });
 ```
 </CodeGroup>
 

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -29,12 +29,11 @@ Learn how to get started:
 Adding sleeps, retries, and reliable steps to a function:
 
 <CodeGroup forceTabs>
-```ts {{ title: "v1" }}
-import { Inngest } from "inngest";
+```ts {{ title: "v2" }}
+import { EventSchemas, Inngest } from "inngest";
 
 type Events = {
   "user/new.signup": {
-    name: "user/new.signup";
     data: {
       email: string;
       name: string;
@@ -42,7 +41,10 @@ type Events = {
   };
 };
 
-const inngest = new Inngest<Events>({ name: "Next.js Shop" });
+const inngest = new Inngest({
+  name: "Next.js Shop",
+  schemas: new EventSchemas().fromRecord<Events>(),
+});
 
 export default inngest.createFunction(
   { name: "Signup flow" },
@@ -69,11 +71,12 @@ export default inngest.createFunction(
   }
 );
 ```
-```ts {{ title: "v2" }}
-import { EventSchemas, Inngest } from "inngest";
+```ts {{ title: "v1" }}
+import { Inngest } from "inngest";
 
 type Events = {
   "user/new.signup": {
+    name: "user/new.signup";
     data: {
       email: string;
       name: string;
@@ -81,10 +84,7 @@ type Events = {
   };
 };
 
-const inngest = new Inngest({
-  name: "Next.js Shop",
-  schemas: new EventSchemas().fromRecord<Events>(),
-});
+const inngest = new Inngest<Events>({ name: "Next.js Shop" });
 
 export default inngest.createFunction(
   { name: "Signup flow" },

--- a/pages/docs/reference/client/create.mdx
+++ b/pages/docs/reference/client/create.mdx
@@ -51,25 +51,6 @@ Click the toggles on the top left of the code block to see the different methods
 </Callout>
 
 <CodeGroup forceTabs={true}>
-```ts {{ title: "v1" }}
-type Events = {
-  "app/account.created": {
-    name: "app/account.created";
-    data: {
-      userId: string;
-    };
-  };
-  "app/subscription.started": {
-    name: "app/subscription.started";
-    data: {
-      userId: string;
-      planId: string;
-    };
-  };
-};
-
-export const inngest = new Inngest<Events>({ name: "My App" });
-```
 ```ts {{ title: "Union (v2)" }}
 import { EventSchemas, Inngest } from "inngest";
 
@@ -175,6 +156,25 @@ export const inngest = new Inngest({
     .fromUnion<AppPostCreated | AppPostDeleted>()
     .fromZod(zodEventSchemas),
 });
+```
+```ts {{ title: "v1" }}
+type Events = {
+  "app/account.created": {
+    name: "app/account.created";
+    data: {
+      userId: string;
+    };
+  };
+  "app/subscription.started": {
+    name: "app/subscription.started";
+    data: {
+      userId: string;
+      planId: string;
+    };
+  };
+};
+
+export const inngest = new Inngest<Events>({ name: "My App" });
 ```
 </CodeGroup>
 

--- a/pages/docs/reference/middleware/create.mdx
+++ b/pages/docs/reference/middleware/create.mdx
@@ -1,21 +1,5 @@
 # Creating middleware <VersionBadge version="v2.0.0+" />
 
-<Callout>
-Middleware is still in pre-release mode. You can use it by installing v2.0.0 using the `next` tag.
-
-<CodeGroup forceTabs>
-```sh {{ title: "npm" }}
-npm install inngest@next
-```
-```sh {{ title: "pnpm " }}
-pnpm install inngest@next
-```
-```sh {{ title: "Yarn" }}
-yarn add inngest@next
-```
-</CodeGroup>
-</Callout>
-
 Creating middleware means defining the lifecycles and subsequent hooks in those lifecycles to run code in. Lifecycles are actions such as a function run or sending events, and individual hooks within those are where we run code, usually with a _before_ and _after_ step.
 
 Middleware is created using the `InngestMiddleware` class.

--- a/pages/docs/reference/middleware/examples.mdx
+++ b/pages/docs/reference/middleware/examples.mdx
@@ -1,21 +1,5 @@
 # Example middleware <VersionBadge version="v2.0.0+" />
 
-<Callout>
-Middleware is still pre-release. You can use it by installing v2.0.0 using the `next` tag.
-
-<CodeGroup forceTabs>
-```sh {{ title: "npm" }}
-npm install inngest@next
-```
-```sh {{ title: "pnpm " }}
-pnpm install inngest@next
-```
-```sh {{ title: "Yarn" }}
-yarn add inngest@next
-```
-</CodeGroup>
-</Callout>
-
 The following examples show how you might use middleware in some real-world scenarios.
 
 ## Sentry error reporting and tracing

--- a/pages/docs/reference/middleware/lifecycle.mdx
+++ b/pages/docs/reference/middleware/lifecycle.mdx
@@ -1,21 +1,5 @@
 # Middleware lifecycle <VersionBadge version="v2.0.0+" />
 
-<Callout>
-Middleware is still pre-release. You can use it by installing v2.0.0 using the `next` tag.
-
-<CodeGroup forceTabs>
-```sh {{ title: "npm" }}
-npm install inngest@next
-```
-```sh {{ title: "pnpm " }}
-pnpm install inngest@next
-```
-```sh {{ title: "Yarn" }}
-yarn add inngest@next
-```
-</CodeGroup>
-</Callout>
-
 ## Registering and order
 
 Middleware can be registered with Inngest clients or functions by providing an array of middleware.

--- a/pages/docs/reference/middleware/overview.mdx
+++ b/pages/docs/reference/middleware/overview.mdx
@@ -1,21 +1,5 @@
 # Advanced: Middleware <VersionBadge version="v2.0.0+" />
 
-<Callout>
-Middleware is still pre-release. You can use it by installing v2.0.0 using the `next` tag.
-
-<CodeGroup forceTabs>
-```sh {{ title: "npm" }}
-npm install inngest@next
-```
-```sh {{ title: "pnpm " }}
-pnpm install inngest@next
-```
-```sh {{ title: "Yarn" }}
-yarn add inngest@next
-```
-</CodeGroup>
-</Callout>
-
 Middleware allows you to specify functions to run at various points in an Inngest client's lifecycle, such as during a function's execution or when sending an event. Use the `InngestMiddleware` class to define new middleware.
 
 ```ts

--- a/pages/docs/reference/middleware/typescript.mdx
+++ b/pages/docs/reference/middleware/typescript.mdx
@@ -1,21 +1,5 @@
 # TypeScript with Middleware <VersionBadge version="v2.0.0+" />
 
-<Callout>
-Middleware is still pre-release. You can use it by installing v2.0.0 using the `next` tag.
-
-<CodeGroup forceTabs>
-```sh {{ title: "npm" }}
-npm install inngest@next
-```
-```sh {{ title: "pnpm " }}
-pnpm install inngest@next
-```
-```sh {{ title: "Yarn" }}
-yarn add inngest@next
-```
-</CodeGroup>
-</Callout>
-
 Some lifecycle hooks can be used to mutate both values and types at key points in a particular lifecycle. The SDK leverages TypeScript's inference powers to make writing middleware easy for both the developer and the user.
 
 ## Mutating input

--- a/pages/docs/sdk/migration.mdx
+++ b/pages/docs/sdk/migration.mdx
@@ -4,22 +4,6 @@ export const description = "Migrate to v2 of the Inngest TS SDK."
 
 This guide walks through migrating to the Inngest TS SDK v2 from v1.
 
-<Callout>
-`v2.0` is still in pre-release mode. You can install it using the `next` tag.
-
-<CodeGroup forceTabs>
-```sh {{ title: "npm" }}
-npm install inngest@next
-```
-```sh {{ title: "pnpm " }}
-pnpm install inngest@next
-```
-```sh {{ title: "Yarn" }}
-yarn add inngest@next
-```
-</CodeGroup>
-</Callout>
-
 ## Breaking changes in v2
 
 Listed below are all breaking changes made in v2, potentially requiring code changes for you to upgrade.

--- a/pages/docs/typescript.mdx
+++ b/pages/docs/typescript.mdx
@@ -23,22 +23,6 @@ We can use these when creating a new Inngest client via `new Inngest()`.
 This comes with powerful inference; we autocomplete your event names when selecting what to react to, without you having to dig for the name and data.
 
 <CodeGroup forceTabs filename="inngest/client.ts">
-```ts {{ title: "v1" }}
-import { Inngest } from "inngest";
-
-type UserSignup = {
-  name: "user/new.signup";
-  data: {
-    email: string;
-    name: string;
-  };
-};
-type Events = {
-  "user/new.signup": UserSignup;
-};
-
-export const inngest = new Inngest<Events>({ name: "My App" });
-```
 ```ts {{ title: "v2" }}
 import { EventSchemas, Inngest } from "inngest";
 
@@ -56,6 +40,22 @@ export const inngest = new Inngest({
   name: "My App",
   schemas: new EventSchemas().fromRecord<Events>(),
 });
+```
+```ts {{ title: "v1" }}
+import { Inngest } from "inngest";
+
+type UserSignup = {
+  name: "user/new.signup";
+  data: {
+    email: string;
+    name: string;
+  };
+};
+type Events = {
+  "user/new.signup": UserSignup;
+};
+
+export const inngest = new Inngest<Events>({ name: "My App" });
 ```
 </CodeGroup>
 
@@ -106,30 +106,6 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 When writing step functions, you can use `waitForEvent` to to, pause the current function until another event is received or the timeout expires - whichever happens first. When you declare your types using the `Inngest` constructor, `waitForEvent` leverages any types that you have:
 
 <CodeGroup forceTabs filename="inngest/client.ts">
-```ts {{ title: "v1" }}
-import { Inngest } from "inngest";
-
-type UserSignup = {
-  name: "user/new.signup";
-  data: {
-    email: string;
-    user_id: string;
-    name: string;
-  };
-};
-type UserAccountSetupCompleted = {
-  name: "user/account.setup.completed";
-  data: {
-    user_id: string;
-  };
-};
-type Events = {
-  "user/new.signup": UserSignup;
-  "user/account.setup.completed": UserAccountSetupCompleted;
-};
-
-export const inngest = new Inngest<Events>({ name: "My App" });
-```
 ```ts {{ title: "v2" }}
 import { EventSchemas, Inngest } from "inngest";
 
@@ -154,6 +130,30 @@ export const inngest = new Inngest({
   name: "My App",
   schemas: new EventSchemas().fromRecord<Events>(),
 });
+```
+```ts {{ title: "v1" }}
+import { Inngest } from "inngest";
+
+type UserSignup = {
+  name: "user/new.signup";
+  data: {
+    email: string;
+    user_id: string;
+    name: string;
+  };
+};
+type UserAccountSetupCompleted = {
+  name: "user/account.setup.completed";
+  data: {
+    user_id: string;
+  };
+};
+type Events = {
+  "user/new.signup": UserSignup;
+  "user/account.setup.completed": UserAccountSetupCompleted;
+};
+
+export const inngest = new Inngest<Events>({ name: "My App" });
 ```
 </CodeGroup>
 


### PR DESCRIPTION
## Summary

Merge after v2 release. Prioritizes v2 examples over v1 and removes `inngest@next` prompts on pages relating to v2.0.0+ features.

## Related

- inngest/inngest-js#203