### PR TITLE
fix(docs): deploy link breaks Dev Server

### DIFF
--- a/shared/Docs/mdx.tsx
+++ b/shared/Docs/mdx.tsx
@@ -147,6 +147,7 @@ export function ButtonDeploy({ label, type, href }) {
   return (
     <a
       href={href}
+      target="_blank"
       className="block text-slate-800 dark:text-slate-200 cursor-pointer bg-slate-200 hover:bg-indigo-300/60 dark:bg-slate-800/40 rounded-lg py-8 px-6 group/deploy dark:hover:bg-indigo-800/40 no-underline transition-all"
     >
       {logoType}


### PR DESCRIPTION
Clicking the DeployButton from the Dev Server would break the Dev Server, because the Dev Server embeds the docs in an iframe. This makes sure the link opens in a new window to fix the issue.