### PR TITLE
Add callout to clarify batching doesn't work on the dev server

### DIFF
--- a/pages/docs/guides/batching.mdx
+++ b/pages/docs/guides/batching.mdx
@@ -80,7 +80,7 @@ the full list of events within a batch, which you can now operate on all of them
 ## Caveats
 
 <Callout>
-  Event batching currently don't work on the Dev server
+  Batching is a cloud-only feature and will be added to the dev server soon
 </Callout>
 
 With batching, certain event level configurations will be invalidated. When invoking a function, it's pretty


### PR DESCRIPTION
Just confirmed locally that Dev server doesn't handle batching.
Adding a callout in the docs to reduce confusion.

We should make it work in dev server too eventually.