### PR TITLE
Add T3 framework to serve docs

### DIFF
--- a/pages/docs/sdk/serve.mdx
+++ b/pages/docs/sdk/serve.mdx
@@ -29,6 +29,7 @@ We provide framework-specific bindings to make this easy for common platforms:
 - [Next.js](#framework-next-js)
 - [Redwood](#framework-redwood)
 - [Remix](#framework-remix)
+- [T3](#framework-t3)
 - [Custom](#custom-frameworks)
 
 Each of these bindings wrap our base API which implemnts the core logic, so adding support for new
@@ -254,6 +255,53 @@ export const config = {
 };
 
 const handler = serve(inngest, [...fns], {
+  streaming: "allow",
+});
+```
+
+For more information, check out the [Streaming](/docs/streaming) page.
+
+## Framework: T3
+
+You can add Inngest to a T3 app powered by Next.js easily.
+Add the following within `./pages/api/inngest.ts`:
+
+<CodeGroup filename="pages/api/inngest.ts">
+```typescript
+import { serve } from "inngest/next";
+import { inngest } from "../../inngest/client";
+import fnA from "../../inngest/fnA"; // Your own function
+
+export default serve(inngest, [fnA]);
+```
+</CodeGroup>
+
+### Next.js 13+ <VersionBadge version="v1.8.0+" />
+
+Version 13+ of Next.js uses [Route Handlers](https://beta.nextjs.org/docs/routing/route-handlers), requiring a separate export for each HTTP method the API supports. Inngest requires `GET`, `POST`, and `PUT` methods (see [How the API works](#how-the-api-works) below), which you can export via destructuring instead of `export default`:
+
+<CodeGroup filename="src/app/api/inngest/route.ts">
+```typescript
+import { serve } from "inngest/next";
+import { inngest } from "../../../inngest/client";
+import fnA from "../../../inngest/fnA"; // Your own functions
+
+export const { GET, POST, PUT } = serve(inngest, [fnA]);
+```
+</CodeGroup>
+
+### Streaming <VersionBadge version="v1.8.0+" />
+
+Next.js Edge Functions hosted on [Vercel](/docs/deploy/vercel) can also stream responses back to Inngest, giving you a much higher request timeout of 15 minutes (up from 10 seconds on the Vercel Hobby plan!).
+
+To enable this, set your runtime to `"edge"` (see [Quickstart for Using Edge Functions | Vercel Docs](https://vercel.com/docs/concepts/functions/edge-functions/quickstart)) and add the `streaming: "allow"` option to your serve handler:
+
+```typescript
+export const config = {
+  runtime: "edge",
+};
+
+export default serve(inngest, [...fns], {
   streaming: "allow",
 });
 ```


### PR DESCRIPTION
# Summary

Adds the [T3](https://create.t3.gg/) framework to serving docs. Feels like it's worth having its own section to hammer home that it's a supported stack. We could also just link them to the **Next.js** header and rename that section something like **Next.js / T3**. I like having them separate, though.

When we switch to the monorepo, we should start adding links to the example projects to each of these mini guides.

Following that, we should also add the `npm create inngest` commands when that becomes available.