### PR TITLE
content(blog): set `moduleResolution` to `bundler`

### DIFF
--- a/pages/blog/_posts/migrating-from-vite-to-nextjs.mdx
+++ b/pages/blog/_posts/migrating-from-vite-to-nextjs.mdx
@@ -62,10 +62,9 @@ We need to update your `tsconfig.json` file with the following changes to make i
 4. Add `{ "name": "next" }` to the [`plugins` array in `compilerOptions`](https://www.typescriptlang.org/tsconfig#plugins): `"plugins": [{ "name": "next" }]`
 5. Set [`esModuleInterop`](https://www.typescriptlang.org/tsconfig#esModuleInterop) to `true`: `"esModuleInterop": true`
 6. Set [`jsx`](https://www.typescriptlang.org/tsconfig#jsx) to `preserve`: `"jsx": "preserve"`
-7. Set [`moduleResolution`](https://www.typescriptlang.org/tsconfig#moduleResolution) to `node`: `"moduleResolution": "node"`
-8. Set [`allowJs`](https://www.typescriptlang.org/tsconfig#allowJs) to `true`: `"allowJs": true`
-9. Set [`forceConsistentCasingInFileNames`](https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames) to `true`: `"forceConsistentCasingInFileNames": true`
-10. Set [`incremental`](https://www.typescriptlang.org/tsconfig#incremental) to `true`: `"incremental": true`
+7. Set [`allowJs`](https://www.typescriptlang.org/tsconfig#allowJs) to `true`: `"allowJs": true`
+8. Set [`forceConsistentCasingInFileNames`](https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames) to `true`: `"forceConsistentCasingInFileNames": true`
+9. Set [`incremental`](https://www.typescriptlang.org/tsconfig#incremental) to `true`: `"incremental": true`
 
 Here's an example of a working `tsconfig.json` file with those changes:
 
@@ -78,7 +77,7 @@ Here's an example of a working `tsconfig.json` file with those changes:
     "module": "ESNext",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -91,7 +90,7 @@ Here's an example of a working `tsconfig.json` file with those changes:
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "plugins": [{ "name": "next" }]
   },
   "include": ["./src", "./dist/types/**/*.ts", "./next-env.d.ts"],
   "exclude": ["./node_modules"]


### PR DESCRIPTION
Small correction on the Vite blog post due to a recent update on the official Next.js TypeScript configuration.

See https://github.com/vercel/next.js/pull/51957