### PR TITLE
Fix custom handler link after monorepo shift for `inngest/inngest-js`

### DIFF
--- a/pages/docs/reference/serve/index.mdx
+++ b/pages/docs/reference/serve/index.mdx
@@ -74,4 +74,4 @@ The API works by exposing a single endpoint at `/api/inngest` which handles diff
 
 If the framework that your application uses is not included in our list of [first-party supported frameworks](/docs/sdk/serve), you can create a custom `serve` handler.
 
-To create your own handler, check out the [example handler](https://github.com/inngest/inngest-js/blob/main/src/examples/handler.ts) in our SDK's open source repo to understand how it works.
+To create your own handler, check out the [example handler](https://github.com/inngest/inngest-js/blob/main/examples/functions/handler.ts) in our SDK's open source repo to understand how it works.


### PR DESCRIPTION
## Summary

Fixes the link for the custom handler example following changes to the `inngest/inngest-js` project structure.