### PR TITLE
Fix typos and remove front-end description

### DIFF
--- a/pages/careers/_roles/product-designer.mdx
+++ b/pages/careers/_roles/product-designer.mdx
@@ -19,7 +19,7 @@ This role is remote, but requires at least a 4 hour working time overlap with US
 
 **What you'll do**
 
-- Design product features form 0 to 1
+- Design product features from 0 to 1
 - Iterating on existing product features based feedback and product analytics
 - Create satisfying small UX interactions as well as design broad UX flows that support a best-in-class developer experience (DX)
 - Work with customers to research requirements and validate solutions
@@ -41,54 +41,3 @@ This role is remote, but requires at least a 4 hour working time overlap with US
 - We're starting to adopt Storybook to build out the basics of a design system
 - Collaborate via Linear, Notion, Github & Discord
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
---------
-You will be our first Front-end engineer on the Inngest team. You'll be focused on building the best possible developer experience for our users by collaborating with designers, engineers and founders. Your work will mostly be focused across our development server and our cloud dashboard which enables a developer to go from building to operating their Inngest functions. We're building tools that developers will use in their everyday workflow so efforts to improve UX and performance are primary. Importantly, you'll need a strong product mindset and an interest in developer tools.
-
-The location for this role is between Western Europe (CET) and US Pacific time (PT).
-
-### What you'll do
-
-- Build UIs for our cloud dashboard and our development server
-- Collaborate with designers to create user experiences that save time and effort for our users
-- Create and maintain React components and hooks to manage complex UI state and handle real-time updates.
-- Work with backend engineers to design APIs that can be used across the Inngest cloud dashboard, dev server and CLIs.
-- Contribute to growth efforts from writing [blog posts](https://www.inngest.com/blog), building [tools as marketing](https://typedwebhook.tools/), and contributing to [our developer documentation](https://www.inngest.com/docs).
-- Dogfood the Inngest product and develop ideas for improvements, features, or integrations.
-- Communicate with Inngest users through Github issues or questions on our Discord community.
-
-### What you've done in your career
-
-- You've been working in the front-end for a few years and you've seen popular tech come and go.
-- You've used TypeScript for 1 or more years.
-- You've extensively used React.js and have experience with React Hooks and Next.js.
-- You've done some full-stack development and understand the backend.
-- You've consumed and/or created GraphQL APIs.
-
-### What your first 90 days will look like
-
-- First week: You'll learn how we work as a team and our approach to growth. You'll also start to learn our system architecture and hopefully make a couple small contributions to the dev server UI, our cloud dashboard, or our website.
-- By day 30: You'll be proficient with our weekly cadence of work and you'll have contributed a new feature to our dev server or cloud dashboard. You'll fully understand our company, product, and growth strategy and start to build up context for your product mindset.
-- By day 90: You'll have shipped significant changes to our UIs that you had a hand in helping define the spec for. You'll also have learned where you feel you can contribute to outside of the engineering domain (growth, UX design, DevRel, etc.) and have contributed ideas around product and growth. We're all aligned and mutually excited about how we work together now and in the future!
-
-### What we build with
-
-- TypeScript & React front-ends with hooks
-- Tailwind and Styled Components
-- Core GraphQL API
-- Backend: Go, Postgres, Redis, PubSub, and… [Inngest](https://github.com/inngest/inngest) (of course)
-- Hosted on GCP, AWS, and Vercel
-- Github, Linear, Discord, Notion


### PR DESCRIPTION
Probably a left-over of copy & paste.
The front-end description should be deleted for the designer role