### PR TITLE
Add different file name for Remix 2 serving

### DIFF
--- a/pages/docs/sdk/serve.mdx
+++ b/pages/docs/sdk/serve.mdx
@@ -302,9 +302,11 @@ at the `/api` root.
 
 ## Framework: Remix
 
-You can add Inngest to Remix easily.  Add the following to `./app/routes/api/inngest.ts`:
+You can add Inngest to Remix easily.  Add the following to `./app/routes/api.inngest.ts` for Remix v2 (or `./app/routes/api/inngest.ts` for Remix v1):
 
-```typescript
+<CodeGroup forceTabs>
+```typescript {{ title: "Remix 2" }}
+// app/routes/api.inngest.ts
 import { serve } from "inngest/remix";
 import { inngest } from "~/inngest/client";
 import fnA from "~/inngest/fnA";
@@ -313,6 +315,18 @@ const handler = serve(inngest, [fnA]);
 
 export { handler as loader, handler as action };
 ```
+
+```typescript {{ title: "Remix 1" }}
+// app/routes/api/inngest.ts
+import { serve } from "inngest/remix";
+import { inngest } from "~/inngest/client";
+import fnA from "~/inngest/fnA";
+
+const handler = serve(inngest, [fnA]);
+
+export { handler as loader, handler as action };
+```
+</CodeGroup>
 
 ### Streaming <VersionBadge version="v2.3.0+" />
 


### PR DESCRIPTION
Adds a default "_Remix 2_" tab to Remix serve docs, just showing a different file path for their new routing.

https://website-git-remix-2-serve-note-inngest.vercel.app/docs/sdk/serve#framework-remix

![image](https://github.com/inngest/website/assets/1736957/5d11abc6-c077-4c3a-be14-c2925d8efc9b)
