### PR TITLE
Add Fly.io service limits

### DIFF
--- a/pages/docs/usage-limits/providers.mdx
+++ b/pages/docs/usage-limits/providers.mdx
@@ -13,6 +13,9 @@ Here are the the known usage limits for each provider we support based on their 
 | [Vercel][vercel-limits]                 | 4MB - 4.5MB   | 1000                | 10s - 900s, N/A (Edge Fn)  |
 | [Netlify][netlify-limits]               | 256KB - 6MB   | ???                 | 10s - 15m                  |
 | [DigitalOcean][digitalocean-limits]     | 1MB           | 120                 | 15m                        |
+| Fly.io                                  | 200kb*        | [User configured][flyio-limits]     | 60s                        |
+
+<small>* - Undocumented</small>
 
 For more details tailored to your plan, please check each provider's website.
 
@@ -24,3 +27,4 @@ For more details tailored to your plan, please check each provider's website.
 [vercel-limits]: https://vercel.com/docs/concepts/limits/overview
 [netlify-limits]: https://docs.netlify.com/functions/overview/#default-deployment-options
 [digitalocean-limits]: https://docs.digitalocean.com/products/functions/details/limits/
+[flyio-limits]: https://fly.io/docs/reference/configuration/#http_service-concurrency


### PR DESCRIPTION
After helping a customer, we discovered that Fly limits requests to about 200kb - it's undocumented though

https://discord.com/channels/902204559378763786/1156277013812887692/1156318727952937040