### PR TITLE
Default to Next.js app router in serve docs

### DIFF
--- a/pages/docs/sdk/serve.mdx
+++ b/pages/docs/sdk/serve.mdx
@@ -220,30 +220,24 @@ See the [github.com/unjs/h3](https://github.com/unjs/h3) repository for more inf
 
 ## Framework: Next.js
 
-Inngest has first class support for Next.js API routes, allowing you to easily create the Inngest API.
-Add the following within `./pages/api/inngest.ts`:
+Inngest has first class support for Next.js API routes, allowing you to easily create the Inngest API. Both the App Router and the Pages Router are supported. For the App Router, Inngest requires `GET`, `POST`, and `PUT` methods.
 
-<CodeGroup filename="pages/api/inngest.ts">
-```typescript
-import { serve } from "inngest/next";
-import { inngest } from "../../inngest/client";
-import fnA from "../../inngest/fnA"; // Your own function
-
-export default serve(inngest, [fnA]);
-```
-</CodeGroup>
-
-### Next.js 13+ <VersionBadge version="v1.8.0+" />
-
-Version 13+ of Next.js uses [Route Handlers](https://beta.nextjs.org/docs/routing/route-handlers), requiring a separate export for each HTTP method the API supports. Inngest requires `GET`, `POST`, and `PUT` methods (see [How the API works](#how-the-api-works) below), which you can export via destructuring instead of `export default`:
-
-<CodeGroup filename="src/app/api/inngest/route.ts">
-```typescript
+<CodeGroup>
+```typescript {{ title: "App Router" }}
+// src/app/api/inngest/route.ts
 import { serve } from "inngest/next";
 import { inngest } from "../../../inngest/client";
 import fnA from "../../../inngest/fnA"; // Your own functions
 
 export const { GET, POST, PUT } = serve(inngest, [fnA]);
+```
+```typescript {{ title: "Pages Router" }}
+// pages/api/inngest.ts
+import { serve } from "inngest/next";
+import { inngest } from "../../inngest/client";
+import fnA from "../../inngest/fnA"; // Your own function
+
+export default serve(inngest, [fnA]);
 ```
 </CodeGroup>
 


### PR DESCRIPTION
We should default to the pages router and inline them with tabs for now to make it more obvious than the previous "Next 13+" thing. Also there was a broken link and we're long past v 1.8 so we don't need to call that out.