### PR TITLE
Add version badge to debounce docs

### DIFF
--- a/pages/docs/reference/functions/debounce.mdx
+++ b/pages/docs/reference/functions/debounce.mdx
@@ -1,4 +1,4 @@
-# Debounce functions
+# Debounce functions <VersionBadge version="v3.1.0+" />
 
 Debounce delays a function run for the given `period`, and reschedules functions for the given `period` any time new events are received while the debounce is active.  The function run starts after the specified `period` passes and no new events have been received.  Functions use the last event as their input data.
 


### PR DESCRIPTION
Adds a `v3.1.0+` version badge to debounce docs.

![image](https://github.com/inngest/website/assets/1736957/28037fd4-196c-4524-b40b-9a4fc699444b)
