### PR TITLE
Fix sentence fragment. Update to reflect current state.

### DIFF
--- a/pages/docs/reference/events/send.mdx
+++ b/pages/docs/reference/events/send.mdx
@@ -110,10 +110,9 @@ To send events from within of the context of a function, use [`step.sendEvent()`
 
 ## User data encryption 🔐
 
-All data sent in the `user` object is fully encrypted at rest. Each unique user gets their own encryption key and when you delete the user from our system, which helps comply with GDPR and CCPA.
+All data sent in the `user` object is fully encrypted at rest.
 
-An API is planned to allow you to do this programmatically which will use the `user.external_id` (see above) to perform the delete operation.
-
+In the future, this object will be used to support programmatic deletion via API endpoint to support certain right-to-be-forgotten flows in your system. This will use the `user.external_id` property for lookup.
 
 ## Send Events via HTTP (Event API)
 


### PR DESCRIPTION
This needs to be updated to reflect how the system currently works as the user field no longer has a usable encryption  key to decrypt this data. In essence, it's currently encrypted and the key is thrown away. There is no way to delete this user data now, but also, the data cannot be read, so it's still secure and private.

https://discord.com/channels/902204559378763786/959192780415049778/1161241881120866344