### PR TITLE
Fix RetryAfterError time units

### DIFF
--- a/pages/docs/functions/retries.mdx
+++ b/pages/docs/functions/retries.mdx
@@ -189,5 +189,5 @@ You can manually schedule a retry by throwing `RetryAfterError`:
 
 ```ts
 // Retry in 5 seconds
-throw new RetryAfterError("your error message", 5)
+throw new RetryAfterError("your error message", 5 * 1000)
 ```


### PR DESCRIPTION
`RetryAfterError`'s second argument is in milliseconds