### PR TITLE
Add support for markdown footnotes in blog

### DIFF
--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -20,6 +20,7 @@ import CTACallout from "src/shared/CTACallout";
 import Blockquote from "src/shared/Blog/Blockquote";
 import rehypeCodeTitles from "rehype-code-titles";
 import YouTube from "react-youtube-embed";
+import remarkGfm from "remark-gfm";
 
 const components = {
   DiscordCTA,
@@ -259,6 +260,7 @@ export async function getStaticProps({ params }) {
         rehypeShiki,
         [rehypeRaw, { passThrough: nodeTypes }],
         rehypeSlug,
+        remarkGfm,
       ],
     },
   });

--- a/typography.js
+++ b/typography.js
@@ -344,6 +344,14 @@ module.exports = ({ theme }) => ({
       ".button:hover": {
         textDecoration: "none !important",
       },
+
+      // Footnotes
+      ".footnotes li": {
+        scrollMarginTop: theme("spacing.32"),
+      },
+      "a[data-footnote-ref]": {
+        scrollMarginTop: theme("spacing.32"),
+      },
     },
   },
   invert: {


### PR DESCRIPTION
Support footnotes for #584

<img width="754" alt="Screen Shot 2023-11-28 at 4 05 32 PM" src="https://github.com/inngest/website/assets/1509457/991368c3-2b7e-45e1-bee6-0e6579918d56">


<img width="863" alt="Screen Shot 2023-11-28 at 4 05 38 PM" src="https://github.com/inngest/website/assets/1509457/72d75eca-02d2-4f52-9efc-87e8a22a7067">
