### PR TITLE
Add Next.js 13 case

### DIFF
--- a/pages/docs/sdk/serve.mdx
+++ b/pages/docs/sdk/serve.mdx
@@ -417,11 +417,10 @@ Next.js Edge Functions hosted on [Vercel](/docs/deploy/vercel) can also stream r
 
 To enable this, set your runtime to `"edge"` (see [Quickstart for Using Edge Functions | Vercel Docs](https://vercel.com/docs/concepts/functions/edge-functions/quickstart)) and add the `streaming: "allow"` option to your serve handler:
 
+**Next.js 13+**
 <CodeGroup>
 ```ts {{ title: "v3" }}
-export const config = {
-  runtime: "edge",
-};
+export const runtime = "edge";
 
 export default serve({
   client: inngest,
@@ -430,15 +429,39 @@ export default serve({
 });
 ```
 ```ts {{ title: "v2" }}
-export const config = {
-  runtime: "edge",
-};
+export const runtime = "edge";
 
 export default serve(inngest, [...fns], {
   streaming: "allow",
 });
 ```
 </CodeGroup>
+
+<details>
+  <summary>**Older versions (Next.js 12)**</summary>
+  <CodeGroup>
+    ```ts {{ title: "v3" }}
+    export const config = {
+      runtime: "edge",
+    };
+
+    const handler = serve({
+      client: inngest,
+      functions: [...fns],
+      streaming: "allow",
+    });
+    ```
+    ```ts {{ title: "v2" }}
+    export const config = {
+      runtime: "edge",
+    };
+
+    const handler = serve(inngest, [...fns], {
+      streaming: "allow",
+    });
+    ```
+  </CodeGroup>
+</details>
 
 For more information, check out the [Streaming](/docs/streaming) page.
 


### PR DESCRIPTION
Update streaming Next.js example to include the syntax for Next.js 13

**Collapsed:**
<img width="1044" alt="Screenshot 2023-11-30 at 14 59 53" src="https://github.com/inngest/website/assets/16758464/d2d30363-b2bd-469a-b26d-5352dc9363d7">

**Expanded:**
<img width="934" alt="Screenshot 2023-11-30 at 15 00 03" src="https://github.com/inngest/website/assets/16758464/8030ac01-317c-4a03-9b80-05c1f33c2fb8">



