### PR TITLE
Add more context about deployment protection with new changes to UI

### DIFF
--- a/pages/docs/deploy/vercel.mdx
+++ b/pages/docs/deploy/vercel.mdx
@@ -66,7 +66,19 @@ or, if you're on Vercel's Pro plan, configure protection bypass:
 
 ## Bypassing Deployment Protection
 
-If you have Vercel’s [Deployment Protection feature](https://vercel.com/docs/security/deployment-protection) enabled, _by default_, Inngest will not be able to send HTTP requests to your application's preview environments. To enable this, you will need to leverage Vercel's "[Protection Bypass for Automation](https://vercel.com/docs/security/deployment-protection#protection-bypass-for-automation)" feature. Access to this feature may be dependent on the Vercel plan that you're paying for (please see docs linked above). Here's how to set it up:
+If you have Vercel's [Deployment Protection feature](https://vercel.com/docs/security/deployment-protection) enabled, _by default_, Inngest may not be able to communicate with your application. This may depend on what configuration you have set:
+
+* **"Standard protection"** or **"All deployments"** - This affects Inngest production and [branch environments](/docs/platform/environments).
+* **"Only preview deployments"** - This affects [branch environments](/docs/platform/environments).
+
+To work around this, you can either:
+
+1. Disable deployment protection
+2. Configure protection bypass (_Protection bypass may or may not be available depending on your pricing plan_)
+
+### Configure protection bypass
+
+To enable this, you will need to leverage Vercel's "[Protection Bypass for Automation](https://vercel.com/docs/security/deployment-protection#protection-bypass-for-automation)" feature. Access to this feature may be dependent on the Vercel plan that you're paying for (please see docs linked above). Here's how to set it up:
 
 1. Enable "Protection Bypass for Automation" on your Vercel project
 2. Copy your secret


### PR DESCRIPTION
This updates the copy to more clear for what will happen and how they can work around this, additionally by disabling deployment protection. Not ideal, but valid.

Related:
* https://github.com/inngest/monorepo/pull/2073
* https://github.com/inngest/inngest/pull/908