### PR TITLE
Remove filename that is not consistent for app/pages routers

### DIFF
--- a/pages/docs/sdk/serve.mdx
+++ b/pages/docs/sdk/serve.mdx
@@ -386,7 +386,7 @@ See the [Koa example](https://github.com/inngest/inngest-js/tree/main/examples/f
 
 Inngest has first class support for Next.js API routes, allowing you to easily create the Inngest API. Both the App Router and the Pages Router are supported. For the App Router, Inngest requires `GET`, `POST`, and `PUT` methods.
 
-<CodeGroup filename="pages/api/inngest.ts">
+<CodeGroup>
 ```typescript {{ title: "App Router" }}
 // src/app/api/inngest/route.ts
 import { serve } from "inngest/next";


### PR DESCRIPTION
The filename is mentioned in the code itself and it's more obvious to have these tabs left-aligned.

## After 
![image](https://github.com/inngest/website/assets/1509457/6bbb6919-6a05-4251-bcea-b66317882032)

## Before

![image](https://github.com/inngest/website/assets/1509457/e77f1340-d271-4849-b3a7-26bc603d9897)
