### PR TITLE
Fix docs page open graph image for homepage

### DIFF
--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -42,10 +42,12 @@ export function Layout({
   metaTitle,
   description,
 }: Props) {
-  const preferredTitle: string = metaTitle || title;
-  const pageTitle = preferredTitle
-    ? `${preferredTitle} - Inngest Documentation`
-    : `Inngest Documentation`;
+  const siteTitle = `Inngest Documentation`;
+  const preferredTitle: string = metaTitle || title || siteTitle;
+  const pageTitle =
+    preferredTitle === siteTitle
+      ? preferredTitle
+      : `${preferredTitle} - ${siteTitle}`;
   const metaDescription =
     description || `Inngest documentation for ${preferredTitle}`;
   const metaImage = getOpenGraphImageURL({ title: preferredTitle });


### PR DESCRIPTION
I noticed that the social card of the [root page](https://www.inngest.com/docs) was printing "Undefined" as a title.

![image](https://github.com/inngest/website/assets/45401242/266b4b06-2733-4937-bd73-31c10e329536)