### PR TITLE
INN-2484: Add scope to concurrency reference

### DIFF
--- a/pages/docs/functions/concurrency.mdx
+++ b/pages/docs/functions/concurrency.mdx
@@ -66,7 +66,11 @@ Optionally, specifying a concurrency `key` applies the `limit` to unique values 
 
         * Limit concurrency to `n` (via `limit`) per customer id: `'event.data.customer_id'`
         * Limit concurrency to `n` per user, per import id: `'event.data.user_id + "-" + event.data.import_id'`
+      </Property>
+      <Property name="scope" type='"fn" | "env" | "account"'>
+        The scope that the concurrency limit should be applied to. Defaults to per-function (`"fn"`).
 
+        Set to `"env"` to apply the limit to all functions in the same environment (e.g. production vs branch environments) or to `"account"` to apply the limit to all functions in your account.
       </Property>
     </Properties>
   </Property>

--- a/pages/docs/reference/functions/create.mdx
+++ b/pages/docs/reference/functions/create.mdx
@@ -40,6 +40,11 @@ The `createFunction` method accepts a series of arguments to define your functio
       <Property name="key" type="string">
         A unique key expression for which to restrict concurrently running steps to. The expression is evaluated for each triggering event and a unique key is generate.
       </Property>
+      <Property name="scope" type='"fn" | "env" | "account"'>
+        The scope that the concurrency limit should be applied to. Defaults to per-function (`"fn"`).
+
+        Set to `"env"` to apply the limit to all functions in the same environment (e.g. production vs branch environments) or to `"account"` to apply the limit to all functions in your account.
+      </Property>
     </Properties>
   </Property>
 


### PR DESCRIPTION
This is a placeholder right now. We need more information about how the concurrency limit works across non-fn-scopes. @tonyhb, I could use some help with that - I'm not sure how concurrency is shared across two functions. 

INN-2484