### PR TITLE
Add Vercel deployment gotcha

### DIFF
--- a/pages/docs/deploy/vercel.mdx
+++ b/pages/docs/deploy/vercel.mdx
@@ -68,7 +68,7 @@ or, if you're on Vercel's Pro plan, configure [protection bypass](/docs/deploy/v
 
 👉 Please note that **currently**, active runs will use the function configuration and URL that was the latest when the run started. Each Vercel deploy has a unique URL, which means that new deploys will not affect active runs. This will be addressed in the future releases, please check our [Roadmap](https://roadmap.inngest.com/roadmap).
 
-Inngest can always use the latest function logic by using a static URL. To do so, use the `serveHost` param in the [`serve`](https://www.inngest.com/docs/reference/serve) function. For example, if you change the `serveHost` to your domain name, Inngest will use that domain name instead. In this way, you will always use the latest version of the callback passed to the Inngest function.
+Inngest can always use the latest function logic by using a static URL. To do so, use the `serveHost` param in the [`serve`](/docs/reference/serve) function. For example, if you change the `serveHost` to your domain name, Inngest will use that domain name instead. In this way, you will always use the latest version of the callback passed to the Inngest function.
 
 However, this solution won't affect any of the function configuration. For example, changing a function's `retries` option and deploying will not affect retries for active runs.
 


### PR DESCRIPTION
## PR Description
In reference to the [Discord conversation](https://discord.com/channels/842170679536517141/1191732968029438023/1192502822823006360),  I'm suggesting a Callout about the URL gotcha.

## Preview link

🍿 [see the callout starting with "Please note that"](https://website-git-docs-deployment-gotcha-inngest.vercel.app/docs/deploy/vercel#deploying-to-vercel)

##  Concerns

Please check for these two of my concerns:
- I am not sure if this is the right place (or if it's the only one).
- I am not sure if this is the right phrasing and if it includes sufficient information.

## Open questions

The user also voiced that the general narrative is _misleading_ throughout the docs:

> "the docs everywhere mention keeping state consistent across function versions in e.g. [`step.run`](https://www.inngest.com/docs/reference/functions/step-run)."

I'm wondering if we should also change the language in those places as well?