### PR TITLE
Add docs for `Inngest.Any` and `InngestFunction.Any`

### DIFF
--- a/pages/docs/typescript.mdx
+++ b/pages/docs/typescript.mdx
@@ -270,3 +270,15 @@ import { inngest } from "@/inngest";
 type StepTools = GetStepTools<typeof inngest>;
 type StepToolsWithTrigger = GetStepTools<typeof inngest, "app/user.created">;
 ```
+
+### Inngest.Any / InngestFunction.Any <VersionBadge version="v3.10.0+" />
+
+Some exported classes have an `Any` type within their namespace that represents any instance of that class without inference or generics.
+
+This is useful for typing lists of functions or factories that create Inngest primitives.
+
+```ts
+import { type InngestFunction } from "inngest";
+
+const functionsToServe: InngestFunction.Any[] = [];
+```


### PR DESCRIPTION
## Summary

Adds documentation for using some new exports, `Inngest.Any` and `InngestFunction.Any`, within the "TypeScript" section of the TS SDK docs.

## Related

- inngest/inngest-js#459