### PR TITLE
Fix tag contrast in nav

### DIFF
--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -66,7 +66,7 @@ function NavLink({
     >
       <span className="truncate">{children}</span>
       {tag && (
-        <Tag variant="small" color="slate">
+        <Tag variant="small" color="slate" background="page">
           {tag}
         </Tag>
       )}

--- a/shared/Docs/Tag.tsx
+++ b/shared/Docs/Tag.tsx
@@ -10,10 +10,16 @@ const variantStyle = (variant: string): string => {
   }
 };
 
-const colorStyle = (color: string, variant: string): string => {
+const colorStyle = (
+  color: string,
+  variant: string,
+  background: "default" | "page"
+): string => {
   switch (variant) {
     case "small":
-      return `text-${color}-200 dark:text-${color}-300`;
+      return `text-${color}-${
+        background === "default" ? "200" : "600"
+      } dark:text-${color}-${background === "default" ? "300" : "200"}`;
 
     case "medium":
       return `ring-${color}-300 dark:ring-${color}-400/30 bg-${color}-400/10 text-${color}-500 dark:text-${color}-400`;
@@ -34,13 +40,19 @@ export function Tag({
   children,
   variant = "medium",
   color = valueColorMap[children.toLowerCase()] ?? "indigo",
+  background = "default",
+}: {
+  children: string;
+  variant?: "small" | "medium";
+  color?: string;
+  background?: "default" | "page";
 }) {
   return (
     <span
       className={clsx(
         "font-mono text-[0.625rem] font-semibold leading-4",
         variantStyle(variant),
-        colorStyle(color, variant)
+        colorStyle(color, variant, background)
       )}
     >
       {children}


### PR DESCRIPTION
A previous PR I changed the colors to lighter as it's usually used on dark backgrounds, but forgot this is used on the sidebar which is on a light/dark background.

![image](https://github.com/inngest/website/assets/1509457/be60e71f-1e3c-41d2-80af-955913a19eb8)
