### PR TITLE
Launch Week banner+page update

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -41,10 +41,8 @@ export function LaunchWeekBanner({ urlRef = "homepage-banner" }) {
     <PageBanner href={`/launch-week?ref=${urlRef}`} className="mt-px">
       <RocketLaunchIcon className="inline-flex h-7 sm:h-5 mr-1" />
       <span className="shrink">
-        It's Launch Week!{" "}
-        <span className="font-normal inline-flex">
-          New features and enhancements shipped daily.
-        </span>
+        We've just wrapped up a Launch Week.{" "}
+        <span className="font-normal inline-flex">See all we've shipped.</span>
       </span>
     </PageBanner>
   );

--- a/pages/launch-week/index.tsx
+++ b/pages/launch-week/index.tsx
@@ -39,25 +39,14 @@ export default function LaunchWeek() {
                 Launch Week
               </span>
             </h1>
-            <div className="mt-5 flex items-center justify-center">
-              <span
-                className="py-2 px-8 uppercase text-white font-extrabold text-lg md:text-xl border-2 border-transparent rounded-full"
-                style={{
-                  background: `linear-gradient(#292e23, #292e23) padding-box,
-                              linear-gradient(to right, #5EEAD4, #A7F3D0, #FDE68A) border-box`,
-                }}
-              >
-                January 22-25 2024
-              </span>
-            </div>
-            <p className="my-12 text-slate-200 text-lg md:text-xl">
-              A week of updates from Inngest starting{" "}
-              <span className="font-bold bg-clip-text text-transparent bg-gradient-to-br bg-gradient-to-r from-[#5EEAD4] via-[#A7F3D0] to-[#FDE68A]">
-                January 22nd, 2024
-              </span>
-            </p>
-
-            <NewsletterSignup tags={["launch-week-jan-2023"]} />
+            <RowItem
+              title="Launch week recap"
+              subtitle="The tl;dr of this week's updates"
+              image="/assets/launch-week/og.png"
+              label="Recap"
+              buttonHref="/blog/launch-week-recap"
+              orientation="right"
+            />
           </div>
         </div>
 


### PR DESCRIPTION
I've changed the banner wording, removed the newsletter subscription CTA, and moved the recap to the top.
<img width="1297" alt="Screenshot 2024-01-29 at 8 49 38 PM" src="https://github.com/inngest/website/assets/45401242/c81dfd18-5395-4e07-9419-c01dd7b40a79">
<img width="1297" alt="Screenshot 2024-01-29 at 8 49 48 PM" src="https://github.com/inngest/website/assets/45401242/86024627-e6ef-490f-b196-2da0c9c68581">
