### PR TITLE
Add `timeout` to `step.invoke()` options in TS docs

### DIFF
--- a/pages/docs/reference/functions/step-invoke.mdx
+++ b/pages/docs/reference/functions/step-invoke.mdx
@@ -52,6 +52,8 @@ const mainFunction = inngest.createFunction(
           <Property name="timeout" type="string | number | Date" version="v3.14.0+">
             {/* Purposefully not mentioning the default timeout of 1 year, as we expect to lower this very soon. */}
             The amount of time to wait for the invoked function to complete. The time to wait can be specified using a `number` of milliseconds, an `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`, or a `Date` object.
+
+            Note that the invoked function will continue to run even if this step times out.
           </Property>
         </Properties>
         Throwing errors within the invoked function will be reflected in the invoking function.


### PR DESCRIPTION
## Summary

Adds docs for inngest/inngest-js#484, which adds `timeout` to `step.invoke()` options.

## Related

- inngest/inngest-js#484