### PR TITLE
Add docs for `INNGEST_DEV` and `isDev`

### DIFF
--- a/pages/docs/reference/client/create.mdx
+++ b/pages/docs/reference/client/create.mdx
@@ -27,11 +27,21 @@ const inngest = new Inngest({
   <Property name="id" type="string" required>
     A unique identifier for your application. We recommend a hyphenated slug.
   </Property>
+  <Property name="baseUrl" type="string">
+    Override the default (`https://inn.gs/`) base URL for sending events. See also the [`INNGEST_BASE_URL`](/docs/sdk/environment-variables#inngest-base-url) environment variable.
+  </Property>
+    <Property name="env" type="string">
+    The environment name. Required only when using [Branch Environments](/docs/platform/environments).
+  </Property>
   <Property name="eventKey" type="string">
     An Inngest [Event Key](/docs/events/creating-an-event-key). Alternatively, set the [`INNGEST_EVENT_KEY`](/docs/sdk/environment-variables#inngest-event-key) environment variable.
   </Property>
-  <Property name="schemas" type="EventSchemas" version="v2.0.0+">
-    Event payload types. See [Defining Event Payload Types](#defining-event-payload-types).
+  <Property name="fetch" type="Fetch API compatible interface">
+    Override the default [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation. Defaults to the runtime's native Fetch API.
+  </Property>
+  <Property name="isDev" type="boolean" version="v3.15.0+">
+    Set to `true` to force Dev mode, setting default local URLs and turning off
+    signature verification, or force Cloud mode with `false`. Alternatively, set [`INNGEST_DEV`](/docs/sdk/environment-variables#inngest-dev).
   </Property>
   <Property name="logger" type="Logger" version="v2.0.0+">
     A logger object that provides the following interfaces (`.info()`, `.warn()`, `.error()`, `.debug()`). Defaults to using `console` if not provided. Overwrites [`INNGEST_LOG_LEVEL`](/docs/sdk/environment-variables#inngest-log-level) if set. See [logging guide](/docs/guides/logging) for more details.
@@ -39,14 +49,8 @@ const inngest = new Inngest({
   <Property name="middleware" type="array" version="v2.0.0+">
     A stack of [middleware](/docs/reference/middleware/overview) to add to the client.
   </Property>
-  <Property name="env" type="string">
-    The environment name. Required only when using [Branch Environments](/docs/platform/environments).
-  </Property>
-  <Property name="fetch" type="Fetch API compatible interface">
-    Override the default [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation. Defaults to the runtime's native Fetch API.
-  </Property>
-  <Property name="baseUrl" type="string">
-    Override the default (`https://inn.gs/`) base URL for sending events. See also the [`INNGEST_BASE_URL`](/docs/sdk/environment-variables#inngest-base-url) environment variable.
+  <Property name="schemas" type="EventSchemas" version="v2.0.0+">
+    Event payload types. See [Defining Event Payload Types](#defining-event-payload-types).
   </Property>
 </Properties>
 
@@ -203,7 +207,27 @@ type Events = GetEvents<typeof inngest>;
 type AppUserCreated = Events["app/user.created"];
 ```
 
-For more information on this and other TypeScript helpers, see [TypeScript - Helpers](/docs/typescript#helpers).
+For more information on this and other TypeScript helpers, see [TypeScript -
+Helpers](/docs/typescript#helpers).
+
+## Cloud Mode and Dev Mode
+
+An SDK can run in two separate "modes:" **Cloud** or **Dev**.
+
+- **Cloud Mode**
+  - 🔒 Signature verification **ON**
+  - Defaults to communicating with Inngest Cloud (e.g. `https://api.inngest.com`)
+- **Dev Mode**
+  - ❌ Signature verification **OFF**
+  - Defaults to communicating with an Inngest Dev Server (e.g. `http://localhost:8288`)
+
+You can force either Dev or Cloud Mode by setting
+[`INNGEST_DEV`](/docs/sdk/environment-variables#inngest-dev) or the
+[`isDev`](#configuration) option.
+
+If neither is set, the SDK will attempt to infer which mode it should be in
+based on environment variables such as `NODE_ENV`. Most of the time, this inference is all you need and explicitly setting a mode
+isn't required.
 
 ## Best Practices
 

--- a/pages/docs/sdk/environment-variables.mdx
+++ b/pages/docs/sdk/environment-variables.mdx
@@ -4,6 +4,16 @@ You can set environment variables to change various parts of Inngest's configura
 
 We'll look at all available environment variables here, what to set them to, and what our recommendations are for their use.
 
+- [INNGEST_BASE_URL](#inngest-base-url)
+- [INNGEST_DEV](#inngest-dev)
+- [INNGEST_ENV](#inngest-env)
+- [INNGEST_EVENT_KEY](#inngest-event-key)
+- [INNGEST_LOG_LEVEL](#inngest-log-level)
+- [INNGEST_SERVE_HOST](#inngest-serve-host)
+- [INNGEST_SERVE_PATH](#inngest-serve-path)
+- [INNGEST_SIGNING_KEY](#inngest-signing-key)
+- [INNGEST_STREAMING](#inngest-streaming)
+
 ---
 
 ## INNGEST_BASE_URL
@@ -12,15 +22,35 @@ Use this to tell an SDK the host to use to communicate with Inngest.
 
 If set, it should be the host including the protocol and port, e.g. `http://localhost:8288` or `https://my.tunnel.com`. Can be overwritten by manually specifying `baseUrl` in `new Inngest()` or `serve()`.
 
-In most cases we recommend keeping this unset. A common case, though, is wanting to force a production build of your app to use the Inngest Dev Server instead of Inngest Cloud for local integration testing or similar.
+In most cases we recommend keeping this unset. A common case, though, is wanting
+to force a production build of your app to use the Inngest Dev Server instead of
+Inngest Cloud for local integration testing or similar.
 
-In this case, set `INNGEST_BASE_URL=http://localhost:8288`, or wherever your Inngest Dev Server is accessible. For docker, this might be `http://host.docker.internal:8288`.
+In this case, prefer using [INNGEST_DEV=1](#inngest-dev). For Docker, it may be
+appropriate to also set `INNGEST_BASE_URL=http://host.docker.internal:8288`.
+
+---
+
+## INNGEST_DEV
+
+Use this to force an SDK to be in Dev Mode with `INNGEST_DEV=1`, or Cloud mode
+with `INNGEST_DEV=0`.
+
+Can be overwritten by manually specifying `isDev` is `new Inngest()`.
+
+Explicitly setting either mode will change the URLs used to communicate with
+Inngest, as well as turning **off** signature verification in Dev mode, or **on** in
+Cloud mode.
+
+If neither the environment variable nor config option are specified, the SDK will
+attempt to infer which mode it should be in based on environment variables such
+as `NODE_ENV`.
 
 ---
 
 ## INNGEST_ENV
 
-Use this to tell Inngest which [envionment](/docs/platform/environments?ref=environment-variables) you're wanting to send and receive events from.
+Use this to tell Inngest which [Inngest Envionment](/docs/platform/environments?ref=environment-variables) you're wanting to send and receive events from.
 
 Can be overwritten by manually specifying `env` in `new Inngest()`.
 

--- a/pages/docs/sdk/environment-variables.mdx
+++ b/pages/docs/sdk/environment-variables.mdx
@@ -34,7 +34,7 @@ appropriate to also set `INNGEST_BASE_URL=http://host.docker.internal:8288`.
 ## INNGEST_DEV
 
 Use this to force an SDK to be in Dev Mode with `INNGEST_DEV=1`, or Cloud mode
-with `INNGEST_DEV=0`.
+with `INNGEST_DEV=0`. A URL for the dev server can be set at the same time with `INNGEST_DEV=http://localhost:8288`.
 
 Can be overwritten by manually specifying `isDev` is `new Inngest()`.
 


### PR DESCRIPTION
## Summary

Adds docs for `INNGEST_DEV` and `isDev` for the release of inngest/inngest-js#488.

- Added `INNGEST_DEV` to the [Environment Variables](https://website-git-docs-inngestdev-inngest.vercel.app/docs/sdk/environment-variables#inngest-dev) page
- Added `isDev` to the [Create the Inngest Client](https://website-git-docs-inngestdev-inngest.vercel.app/docs/reference/client/create#configuration) page
- Added a ToC to the [Environment Variables](https://website-git-docs-inngestdev-inngest.vercel.app/docs/sdk/environment-variables#inngest-dev) page
- Added a [Cloud Mode and Dev Mode](https://website-git-docs-inngestdev-inngest.vercel.app/docs/reference/client/create#cloud-mode-and-dev-mode) section to the [Create the Inngest Client](https://website-git-docs-inngestdev-inngest.vercel.app/docs/reference/client/create#configuration) page

## Related

- inngest/inngest-js#488