### PR TITLE
Add info for when to use `step.invoke()`

### DIFF
--- a/pages/docs/guides/invoking-functions-directly.mdx
+++ b/pages/docs/guides/invoking-functions-directly.mdx
@@ -6,6 +6,15 @@ Inngest's `step.invoke()` function provides a powerful tool for calling function
 - Naturally separates your system into reusable functions that can spread across process boundaries
 - Allows use of synchronous interaction between functions in an otherwise-asynchronous event-driven architecture, making it much easier to manage functions that require immediate outcomes
 
+<Callout>
+### When should I invoke?
+
+Use `step.invoke()` in tasks that need specific settings like concurrency limits. Because it runs with its own configuration,
+distinct from the invoker's, you can provide a tailored configuration for each function.
+
+If you don't need to define granular configuration or if your function won't be reused across app boundaries, use `step.run()` for simplicity.
+</Callout>
+
 ## Invoking another function
 
 ```ts

--- a/pages/docs/reference/functions/step-invoke.mdx
+++ b/pages/docs/reference/functions/step-invoke.mdx
@@ -152,6 +152,11 @@ See [Referencing functions](/docs/functions/references) for more information.
 
 Use of `step.invoke()` to call an Inngest function directly is more akin to traditional RPC than Inngest's usual event-driven flow. While this tool still uses events behind the scenes, you can use it to help break up your codebase into reusable workflows that can be called from anywhere.
 
+Use `step.invoke()` in tasks that need specific settings like concurrency limits. Because it runs with its own configuration,
+distinct from the invoker's, you can provide a tailored configuration for each function.
+
+If you don't need to define granular configuration or if your function won't be reused across app boundaries, use `step.run()` for simplicity.
+
 ## Internal behaviour
 
 When a function object is passed as an argument, internally, the SDK retrieves the function's ID automatically. Alternatively, if a function ID `string` is passed, the Inngest SDK will assert the ID is correct at runtime. See [Error handling](#error-handling) for more information about this point.


### PR DESCRIPTION
## Summary

Adds a callout and some more info in the `step.invoke()` reference for when to use `step.invoke()` vs `step.run()`.