### PR TITLE
Add "Edit this page" link

### DIFF
--- a/mdx/plugins/sourceFilePath.mjs
+++ b/mdx/plugins/sourceFilePath.mjs
@@ -1,8 +1,8 @@
-import * as path from 'path';
-import { parse } from 'acorn';
+import * as path from "path";
+import { parse } from "acorn";
 
-const VARIABLE_NODE_TYPE = 'mdxjsEsm';
-const VARIABLE_NAME = 'sourceFilePath';
+const VARIABLE_NODE_TYPE = "mdxjsEsm";
+const VARIABLE_NAME = "sourceFilePath";
 
 /**
  * Exports the MDX file path, relative to the project root
@@ -20,7 +20,7 @@ export function remark() {
       value: `export const ${VARIABLE_NAME} = ${JSON.stringify(relative)}`,
     });
 
-    if (typeof next === 'function') {
+    if (typeof next === "function") {
       return next(null, ast, vFile);
     }
 
@@ -34,7 +34,8 @@ export function remark() {
 export function rehype() {
   return function transformer(ast) {
     const def = ast.children.find(
-      (node) => node.type === VARIABLE_NODE_TYPE && node.value.includes(VARIABLE_NAME)
+      (node) =>
+        node.type === VARIABLE_NODE_TYPE && node.value.includes(VARIABLE_NAME)
     );
 
     // add estree metadata to the node, or it will not be picked up by recma-nextjs-static-props
@@ -42,8 +43,8 @@ export function rehype() {
     if (def) {
       def.data = {
         estree: parse(def.value, {
-          sourceType: 'module',
-          ecmaVersion: 'latest',
+          sourceType: "module",
+          ecmaVersion: "latest",
         }),
       };
     }

--- a/mdx/plugins/sourceFilePath.mjs
+++ b/mdx/plugins/sourceFilePath.mjs
@@ -1,0 +1,51 @@
+import * as path from 'path';
+import { parse } from 'acorn';
+
+const VARIABLE_NODE_TYPE = 'mdxjsEsm';
+const VARIABLE_NAME = 'sourceFilePath';
+
+/**
+ * Exports the MDX file path, relative to the project root
+ **/
+export function remark() {
+  return function transformer(ast, vFile, next) {
+    // find current file path relative to project root
+    const [filePath] = vFile.history;
+    const relative = path.relative(vFile.cwd, filePath);
+
+    // add it as an export statement to the top of the file to make it
+    // available on Next.js pageProps (via the recma-nextjs-static-props plugin)
+    ast.children.unshift({
+      type: VARIABLE_NODE_TYPE,
+      value: `export const ${VARIABLE_NAME} = ${JSON.stringify(relative)}`,
+    });
+
+    if (typeof next === 'function') {
+      return next(null, ast, vFile);
+    }
+
+    return ast;
+  };
+}
+
+/**
+ * Preserves the MDX file path export when processing through rehype
+ **/
+export function rehype() {
+  return function transformer(ast) {
+    const def = ast.children.find(
+      (node) => node.type === VARIABLE_NODE_TYPE && node.value.includes(VARIABLE_NAME)
+    );
+
+    // add estree metadata to the node, or it will not be picked up by recma-nextjs-static-props
+    // not sure why this is necessary, following pattern from existing rehypeAddMDXExports plugin
+    if (def) {
+      def.data = {
+        estree: parse(def.value, {
+          sourceType: 'module',
+          ecmaVersion: 'latest',
+        }),
+      };
+    }
+  };
+}

--- a/mdx/rehype.mjs
+++ b/mdx/rehype.mjs
@@ -1,20 +1,19 @@
-import { mdxAnnotations } from "mdx-annotations";
-import { visit } from "unist-util-visit";
-import rehypeMdxTitle from "rehype-mdx-title";
-import shiki from "shiki";
-import { toString } from "mdast-util-to-string";
-import * as acorn from "acorn";
-import { slugifyWithCounter } from "@sindresorhus/slugify";
-import rehypeCodeTitles from "rehype-code-titles";
+import { slugifyWithCounter } from '@sindresorhus/slugify';
+import * as acorn from 'acorn';
+import { toString } from 'mdast-util-to-string';
+import { mdxAnnotations } from 'mdx-annotations';
+import rehypeCodeTitles from 'rehype-code-titles';
+import rehypeMdxTitle from 'rehype-mdx-title';
+import shiki from 'shiki';
+import { visit } from 'unist-util-visit';
+
+import * as sourceFilePath from './plugins/sourceFilePath.mjs';
 
 export function rehypeParseCodeBlocks() {
   return (tree) => {
-    visit(tree, "element", (node, _nodeIndex, parentNode) => {
-      if (node.tagName === "code" && node.properties.className) {
-        parentNode.properties.language = node.properties.className[0]?.replace(
-          /^language-/,
-          ""
-        );
+    visit(tree, 'element', (node, _nodeIndex, parentNode) => {
+      if (node.tagName === 'code' && node.properties.className) {
+        parentNode.properties.language = node.properties.className[0]?.replace(/^language-/, '');
       }
     });
   };
@@ -24,21 +23,17 @@ let highlighter;
 
 export function rehypeShiki() {
   return async (tree) => {
-    highlighter =
-      highlighter ?? (await shiki.getHighlighter({ theme: "css-variables" }));
+    highlighter = highlighter ?? (await shiki.getHighlighter({ theme: 'css-variables' }));
 
-    visit(tree, "element", (node) => {
-      if (node.tagName === "pre" && node.children[0]?.tagName === "code") {
+    visit(tree, 'element', (node) => {
+      if (node.tagName === 'pre' && node.children[0]?.tagName === 'code') {
         let codeNode = node.children[0];
         let textNode = codeNode.children[0];
 
         node.properties.code = textNode.value;
 
         if (node.properties.language) {
-          let tokens = highlighter.codeToThemedTokens(
-            textNode.value,
-            node.properties.language
-          );
+          let tokens = highlighter.codeToThemedTokens(textNode.value, node.properties.language);
 
           textNode.value = shiki.renderToHtml(tokens, {
             elements: {
@@ -53,11 +48,11 @@ export function rehypeShiki() {
   };
 }
 
-const tagsToAddIds = ["h2", "h3", "h4"];
+const tagsToAddIds = ['h2', 'h3', 'h4'];
 function rehypeSlugify() {
   return (tree) => {
     let slugify = slugifyWithCounter();
-    visit(tree, "element", (node) => {
+    visit(tree, 'element', (node) => {
       if (tagsToAddIds.includes(node.tagName) && !node.properties.id) {
         node.properties.id = slugify(toString(node));
       }
@@ -72,7 +67,7 @@ function rehypeAddMDXExports(getExports) {
     for (let [name, value] of exports) {
       for (let node of tree.children) {
         if (
-          node.type === "mdxjsEsm" &&
+          node.type === 'mdxjsEsm' &&
           new RegExp(`export\\s+const\\s+${name}\\s*=`).test(node.value)
         ) {
           return;
@@ -82,12 +77,12 @@ function rehypeAddMDXExports(getExports) {
       let exportStr = `export const ${name} = ${value}`;
 
       tree.children.push({
-        type: "mdxjsEsm",
+        type: 'mdxjsEsm',
         value: exportStr,
         data: {
           estree: acorn.parse(exportStr, {
-            sourceType: "module",
-            ecmaVersion: "latest",
+            sourceType: 'module',
+            ecmaVersion: 'latest',
           }),
         },
       });
@@ -99,7 +94,7 @@ function getSections(node) {
   let sections = [];
 
   for (let child of node.children ?? []) {
-    if (child.type === "element" && child.tagName === "h2") {
+    if (child.type === 'element' && child.tagName === 'h2') {
       sections.push(`{
         title: ${JSON.stringify(toString(child))},
         id: ${JSON.stringify(child.properties.id)},
@@ -126,4 +121,5 @@ export const rehypePlugins = [
       sections: `[${getSections(tree).join()}]`,
     }),
   ],
+  sourceFilePath.rehype,
 ];

--- a/mdx/rehype.mjs
+++ b/mdx/rehype.mjs
@@ -1,19 +1,22 @@
-import { slugifyWithCounter } from '@sindresorhus/slugify';
-import * as acorn from 'acorn';
-import { toString } from 'mdast-util-to-string';
-import { mdxAnnotations } from 'mdx-annotations';
-import rehypeCodeTitles from 'rehype-code-titles';
-import rehypeMdxTitle from 'rehype-mdx-title';
-import shiki from 'shiki';
-import { visit } from 'unist-util-visit';
+import { slugifyWithCounter } from "@sindresorhus/slugify";
+import * as acorn from "acorn";
+import { toString } from "mdast-util-to-string";
+import { mdxAnnotations } from "mdx-annotations";
+import rehypeCodeTitles from "rehype-code-titles";
+import rehypeMdxTitle from "rehype-mdx-title";
+import shiki from "shiki";
+import { visit } from "unist-util-visit";
 
-import * as sourceFilePath from './plugins/sourceFilePath.mjs';
+import * as sourceFilePath from "./plugins/sourceFilePath.mjs";
 
 export function rehypeParseCodeBlocks() {
   return (tree) => {
-    visit(tree, 'element', (node, _nodeIndex, parentNode) => {
-      if (node.tagName === 'code' && node.properties.className) {
-        parentNode.properties.language = node.properties.className[0]?.replace(/^language-/, '');
+    visit(tree, "element", (node, _nodeIndex, parentNode) => {
+      if (node.tagName === "code" && node.properties.className) {
+        parentNode.properties.language = node.properties.className[0]?.replace(
+          /^language-/,
+          ""
+        );
       }
     });
   };
@@ -23,17 +26,21 @@ let highlighter;
 
 export function rehypeShiki() {
   return async (tree) => {
-    highlighter = highlighter ?? (await shiki.getHighlighter({ theme: 'css-variables' }));
+    highlighter =
+      highlighter ?? (await shiki.getHighlighter({ theme: "css-variables" }));
 
-    visit(tree, 'element', (node) => {
-      if (node.tagName === 'pre' && node.children[0]?.tagName === 'code') {
+    visit(tree, "element", (node) => {
+      if (node.tagName === "pre" && node.children[0]?.tagName === "code") {
         let codeNode = node.children[0];
         let textNode = codeNode.children[0];
 
         node.properties.code = textNode.value;
 
         if (node.properties.language) {
-          let tokens = highlighter.codeToThemedTokens(textNode.value, node.properties.language);
+          let tokens = highlighter.codeToThemedTokens(
+            textNode.value,
+            node.properties.language
+          );
 
           textNode.value = shiki.renderToHtml(tokens, {
             elements: {
@@ -48,11 +55,11 @@ export function rehypeShiki() {
   };
 }
 
-const tagsToAddIds = ['h2', 'h3', 'h4'];
+const tagsToAddIds = ["h2", "h3", "h4"];
 function rehypeSlugify() {
   return (tree) => {
     let slugify = slugifyWithCounter();
-    visit(tree, 'element', (node) => {
+    visit(tree, "element", (node) => {
       if (tagsToAddIds.includes(node.tagName) && !node.properties.id) {
         node.properties.id = slugify(toString(node));
       }
@@ -67,7 +74,7 @@ function rehypeAddMDXExports(getExports) {
     for (let [name, value] of exports) {
       for (let node of tree.children) {
         if (
-          node.type === 'mdxjsEsm' &&
+          node.type === "mdxjsEsm" &&
           new RegExp(`export\\s+const\\s+${name}\\s*=`).test(node.value)
         ) {
           return;
@@ -77,12 +84,12 @@ function rehypeAddMDXExports(getExports) {
       let exportStr = `export const ${name} = ${value}`;
 
       tree.children.push({
-        type: 'mdxjsEsm',
+        type: "mdxjsEsm",
         value: exportStr,
         data: {
           estree: acorn.parse(exportStr, {
-            sourceType: 'module',
-            ecmaVersion: 'latest',
+            sourceType: "module",
+            ecmaVersion: "latest",
           }),
         },
       });
@@ -94,7 +101,7 @@ function getSections(node) {
   let sections = [];
 
   for (let child of node.children ?? []) {
-    if (child.type === 'element' && child.tagName === 'h2') {
+    if (child.type === "element" && child.tagName === "h2") {
       sections.push(`{
         title: ${JSON.stringify(toString(child))},
         id: ${JSON.stringify(child.properties.id)},

--- a/mdx/remark.mjs
+++ b/mdx/remark.mjs
@@ -1,6 +1,10 @@
-import { mdxAnnotations } from 'mdx-annotations';
-import remarkGfm from 'remark-gfm';
+import { mdxAnnotations } from "mdx-annotations";
+import remarkGfm from "remark-gfm";
 
-import * as sourceFilePath from './plugins/sourceFilePath.mjs';
+import * as sourceFilePath from "./plugins/sourceFilePath.mjs";
 
-export const remarkPlugins = [mdxAnnotations.remark, sourceFilePath.remark, remarkGfm];
+export const remarkPlugins = [
+  mdxAnnotations.remark,
+  sourceFilePath.remark,
+  remarkGfm,
+];

--- a/mdx/remark.mjs
+++ b/mdx/remark.mjs
@@ -1,4 +1,6 @@
-import { mdxAnnotations } from "mdx-annotations";
-import remarkGfm from "remark-gfm";
+import { mdxAnnotations } from 'mdx-annotations';
+import remarkGfm from 'remark-gfm';
 
-export const remarkPlugins = [mdxAnnotations.remark, remarkGfm];
+import * as sourceFilePath from './plugins/sourceFilePath.mjs';
+
+export const remarkPlugins = [mdxAnnotations.remark, sourceFilePath.remark, remarkGfm];

--- a/shared/Docs/Footer.tsx
+++ b/shared/Docs/Footer.tsx
@@ -180,6 +180,10 @@ function PageNavigation() {
   );
 }
 
+function EditPageLink({ url }: { url: string }) {
+  return <a href={url}>Edit this page on GitHub</a>;
+}
+
 function SmallPrint() {
   return (
     <div className="flex flex-col items-center justify-between gap-5 border-t border-slate-900/5 pt-8 dark:border-white/5 sm:flex-row">
@@ -191,12 +195,13 @@ function SmallPrint() {
   );
 }
 
-export function Footer() {
+export function Footer({ editPageURL }: { editPageURL: string }) {
   let router = useRouter();
 
   return (
     <footer className="mx-auto max-w-2xl space-y-10 pb-16 lg:max-w-5xl">
       {/* <Feedback key={router.pathname} /> */}
+      <EditPageLink url={editPageURL} />
       <PageNavigation />
       <SmallPrint />
     </footer>

--- a/shared/Docs/Footer.tsx
+++ b/shared/Docs/Footer.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, Fragment, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { Transition } from "@headlessui/react";
-
+import { PencilSquareIcon } from "@heroicons/react/24/outline";
 import { Button } from "../Button";
 import { topLevelNav } from "./navigationStructure";
 import SocialBadges from "./SocialBadges";
@@ -180,18 +180,36 @@ function PageNavigation() {
   );
 }
 
+const Divider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <div className="flex flex-col items-center justify-between gap-5 border-t border-slate-900/5 pt-8 dark:border-white/5 sm:flex-row">
+      {children}
+    </div>
+  );
+};
+
 function EditPageLink({ url }: { url: string }) {
-  return <a href={url}>Edit this page on GitHub</a>;
+  return (
+    <Divider>
+      <Link
+        href={url}
+        className="flex space-x-2 font-medium hover:text-black hover:underline transition-all duration-150 dark:hover:text-white"
+      >
+        <PencilSquareIcon className="h-5" />
+        <span>Edit this page on GitHub</span>
+      </Link>
+    </Divider>
+  );
 }
 
 function SmallPrint() {
   return (
-    <div className="flex flex-col items-center justify-between gap-5 border-t border-slate-900/5 pt-8 dark:border-white/5 sm:flex-row">
+    <Divider>
       <p className="text-xs text-slate-600 dark:text-slate-400">
         &copy; {new Date().getFullYear()} Inngest Inc. All rights reserved.
       </p>
       <SocialBadges />
-    </div>
+    </Divider>
   );
 }
 

--- a/shared/Docs/Footer.tsx
+++ b/shared/Docs/Footer.tsx
@@ -193,7 +193,7 @@ function EditPageLink({ url }: { url: string }) {
     <Divider>
       <Link
         href={url}
-        className="flex space-x-2 font-medium hover:text-black hover:underline transition-all duration-150 dark:hover:text-white"
+        className="flex space-x-2 font-medium text-indigo-600 hover:text-slate-800 hover:underline transition-all duration-150 dark:hover:text-white dark:text-indigo-400"
       >
         <PencilSquareIcon className="h-5" />
         <span>Edit this page on GitHub</span>

--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -15,6 +15,8 @@ import { SectionProvider } from "./SectionProvider";
 import { useMobileNavigationStore } from "./MobileNavigation";
 import { getOpenGraphImageURL } from "../../utils/social";
 
+const GITHUB_PREFIX = "https://github.com/inngest/website/tree/main/";
+
 // Unsure if this should be here or in the _app and conditionally run only on docs
 function onRouteChange() {
   useMobileNavigationStore.getState().close();
@@ -33,6 +35,8 @@ export type Props = {
   metaTitle?: string;
   /* The optional description */
   description?: string;
+  /* Source file path for the current page */
+  sourceFilePath?: string;
 };
 
 export function Layout({
@@ -41,6 +45,7 @@ export function Layout({
   title,
   metaTitle,
   description,
+  sourceFilePath,
 }: Props) {
   const siteTitle = `Inngest Documentation`;
   const preferredTitle: string = metaTitle || title || siteTitle;
@@ -51,6 +56,9 @@ export function Layout({
   const metaDescription =
     description || `Inngest documentation for ${preferredTitle}`;
   const metaImage = getOpenGraphImageURL({ title: preferredTitle });
+  const editPageURL = sourceFilePath
+    ? GITHUB_PREFIX + sourceFilePath
+    : undefined;
 
   return (
     <div className="dark:bg-slate-1000">
@@ -90,7 +98,7 @@ export function Layout({
               <main className="py-16">
                 <Prose as="article">{children}</Prose>
               </main>
-              <Footer />
+              <Footer editPageURL={editPageURL} />
             </div>
           </div>
         </SectionProvider>


### PR DESCRIPTION
## Overview

This PR adds "Edit this page on GitHub" link to all the docs pages.

This seemingly simple task turned out more complex because in Next.js there's no direct 1:1 mapping between the file path and the rendered URL. For example, the landing pages are rendered from `index.mdx` files.

The solution could have been easier if we deleted the `index.mdx` files and created a corresponding file in a parent directory to be the landing page (for example: instead of `/docs/guides/index.mdx` it would be `docs/guides.mdx`). However, this could still break if we ever disobeyed this convention.

Instead, we hook into the Next.js MDX pipeline and pass the actual filename as a static prop to the `Layout` that renders the pages. This is a little messy but it _seems_ to work on different file paths.

## See it in action

See the link at the bottom of the page. If you think it doesn't belong to homepage or landing pages, we can disable that (but I personally think it's fine):

➡️ [Docs homepage](https://website-g35s5m2zj-inngest.vercel.app/docs)
➡️ [Random landing page](https://website-g35s5m2zj-inngest.vercel.app/docs/guides)
➡️ [Docs page ending on a list](https://website-g35s5m2zj-inngest.vercel.app/docs/guides/background-jobs)
➡️ [Docs page ending on a code snippet](https://website-g35s5m2zj-inngest.vercel.app/docs/guides/scheduled-functions)
➡️ [Docs page ending on a paragraph](https://website-g35s5m2zj-inngest.vercel.app/docs/guides/writing-expressions)

## Design consideration

I added this link without prior sketching of the feature. I tried to make it consistent with our website and with other docs pages that enable editing. I'm hoping for @whatupjohnb's feedback.

### How others do it

Each image is a link
<a href="https://docs.astro.build/en/basics/layouts/"><img width="1459" alt="image" src="https://github.com/inngest/website/assets/45401242/75e1a8d2-ff67-4058-8efc-89c15cad1a2c"></a>
<br/><br/>
<a href="https://developer.stackblitz.com/codeflow/what-is-codeflow"><img width="1458" alt="image" src="https://github.com/inngest/website/assets/45401242/8ee51eae-6540-40c5-a45e-1953d67ddc27"></a>
<br/><br/>
<a href="https://fly.io/docs/"><img width="1458" alt="image" src="https://github.com/inngest/website/assets/45401242/47b09a7c-b6f5-4c1b-9e4d-ad8870ea97b0"></a>
<br/><br/>
<a href="https://vuejs.org/guide/introduction.html">
<img width="1458" alt="image" src="https://github.com/inngest/website/assets/45401242/af0a8114-9dcd-4419-a2c3-0a80c1670b35"></a>
<br/><br/>

## Closing remarks

To manage your expectations about my knowledge of Next.js internals: I have quite heavily consulted this solution 🫣