### PR TITLE
Add default environment variables for local development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,14 @@
+# Default environment variables for local development
+# This file is checked into source control to enable open source contributions only
+# No keys or any other information should be added to this file
+
+NEXT_PUBLIC_HOSTNAME=localhost
+NEXT_PUBLIC_HOST=http://localhost:3001
+NEXT_PUBLIC_APP_HOST=http://localhost:3000
+NEXT_PUBLIC_API_HOST=http://localhost:8090
+NEXT_PUBLIC_SIGNIN_URL=$NEXT_PUBLIC_APP_HOST/sign-in
+NEXT_PUBLIC_SIGNUP_URL=$NEXT_PUBLIC_APP_HOST/sign-up
+NEXT_PUBLIC_SUPPORT_URL=$NEXT_PUBLIC_APP_HOST/support
+
+NEXT_PUBLIC_FAVICON="favicon-may-2022-local.png"
+

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,11 @@
 *.pem
 /.idea/
 
-# Environment variable files; we keep our environment variables on Vercel
+# Environment variable files.
+# Development is allowed for open-source contributions and defaults in local development
+# Necessary keys can be fetched via Vercel CLI (see README.md)
 .env*
+!.env.development
 
 # Vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Before being able to run the app for the first time, you need to follow the step
 
 - [Git](https://git-scm.com/downloads)
 - [Node.js 18](https://nodejs.org/en/download/)
-- Join the team on Vercel with your GitHub account.
+- _Optional\*_ - Join the team on Vercel with your GitHub account.
 
 ### Instructions
 
@@ -19,8 +19,10 @@ Before being able to run the app for the first time, you need to follow the step
    [Corepack](https://nodejs.org/docs/latest-v18.x/api/corepack.html) by running
    `corepack enable; corepack prepare`
 3. Install dependencies by running `pnpm install`
-4. Link local project to its Vercel project by running `pnpm vercel link`
-5. Download environment variables by running `pnpm env:pull`
+4. _Optional\*_ - Link local project to its Vercel project by running `pnpm vercel link`
+5. _Optional\*_ - Download environment variables by running `pnpm env:pull`
+
+\* Running the website is possible with the default environment variables available in `.env.development`. Fetching other environment variables is only necessary if working on features that require them.
 
 ## Developing
 


### PR DESCRIPTION
These default, non-sensitive env vars enable open source contributions. This follows Next.js recommended practices as well as for most local development (even within the team), sensitive keys are unnecessary.