### PR TITLE
Use branch current build to build edit this page URL

### DIFF
--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -15,7 +15,8 @@ import { SectionProvider } from "./SectionProvider";
 import { useMobileNavigationStore } from "./MobileNavigation";
 import { getOpenGraphImageURL } from "../../utils/social";
 
-const GITHUB_PREFIX = "https://github.com/inngest/website/tree/main/";
+const GITHUB_BRANCH = process.env.VERCEL_GIT_COMMIT_REF || "main";
+const GITHUB_PREFIX = `https://github.com/inngest/website/tree/${GITHUB_BRANCH}/`;
 
 // Unsure if this should be here or in the _app and conditionally run only on docs
 function onRouteChange() {

--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -15,7 +15,7 @@ import { SectionProvider } from "./SectionProvider";
 import { useMobileNavigationStore } from "./MobileNavigation";
 import { getOpenGraphImageURL } from "../../utils/social";
 
-const GITHUB_BRANCH = process.env.VERCEL_GIT_COMMIT_REF || "main";
+const GITHUB_BRANCH = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF || "main";
 const GITHUB_PREFIX = `https://github.com/inngest/website/tree/${GITHUB_BRANCH}/`;
 
 // Unsure if this should be here or in the _app and conditionally run only on docs


### PR DESCRIPTION
This is only mean to make links for newly created MDX documents work on branch builds/preview builds. This also is nice as if someone shares a preview build, the button goes to the correct pull request branch on Github. By default this will be "main."