### PR TITLE
Change the banner

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -38,11 +38,17 @@ export async function getStaticProps(): Promise<
 
 export function LaunchWeekBanner({ urlRef = "homepage-banner" }) {
   return (
-    <PageBanner href={`/launch-week?ref=${urlRef}`} className="mt-px">
+    <PageBanner
+      href={`/blog/announcing-funding-from-a16z?ref=${urlRef}`}
+      className="mt-px"
+    >
       <RocketLaunchIcon className="inline-flex h-7 sm:h-5 mr-1" />
       <span className="shrink">
-        We've just wrapped up a Launch Week.{" "}
-        <span className="font-normal inline-flex">See all we've shipped.</span>
+        We've just raised $6.1M{" "}
+        <span className="font-normal inline-flex">
+          {" "}
+          in new funding led by a16z.
+        </span>
       </span>
     </PageBanner>
   );


### PR DESCRIPTION
This PR changes the banner from celebrating the Launch Week to announcing our recent funding.

**BEFORE:**
<img width="1470" alt="Screenshot 2024-02-27 at 5 54 21 PM" src="https://github.com/inngest/website/assets/45401242/217c9d18-56c2-4eef-a4c1-ab14735f8678">

**AFTER:**
<img width="1470" alt="Screenshot 2024-02-27 at 5 54 32 PM" src="https://github.com/inngest/website/assets/45401242/f3c0dc3f-3e03-4e3e-b1cd-608ce4370fa5">
