### PR TITLE
Add a note that `onSendEvent` middleware will run with `step.invoke()`

### DIFF
--- a/pages/docs/reference/middleware/lifecycle.mdx
+++ b/pages/docs/reference/middleware/lifecycle.mdx
@@ -241,13 +241,13 @@ The `init()` function can return functions for two separate lifecycles to hook i
      <Col>
           ### `onSendEvent` lifecycle
 
-          Triggered when an event is going to be sent via `inngest.send()` or `step.sendEvent()`.
+          Triggered when an event is going to be sent via `inngest.send()`, `step.sendEvent()`, or `step.invoke()`.
 
           <Properties name="Output" nested>
-               <Property name="input" type="function">
+               <Property name="transformInput" type="function">
                     Called before the events are sent to Inngest. This is where you can modify the events before they're sent.
                </Property>
-               <Property name="output" type="function">
+               <Property name="transformOutput" type="function">
                     Called after events are sent to Inngest. This is where you can perform any final actions and modify the output from `inngest.send()`.
                </Property>
           </Properties>


### PR DESCRIPTION
## Summary

Adds a note to the TS middleware docs that `onSendEvent()` will be run for calls to `step.invoke()`, following the bug fix in inngest/inngest-js#503.

## Related

- inngest/inngest-js#503