### PR TITLE
Docs navbar tweaks

### DIFF
--- a/shared/Docs/Header.tsx
+++ b/shared/Docs/Header.tsx
@@ -14,7 +14,7 @@ import { useMobileNavigationStore } from "./MobileNavigation";
 import { ModeToggle } from "./ModeToggle";
 import { MobileSearch, Search } from "./Search";
 import SocialBadges from "./SocialBadges";
-import { headerLinks } from "./Navigation";
+// import { headerLinks } from "./Navigation";
 
 function TopLevelNavItem({ href, children }) {
   return (
@@ -70,7 +70,7 @@ export const Header = forwardRef<HTMLDivElement>(function Header(
       <Search />
       <div className="flex items-center gap-5 lg:hidden">
         <MobileNavigation />
-        <a href="/" className="flex gap-1.5 group/logo items-center pt-1">
+        <a href="/docs" className="flex gap-1.5 group/logo items-center pt-1">
           <Logo className="w-20 text-indigo-500 dark:text-white" />
           <span className="text-slate-700 dark:text-indigo-400 text-base group-hover/logo:text-white transition-color font-semibold">
             Docs
@@ -78,7 +78,7 @@ export const Header = forwardRef<HTMLDivElement>(function Header(
         </a>
       </div>
       <div className="flex items-center gap-5">
-        <nav className="hidden lg:block mr-4">
+        {/* <nav className="hidden lg:block mr-4">
           <ul role="list" className="flex items-center gap-8">
             {headerLinks.map((link) => (
               <TopLevelNavItem key={link.title} href={link.href}>
@@ -86,7 +86,7 @@ export const Header = forwardRef<HTMLDivElement>(function Header(
               </TopLevelNavItem>
             ))}
           </ul>
-        </nav>
+        </nav> */}
         <div className="hidden lg:block">
           <SocialBadges />
         </div>

--- a/shared/Docs/Header.tsx
+++ b/shared/Docs/Header.tsx
@@ -87,13 +87,8 @@ export const Header = forwardRef<HTMLDivElement>(function Header(
             ))}
           </ul>
         </nav> */}
-        <div className="hidden lg:block">
+        <div className="hidden lg:block mr-3">
           <SocialBadges />
-        </div>
-        <div className="hidden lg:block md:h-5 md:w-px md:bg-slate-900/10 md:dark:bg-white/15" />
-        <div className="flex gap-4">
-          <MobileSearch />
-          <ModeToggle />
         </div>
         <div className="hidden sm:flex items-center gap-3">
           <Button
@@ -110,6 +105,11 @@ export const Header = forwardRef<HTMLDivElement>(function Header(
           >
             Sign Up
           </Button>
+        </div>
+        <div className="hidden lg:block md:h-5 md:w-px md:bg-slate-900/10 md:dark:bg-white/15" />
+        <div className="flex gap-4">
+          <MobileSearch />
+          <ModeToggle />
         </div>
       </div>
     </motion.div>

--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -84,7 +84,10 @@ export function Layout({
               className="fixed inset-y-0 left-0 z-40 contents w-72 overflow-y-auto border-r border-slate-900/10 px-6 pt-4 pb-8 dark:border-white/10 lg:block xl:w-80"
             >
               <div className="hidden lg:flex">
-                <a href="/" className="flex gap-1.5 group/logo items-center">
+                <a
+                  href="/docs"
+                  className="flex gap-1.5 group/logo items-center"
+                >
                   <Logo className="w-20 text-indigo-500 dark:text-white" />
                   <span className="mb-0.5 text-slate-700 dark:text-indigo-400 text-base group-hover/logo:text-slate-500 dark:group-hover/logo:text-white transition-color font-semibold">
                     Docs

--- a/shared/Docs/ModeToggle.tsx
+++ b/shared/Docs/ModeToggle.tsx
@@ -7,7 +7,7 @@ function SunIcon(props) {
         d="M10 5.5v-1M13.182 6.818l.707-.707M14.5 10h1M13.182 13.182l.707.707M10 15.5v-1M6.11 13.889l.708-.707M4.5 10h1M6.11 6.111l.708.707"
       />
     </svg>
-  )
+  );
 }
 
 function MoonIcon(props) {
@@ -15,28 +15,28 @@ function MoonIcon(props) {
     <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" {...props}>
       <path d="M15.224 11.724a5.5 5.5 0 0 1-6.949-6.949 5.5 5.5 0 1 0 6.949 6.949Z" />
     </svg>
-  )
+  );
 }
 
 export function ModeToggle() {
   function disableTransitionsTemporarily() {
-    document.documentElement.classList.add('[&_*]:!transition-none')
+    document.documentElement.classList.add("[&_*]:!transition-none");
     window.setTimeout(() => {
-      document.documentElement.classList.remove('[&_*]:!transition-none')
-    }, 0)
+      document.documentElement.classList.remove("[&_*]:!transition-none");
+    }, 0);
   }
 
   function toggleMode() {
-    disableTransitionsTemporarily()
+    disableTransitionsTemporarily();
 
-    let darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-    let isSystemDarkMode = darkModeMediaQuery.matches
-    let isDarkMode = document.documentElement.classList.toggle('dark')
+    let darkModeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    let isSystemDarkMode = darkModeMediaQuery.matches;
+    let isDarkMode = document.documentElement.classList.toggle("dark");
 
     if (isDarkMode === isSystemDarkMode) {
-      delete window.localStorage.isDarkMode
+      delete window.localStorage.isDarkMode;
     } else {
-      window.localStorage.isDarkMode = isDarkMode
+      window.localStorage.isDarkMode = isDarkMode;
     }
   }
 
@@ -47,8 +47,8 @@ export function ModeToggle() {
       aria-label="Toggle dark mode"
       onClick={toggleMode}
     >
-      <SunIcon className="h-5 w-5 stroke-slate-900 dark:hidden" />
+      <SunIcon className="h-6 w-6 stroke-slate-900 dark:hidden" />
       <MoonIcon className="hidden h-5 w-5 stroke-white dark:block" />
     </button>
-  )
+  );
 }

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -220,16 +220,16 @@ function NavigationGroup({ group, className = "" }) {
   );
 }
 
-export const headerLinks = [
-  {
-    title: "Docs",
-    href: BASE_DIR,
-  },
-  {
-    title: "Patterns",
-    href: "/patterns?ref=docs",
-  },
-];
+// export const headerLinks = [
+//   {
+//     title: "Docs",
+//     href: BASE_DIR,
+//   },
+//   {
+//     title: "Patterns",
+//     href: "/patterns?ref=docs",
+//   },
+// ];
 
 // Flatten the nested nav and get all nav sections w/ sectionLinks
 function getAllSections(nav) {

--- a/shared/Docs/SocialBadges.tsx
+++ b/shared/Docs/SocialBadges.tsx
@@ -38,14 +38,19 @@ export default function SocialBadges() {
   return (
     <div className="flex gap-4">
       <SocialLink href="https://github.com/inngest/inngest" icon={GitHubIcon}>
-        Star our open source repo
+        Star our open source repository
       </SocialLink>
-      <SocialLink href="https://www.inngest.com/discord" icon={DiscordIcon}>
+      <SocialLink
+        href="https://www.inngest.com/discord?ref=social-badge"
+        icon={DiscordIcon}
+      >
         Join our Discord community
       </SocialLink>
-      <SocialLink href="https://twitter.com/inngest" icon={TwitterIcon}>
-        Follow us on X.com
-      </SocialLink>
+      <span className="transform scale-75">
+        <SocialLink href="https://twitter.com/inngest" icon={TwitterIcon}>
+          Follow us on X
+        </SocialLink>
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Overview

This PR tidies up the docs navbar:
- links up the docs logo to `/docs`
  - Logo of the page should direct to the homepage (so, "Inngest Docs" should direct to the docs homepage)
- deletes "Docs" and "Patterns" links as they are no longer needed 
  - "Patterns" will be incorporated into docs (and docs should be our primary source of truth for education)
  - "Docs" is now achieved by clicking on the logo
- resizes the twitter logo so it's the same size as its neighbors
- moves the mode icon to the end
  - inspired by docs sites like Auth0
  - where it was previously, it kinda looked like another social icon
- resizes the sun icon so it's not too small

Additionally, I have also added a `ref` to the Discord link so we'd know how many people reach Discord through there.

## Open questions

I've noticed that the social icons are duplicated (website and docs). Possibly a thing to refactor.

## Comparison

### Dark mode

**BEFORE**
<img width="1470" alt="Screenshot 2024-03-01 at 9 13 08 PM" src="https://github.com/inngest/website/assets/45401242/77c6b845-8d4c-4af0-81b3-3de21b589fee">

**AFTER**
<img width="1470" alt="Screenshot 2024-03-01 at 9 13 12 PM" src="https://github.com/inngest/website/assets/45401242/42895650-988d-4be1-8e52-53a659bb008b">

### Light mode

**BEFORE**
<img width="1470" alt="Screenshot 2024-03-01 at 9 13 32 PM" src="https://github.com/inngest/website/assets/45401242/c27fdaa1-7d26-4fe6-a7e5-9e821d1df81d">

**AFTER**
<img width="1470" alt="Screenshot 2024-03-01 at 9 13 21 PM" src="https://github.com/inngest/website/assets/45401242/e990c3e5-44e8-492a-9af8-0f92701b7d7b">
