### PR TITLE
Remove our dashboard from the cancel docs description

### DIFF
--- a/pages/docs/guides/cancel-running-functions.mdx
+++ b/pages/docs/guides/cancel-running-functions.mdx
@@ -1,4 +1,4 @@
-export const description = 'Learn how to cancel long running functions with events, our API, or from the Inngest dashboard.'
+export const description = 'Learn how to cancel long running functions with events or our API.'
 
 # Cancel running functions
 


### PR DESCRIPTION
There isn't a way to cancel function runs from our UI yet, so we shouldn't mention the dashboard in the cancel page's description