### PR TITLE
INN-2866 Add multi-trigger reference docs

### DIFF
--- a/pages/docs/reference/functions/create.mdx
+++ b/pages/docs/reference/functions/create.mdx
@@ -159,8 +159,8 @@ The `createFunction` method accepts a series of arguments to define your functio
 
 One of the following function triggers is **Required**.
 
-You can also specify an array of up to 10 of the following triggers to trigger your function
-from multiple events or crons.
+You can also specify an array of up to 10 of the following triggers to invoke
+your function with multiple events or crons.
 
 <Callout>
 Cron triggers with overlapping schedules for a single function will be deduplicated.

--- a/pages/docs/reference/functions/create.mdx
+++ b/pages/docs/reference/functions/create.mdx
@@ -159,6 +159,13 @@ The `createFunction` method accepts a series of arguments to define your functio
 
 One of the following function triggers is **Required**.
 
+You can also specify an array of up to 10 of the following triggers to trigger your function
+from multiple events or crons.
+
+<Callout>
+Cron triggers with overlapping schedules for a single function will be deduplicated.
+</Callout>
+
 <Properties>
   <Property name="event" type="string">
     The name of the event that will trigger this event to run

--- a/pages/docs/reference/python/functions/create.mdx
+++ b/pages/docs/reference/python/functions/create.mdx
@@ -132,7 +132,7 @@ The `create_function` decorator accepts a configuration and wraps a plain functi
     </Properties>
   </Property>
 
-  <Property name="trigger" type="TriggerEvent | TriggerCron" required>
+  <Property name="trigger" type="TriggerEvent | TriggerCron | list[TriggerEvent | TriggerCron]" required>
     What should trigger the function to run. Either an event or a cron schedule.
   </Property>
 </Properties>


### PR DESCRIPTION
## Summary

Adds small tweaks to Python and TypeScript reference documentation to add a mention of multiple triggers.

Golang uses auto-generated documentation from [pkg.go.dev](https://pkg.go.dev/github.com/inngest/inngestgo).

## Related

- INN-2866
- Documents inngest/inngest-js#497
- Documents inngest/inngest-py#59