### PR TITLE
Add convertible Image component

### DIFF
--- a/pages/docs/guides/resend-webhook-events.mdx
+++ b/pages/docs/guides/resend-webhook-events.mdx
@@ -1,9 +1,10 @@
+import ResendLogo from "src/public/assets/docs/guides/resend-webhook-events/featured-image.png";
+
 export const description = 'Set up Resend webhooks with Inngest and use Resend events within Inngest functions.'
 
 # Integrate email events with Resend webhooks
 
-![Resend logo](/assets/docs/guides/resend-webhook-events/featured-image.png)
-
+<ImageTheme light={ResendLogo} alt="Resend Logo"/>
 
 [Resend webhooks](https://resend.com/docs/dashboard/webhooks/introduction) can be used to build functionality into your application based on changes in the email status. In this guide, you will learn:
 

--- a/shared/Docs/mdx.tsx
+++ b/shared/Docs/mdx.tsx
@@ -335,6 +335,7 @@ export function ImageTheme({
   light: string;
   dark?: string;
 }) {
+  // if there's no dark mode image provided, invert the light mode
   if (!dark) {
     return (
       <div>

--- a/shared/Docs/mdx.tsx
+++ b/shared/Docs/mdx.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import { Heading } from "./Heading";
 import React, { useState } from "react";
 import { ChevronDown, ChevronUp } from "react-feather";
+import Image, { ImageProps } from "next/image";
 
 export { default as YouTube } from "react-youtube-embed";
 
@@ -321,6 +322,45 @@ export function VersionBadge({ version }: { version: `v${string}` }) {
   return (
     <div className="inline-flex items-center px-3 py-0.5 rounded-full text-xs font-medium leading-4 bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-200">
       <span>{version}</span>
+    </div>
+  );
+}
+
+export function ImageTheme({
+  light,
+  dark,
+  alt,
+  ...imageProps
+}: ImageProps & {
+  light: string;
+  dark?: string;
+}) {
+  if (!dark) {
+    return (
+      <div>
+        <Image
+          src={light}
+          className="block dark:invert"
+          alt={alt}
+          {...imageProps}
+        />
+      </div>
+    );
+  }
+  return (
+    <div>
+      <Image
+        src={light}
+        className="block dark:hidden"
+        alt={alt}
+        {...imageProps}
+      />
+      <Image
+        src={dark}
+        className="hidden dark:block"
+        alt={alt}
+        {...imageProps}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Overview

This PR adds a component that either accepts two versions of the same image or inverts an image. This is not a solution to all image scenarios but in many cases will be enough.

➡️ [Preview](http://localhost:3001/docs/guides/resend-webhook-events)

## Motivation

I noticed that currently we don't correctly handle images in dark mode, which result in a situation like this:

<img width="1467" alt="image" src="https://github.com/inngest/website/assets/45401242/d17520ac-6858-420d-b6b2-3d018b693a6f">

## Test

Here's a test with one file, inverted:

<img width="1467" alt="image" src="https://github.com/inngest/website/assets/45401242/e0fcd9df-e01b-42f0-bd38-74768cb279b4">

<img width="1470" alt="image" src="https://github.com/inngest/website/assets/45401242/e38f083b-0782-482e-a5f0-9a4f1f720616">

I've also tested it with two files.