### PR TITLE
DEV-51 Add page-specific sidebar

### DIFF
--- a/pages/docs/guides/index.mdx
+++ b/pages/docs/guides/index.mdx
@@ -1,5 +1,7 @@
 import { ResourceGrid, Resource } from 'src/shared/Docs/Resources'
 
+export const hidePageSidebar = true;
+
 # Guides
 
 Learn how to build with Inngest:

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -10,6 +10,7 @@ import StepsIcon from 'src/shared/Icons/Steps'
 export const pageTitle = 'Inngest Documentation & Guides'
 export const description =
   'Learn how to use Inngest to deploy reliable background functions to any platform.'
+export const hidePageSidebar = true;
 
 {/* <HeroPattern/> TODO - Add cool header graphic*/}
 

--- a/pages/docs/platform/index.mdx
+++ b/pages/docs/platform/index.mdx
@@ -1,4 +1,5 @@
 import { GuideGrid, Guide } from 'src/shared/Docs/Guides'
+export const hidePageSidebar = true;
 
 # Platform Guides
 

--- a/shared/Docs/Footer.tsx
+++ b/shared/Docs/Footer.tsx
@@ -200,22 +200,24 @@ const Divider: React.FC<React.PropsWithChildren> = ({ children }) => {
 
 function EditPageLink({ url }: { url: string }) {
   return (
-    <Link
-      href={url}
-      className="flex space-x-2 font-medium text-indigo-600 hover:text-slate-800 hover:underline transition-all duration-150 dark:hover:text-white dark:text-indigo-400"
-    >
-      <PencilSquareIcon className="h-5" />
-      <span>Edit this page on GitHub</span>
-    </Link>
+    <div className="flex justify-center md:justify-start">
+      <Link
+        href={url}
+        className="flex space-x-2 font-medium text-indigo-600 hover:text-slate-800 hover:underline transition-all duration-150 dark:hover:text-white dark:text-indigo-400"
+      >
+        <PencilSquareIcon className="h-5" />
+        <span>Edit this page on GitHub</span>
+      </Link>
+    </div>
   );
 }
 
 function SmallPrint() {
   return (
     <Divider>
-      <p className="text-xs text-slate-600 dark:text-slate-400">
+      <div className="text-xs text-slate-600 dark:text-slate-400">
         &copy; {new Date().getFullYear()} Inngest Inc. All rights reserved.
-      </p>
+      </div>
       <SocialBadges />
     </Divider>
   );
@@ -225,7 +227,7 @@ export function Footer({ editPageURL }: { editPageURL: string }) {
   let router = useRouter();
 
   return (
-    <footer className="mx-auto max-w-2xl space-y-10 pb-16 lg:max-w-5xl">
+    <footer className="mx-auto max-w-2xl space-y-8 lg:max-w-5xl">
       <Feedback key={router.pathname} page={router.pathname} />
       <EditPageLink url={editPageURL} />
       <PageNavigation />

--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -9,7 +9,7 @@ import { Footer } from "./Footer";
 import { Home } from "./Home";
 import { Header } from "./Header";
 import Logo from "../Icons/Logo";
-import { Navigation } from "./Navigation";
+import { Navigation, PageSidebar } from "./Navigation";
 import { Prose } from "./Prose";
 import { SectionProvider } from "./SectionProvider";
 import { useMobileNavigationStore } from "./MobileNavigation";
@@ -38,6 +38,8 @@ export type Props = {
   description?: string;
   /* Source file path for the current page */
   sourceFilePath?: string;
+  /* Whether to hide the right hand sidebar */
+  hidePageSidebar?: boolean;
 };
 
 export function Layout({
@@ -47,6 +49,7 @@ export function Layout({
   metaTitle,
   description,
   sourceFilePath,
+  hidePageSidebar,
 }: Props) {
   const siteTitle = `Inngest Documentation`;
   const preferredTitle: string = metaTitle || title || siteTitle;
@@ -98,11 +101,25 @@ export function Layout({
               <Header />
               <Navigation className="hidden lg:mt-6 lg:block" />
             </motion.header>
-            <div className="relative px-4 pt-14 sm:px-6 lg:px-8">
-              <main className="py-16">
+
+            {hidePageSidebar ? null : (
+              <motion.header
+                layoutScroll
+                className="fixed inset-y-0 my-14 pt-16 pb-12 right-0 z-40 hidden w-60 border-l border-slate-900/10 px-6 2xl:px-10 dark:border-white/10 xl:block 2xl:w-96"
+              >
+                <div className="pt-2">
+                  <PageSidebar />
+                </div>
+              </motion.header>
+            )}
+
+            <div className="relative px-4 pt-14 sm:px-6 lg:px-8 xl:pl-8 xl:pr-16 xl:mr-32 2xl:mr-10">
+              <main className="py-16 pr-20">
                 <Prose as="article">{children}</Prose>
               </main>
-              <Footer editPageURL={editPageURL} />
+              <div className={hidePageSidebar ? "" : "xl:pr-20 2xl:pr-80"}>
+                <Footer editPageURL={editPageURL} />
+              </div>
             </div>
           </div>
         </SectionProvider>

--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -103,23 +103,29 @@ export function Layout({
             </motion.header>
 
             {hidePageSidebar ? null : (
-              <motion.header
+              <motion.nav
                 layoutScroll
-                className="fixed inset-y-0 my-14 pt-16 pb-12 right-0 z-40 hidden w-60 border-l border-slate-900/10 px-6 2xl:px-10 dark:border-white/10 xl:block 2xl:w-96"
+                className="fixed inset-y-0 mt-14 pt-16 pb-12 right-0 z-40 hidden w-60 border-l border-slate-900/10 px-6 2xl:px-10 dark:border-white/10 xl:block 2xl:w-96"
               >
                 <div className="pt-2">
                   <PageSidebar />
                 </div>
-              </motion.header>
+              </motion.nav>
             )}
 
             <div className="relative px-4 pt-14 sm:px-6 lg:px-8 xl:pl-8 xl:pr-16 xl:mr-32 2xl:mr-10">
-              <main className="py-16 pr-20">
-                <Prose as="article">{children}</Prose>
+              <main className="pt-16 xl:pr-16">
+                <Prose as="article">
+                  {children}
+                  <div
+                    className={
+                      hidePageSidebar ? "py-10" : "pt-10 pb-12 xl:pr-0"
+                    }
+                  >
+                    <Footer editPageURL={editPageURL} />
+                  </div>
+                </Prose>
               </main>
-              <div className={hidePageSidebar ? "" : "xl:pr-20 2xl:pr-80"}>
-                <Footer editPageURL={editPageURL} />
-              </div>
             </div>
           </div>
         </SectionProvider>

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -37,6 +37,8 @@ function NavLink({
   active,
   isAnchorLink = false,
   isTopLevel = false,
+  truncate = true,
+
   className = "",
   children,
   target,
@@ -46,6 +48,7 @@ function NavLink({
   active?: boolean;
   isAnchorLink?: boolean;
   isTopLevel?: boolean;
+  truncate?: boolean;
   className?: string;
   target?: string;
   children: React.ReactNode;
@@ -57,14 +60,14 @@ function NavLink({
       target={target}
       className={clsx(
         "flex justify-between items-center gap-2 py-1 pr-3 text-sm font-medium transition group", // group for nested hovers
-        isTopLevel ? "pl-0" : isAnchorLink ? "pl-7" : "pl-4",
+        isTopLevel ? "pl-0" : isAnchorLink ? "pl-3" : "pl-4",
         active
           ? "text-slate-900 dark:text-white"
           : "text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white",
         className
       )}
     >
-      <span className="truncate">{children}</span>
+      <span className={truncate ? "truncate" : ""}>{children}</span>
       {tag && (
         <Tag variant="small" color="slate" background="page">
           {tag}
@@ -137,6 +140,48 @@ function ActivePageMarker({ group, pathname }) {
   );
 }
 
+export function PageSidebar() {
+  let isInsideMobileNavigation = useIsInsideMobileNavigation();
+  let [router, sections] = useInitialValue(
+    [useRouter(), useSectionStore((s) => s.sections)],
+    isInsideMobileNavigation
+  );
+
+  return (
+    <div>
+      <h4 className="text-base font-medium pb-2">On this page</h4>
+      {/* TODO: Add highlighted page section back */}
+      {/* <AnimatePresence initial={!isInsideMobileNavigation}>
+        <VisibleSectionHighlight group={group} pathname={router.pathname} />
+      </AnimatePresence> */}
+      <motion.ul
+        role="list"
+        initial={{ opacity: 0 }}
+        animate={{
+          opacity: 1,
+          transition: { delay: 0.1 },
+        }}
+        exit={{
+          opacity: 0,
+          transition: { duration: 0.15 },
+        }}
+      >
+        {sections.map((section) => (
+          <li key={section.id}>
+            <NavLink
+              href={`#${section.id}`}
+              tag={section.tag}
+              isAnchorLink
+              truncate={false}
+            >
+              {section.title}
+            </NavLink>
+          </li>
+        ))}
+      </motion.ul>
+    </div>
+  );
+}
 // A nested navigation group of links that expand and follow
 function NavigationGroup({ group, className = "" }) {
   // If this is the mobile navigation then we always render the initial
@@ -160,11 +205,6 @@ function NavigationGroup({ group, className = "" }) {
         {group.title}
       </motion.h2>
       <div className="relative mt-3 pl-2">
-        <AnimatePresence initial={!isInsideMobileNavigation}>
-          {isActiveGroup && (
-            <VisibleSectionHighlight group={group} pathname={router.pathname} />
-          )}
-        </AnimatePresence>
         <motion.div
           layout
           className="absolute inset-y-0 left-2 w-px bg-slate-900/10 dark:bg-white/5"
@@ -184,34 +224,6 @@ function NavigationGroup({ group, className = "" }) {
               >
                 {link.title}
               </NavLink>
-              <AnimatePresence mode="popLayout" initial={false}>
-                {link.href === router.pathname && sections.length > 0 && (
-                  <motion.ul
-                    role="list"
-                    initial={{ opacity: 0 }}
-                    animate={{
-                      opacity: 1,
-                      transition: { delay: 0.1 },
-                    }}
-                    exit={{
-                      opacity: 0,
-                      transition: { duration: 0.15 },
-                    }}
-                  >
-                    {sections.map((section) => (
-                      <li key={section.id}>
-                        <NavLink
-                          href={`${link.href}#${section.id}`}
-                          tag={section.tag}
-                          isAnchorLink
-                        >
-                          {section.title}
-                        </NavLink>
-                      </li>
-                    ))}
-                  </motion.ul>
-                )}
-              </AnimatePresence>
             </motion.li>
           ))}
         </ul>


### PR DESCRIPTION
## Overview

This PR moves the page navigation to a separate sidebar to free up real estate on the main sidebar.

## Preview
➡️ [Landing Page - no sidebar](https://website-git-sylwia-page-sidebar-inngest.vercel.app/docs/platform)
➡️ [Docs page](https://website-git-sylwia-page-sidebar-inngest.vercel.app/docs/functions)

## Considerations 

The menu is hidden on **some landing pages** (like `/guides` or `/platform` but not on `functions`, which is currently more text based). This is achieved by adding a variable to a corresponding file:

```js
export const hidePageSidebar = true;
```

## Outstanding issues

Work to be still done:
- Page nav is **hidden on mobile**.
  - Once we've added breadcrumbs, it will become a part of the last bradcrumb (a version of it can be seen [on Astro docs](https://docs.astro.build/en/concepts/why-astro/))
  - [Linear ticket](https://linear.app/inngest/issue/DEV-64/add-page-navigation-to-breadcrumbs)
- The sidebar does not yet track/highlight position
  - [Linear ticket](https://linear.app/inngest/issue/DEV-65/add-highlightingposition-tracking-to-the-page-specific-menu)
- The right-side space could be used for additional CTAs
  - [Linear ticket](https://linear.app/inngest/issue/DEV-66/add-space-for-ctas-on-the-page-specific-sidebar)


## Screenshots

### Landing page (no sidebar)
<img width="1580" alt="Screenshot 2024-03-11 at 7 03 32 PM" src="https://github.com/inngest/website/assets/45401242/72a0fa85-bdf4-429c-bcbb-86524dda3aba">

### Docs page
<img width="1580" alt="Screenshot 2024-03-11 at 7 03 18 PM" src="https://github.com/inngest/website/assets/45401242/5c5099eb-c031-47e9-a7e7-068e50c58632">

### Footer
<img width="1582" alt="Screenshot 2024-03-11 at 7 04 22 PM" src="https://github.com/inngest/website/assets/45401242/65d2bea5-cc24-480d-b7dd-c79ab8c69957">

### Slimmer sizes
<img width="645" alt="Screenshot 2024-03-11 at 7 04 06 PM" src="https://github.com/inngest/website/assets/45401242/4816b53a-bc03-44d9-8e65-2880b3ec1cd5">

<img width="1263" alt="Screenshot 2024-03-11 at 7 04 01 PM" src="https://github.com/inngest/website/assets/45401242/da85e2b6-7c85-4448-90eb-0f8ad117156a">
