### PR TITLE
Change minimum Python version to 3.9

### DIFF
--- a/pages/docs/reference/python/overview/quick-start.mdx
+++ b/pages/docs/reference/python/overview/quick-start.mdx
@@ -11,7 +11,7 @@ This guide will teach you how to add Inngest to a FastAPI app and run an Inngest
 ## Create an app
 
 <Callout variant="warning">
-  ⚠️ Use Python 3.10 or higher.
+  ⚠️ Use Python 3.9 or higher.
 </Callout>
 
 Create and source virtual environment:


### PR DESCRIPTION
We support Python 3.9 as of version `0.3.6` of our SDK