### PR TITLE
Use `if` in cancel, and document vars available in expressions

### DIFF
--- a/pages/docs/guides/cancel-running-functions.mdx
+++ b/pages/docs/guides/cancel-running-functions.mdx
@@ -28,7 +28,8 @@ const scheduleReminder = inngest.createFunction(
     id: "schedule-reminder",
     cancelOn: [{
       event: "tasks/reminder.deleted", // The event name that cancels this function
-      if: "async.data.reminderId == event.data.reminderId", // Ensure the incoming async event's reminderId matches the function run reminderId.
+      // Ensure the cancelation event (async) and the triggering event (event)'s reminderId are the same:
+      if: "async.data.reminderId == event.data.reminderId", 
     }],
   }
   { event: "tasks/reminder.created" },
@@ -47,7 +48,7 @@ Let's break down how this works:
 1. Whenever the function is triggered, a cancelation listener is created which waits for an `"tasks/reminder.deleted"` event to be received.
 2. The `if` statement tells Inngest that both the triggering event (`"tasks/reminder.created"`) and the cancelation event (`"tasks/reminder.deleted"`) have the same exact value for `data.reminderId` in each event payload. This makes sure that an event does not cancel a different reminder.
 
-For more information on writing events, read our guide here](/docs/guides/writing-expressions).
+For more information on writing events, read our guide [on writing expressions](/docs/guides/writing-expressions).
 
 Here is an example of these two events which will be matched on the `data.reminderId` field:
 

--- a/pages/docs/guides/cancel-running-functions.mdx
+++ b/pages/docs/guides/cancel-running-functions.mdx
@@ -28,7 +28,7 @@ const scheduleReminder = inngest.createFunction(
     id: "schedule-reminder",
     cancelOn: [{
       event: "tasks/reminder.deleted", // The event name that cancels this function
-      match: "data.reminderId", // The field that must match in both events received
+      if: "async.data.reminderId == event.data.reminderId", // Ensure the incoming async event's reminderId matches the function run reminderId.
     }],
   }
   { event: "tasks/reminder.created" },
@@ -45,7 +45,9 @@ const scheduleReminder = inngest.createFunction(
 Let's break down how this works:
 
 1. Whenever the function is triggered, a cancelation listener is created which waits for an `"tasks/reminder.deleted"` event to be received.
-2. The `match` statement tells Inngest that both the triggering event (`"tasks/reminder.created"`) and the cancelation event (`"tasks/reminder.deleted"`) have the same exact value for `data.reminderId` in each event payload. This makes sure that an event does not cancel a different reminder.
+2. The `if` statement tells Inngest that both the triggering event (`"tasks/reminder.created"`) and the cancelation event (`"tasks/reminder.deleted"`) have the same exact value for `data.reminderId` in each event payload. This makes sure that an event does not cancel a different reminder.
+
+For more information on writing events, read our guide here](/docs/guides/writing-expressions).
 
 Here is an example of these two events which will be matched on the `data.reminderId` field:
 

--- a/pages/docs/guides/writing-expressions.mdx
+++ b/pages/docs/guides/writing-expressions.mdx
@@ -13,7 +13,12 @@ All expressions are defined using the [Common Expression Language (CEL)](https:/
 Within the scope of Inngest, expressions should evaluate to either a boolean or a value:
 
 * **Booleans** - Any expression used for conditional matching should return a boolean value. These are used in wait for event, cancellation, and the function trigger's `if` option.
-* **Values** - Other expressions can return any value which might be used as keys (for example, concurrency, rate limit, debounce or[idempotency keys](/docs/guides/handling-idempotency)) or a dynamic value (for example, run priority).
+* **Values** - Other expressions can return any value which might be used as keys (for example, concurrency, rate limit, debounce or [idempotency keys](/docs/guides/handling-idempotency)) or a dynamic value (for example, run priority).
+
+## Variables
+
+- `event` refers to the event that triggered the function run, in every case.
+- `async` refers to a new event in `step.waitForEvent` and [cancellation](/docs/functions/cancellation).  It's the incoming event which is matched asynchronously.  This is only present when matching new events in a function run.
 
 ## Examples
 


### PR DESCRIPTION
This shows people expressions directly, which is often needed when cancelling events.