### PR TITLE
DEV-53 Improved Nav Bar

### DIFF
--- a/mdx/rehype.mjs
+++ b/mdx/rehype.mjs
@@ -55,7 +55,8 @@ export function rehypeShiki() {
   };
 }
 
-const tagsToAddIds = ["h2", "h3", "h4"];
+const tagsToAddIds = ["h1", "h2", "h3", "h4"];
+const tagsToIncludeInSectionIndex = ["h1", "h2", "h3"];
 function rehypeSlugify() {
   return (tree) => {
     let slugify = slugifyWithCounter();
@@ -101,7 +102,10 @@ function getSections(node) {
   let sections = [];
 
   for (let child of node.children ?? []) {
-    if (child.type === "element" && child.tagName === "h2") {
+    if (
+      child.type === "element" &&
+      tagsToIncludeInSectionIndex.includes(child.tagName)
+    ) {
       sections.push(`{
         title: ${JSON.stringify(toString(child))},
         id: ${JSON.stringify(child.properties.id)},

--- a/pages/docs/getting-started/quick-start/python.mdx
+++ b/pages/docs/getting-started/quick-start/python.mdx
@@ -1,5 +1,9 @@
-{/* This file will soon be deleted as it's a legacy duplicate of pages/docs/getting-started/quick-start/python.mdx */}
-# Quick start
+export const description =
+  `Get started with Inngest in this ten-minute Python tutorial`
+
+{/* This is a duplicate of /docs/reference/python/overview/quick-start.mdx, which will soon be deleted*/}
+
+# Python Quick Start
 
 This guide will teach you how to add Inngest to a FastAPI app and run an Inngest function.
 
@@ -12,7 +16,7 @@ This guide will teach you how to add Inngest to a FastAPI app and run an Inngest
 ## Create an app
 
 <Callout variant="warning">
-  ⚠️ Use Python 3.9 or higher.
+  ⚠️ Use Python 3.10 or higher.
 </Callout>
 
 Create and source virtual environment:

--- a/pages/docs/reference/index.mdx
+++ b/pages/docs/reference/index.mdx
@@ -1,0 +1,49 @@
+import { ResourceGrid, Resource } from 'src/shared/Docs/Resources'
+import TypeScriptIcon from "src/shared/Icons/TypeScript";
+import PythonIcon from "src/shared/Icons/Python";
+import {
+  CommandLineIcon
+} from "@heroicons/react/24/outline";
+import GoIcon from "src/shared/Icons/Go";
+
+
+export const hidePageSidebar = true;
+
+# Reference
+
+Learn about our SDKs:
+
+<ResourceGrid cols={3}>
+
+<Resource resource={{
+  href: "/docs/reference/typescript",
+  name: "TypeScript SDK",
+  icon: TypeScriptIcon,
+  description: "",
+  pattern: 0,
+}}/>
+
+<Resource resource={{
+  href: "/docs/reference/python",
+  name: "Python SDK",
+  icon: PythonIcon,
+  description: "",
+  pattern: 1,
+}}/>
+
+<Resource resource={{
+  href: "https://pkg.go.dev/github.com/inngest/inngestgo",
+  name: "Go SDK",
+  icon: GoIcon,
+  description: "",
+  pattern: 1,
+}}/>
+
+<Resource resource={{
+  href: "https://api-docs.inngest.com/docs/inngest-api/1j9i5603g5768-introduction",
+  name: "REST API",
+  icon: CommandLineIcon,
+  description: "",
+  pattern: 1,
+}}/>
+</ResourceGrid>

--- a/shared/Docs/Header.tsx
+++ b/shared/Docs/Header.tsx
@@ -14,13 +14,24 @@ import { useMobileNavigationStore } from "./MobileNavigation";
 import { ModeToggle } from "./ModeToggle";
 import { MobileSearch, Search } from "./Search";
 import SocialBadges from "./SocialBadges";
+import { menuTabs } from "./navigationStructure";
+import { useRouter } from "next/router";
 
-function TopLevelNavItem({ href, children }) {
+function TabItem({ href, children, matcher }) {
+  const router = useRouter();
+  const pathname = router.pathname;
+  const isActive = matcher.test(pathname);
   return (
     <li>
       <a
         href={href}
-        className="text-sm leading-5 text-slate-600 transition hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+        className={clsx(
+          "text-sm leading-5 transition whitespace-nowrap p-4 relative top-[3px]",
+          isActive &&
+            "font-medium text-indigo-700 dark:text-white border-b dark:border-b-white border-b-indigo-700  hover:text-indigo-900",
+          !isActive &&
+            "text-slate-600  dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
+        )}
       >
         {children}
       </a>
@@ -59,6 +70,15 @@ export const Header = forwardRef<HTMLDivElement>(function Header(
         } as any
       }
     >
+      <nav className="hidden lg:block mr-4">
+        <ul role="list" className="flex items-center">
+          {menuTabs.map((tab) => (
+            <TabItem key={tab.title} href={tab.href} matcher={tab.matcher}>
+              {tab.title}
+            </TabItem>
+          ))}
+        </ul>
+      </nav>
       <div
         className={clsx(
           "absolute inset-x-0 top-full h-px transition",

--- a/shared/Docs/Header.tsx
+++ b/shared/Docs/Header.tsx
@@ -26,16 +26,33 @@ function TabItem({ href, children, matcher }) {
       <a
         href={href}
         className={clsx(
-          "text-sm leading-5 transition whitespace-nowrap p-4 relative top-[3px]",
+          "text-sm leading-5 transition whitespace-nowrap px-3 py-4 relative top-[3px]",
           isActive &&
             "font-medium text-indigo-700 dark:text-white border-b dark:border-b-white border-b-indigo-700  hover:text-indigo-900",
           !isActive &&
             "text-slate-600  dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
         )}
       >
-        {children}
+        <span className="relative -top-[2px]">{children}</span>
       </a>
     </li>
+  );
+}
+
+function Separator() {
+  return (
+    <div className="hidden lg:block md:h-5 md:w-px md:bg-slate-900/10 md:dark:bg-white/15" />
+  );
+}
+
+function DocsLogo() {
+  return (
+    <a href="/docs" className="flex gap-1.5 group/logo items-center pt-1">
+      <Logo className="w-20 text-indigo-500 dark:text-white" />
+      <span className="mb-0.5 text-slate-700 dark:text-indigo-400 text-base group-hover/logo:text-slate-500 dark:group-hover/logo:text-white transition-color font-semibold">
+        Docs
+      </span>
+    </a>
   );
 }
 
@@ -56,9 +73,8 @@ export const Header = forwardRef<HTMLDivElement>(function Header(
       className={clsx(
         className,
         // NOTE - if we remove the AI button we may have to add "lg:justify-end"
-        "fixed inset-x-0 top-0 z-50 flex h-14 items-center justify-between gap-12 px-4 transition sm:px-6 lg:z-30 lg:px-8",
-        !isInsideMobileNavigation &&
-          "backdrop-blur-sm dark:backdrop-blur lg:left-72 xl:left-80",
+        "fixed inset-x-0 top-0 z-50 flex h-14 items-center justify-between gap-12 px-4 transition lg:z-30",
+        !isInsideMobileNavigation && "backdrop-blur-sm dark:backdrop-blur",
         isInsideMobileNavigation
           ? "bg-white dark:bg-slate-900"
           : "bg-white/[var(--bg-opacity-light)] dark:bg-slate-950/[var(--bg-opacity-dark)]"
@@ -70,56 +86,62 @@ export const Header = forwardRef<HTMLDivElement>(function Header(
         } as any
       }
     >
-      <nav className="hidden lg:block mr-4">
-        <ul role="list" className="flex items-center">
-          {menuTabs.map((tab) => (
-            <TabItem key={tab.title} href={tab.href} matcher={tab.matcher}>
-              {tab.title}
-            </TabItem>
-          ))}
-        </ul>
-      </nav>
-      <div
-        className={clsx(
-          "absolute inset-x-0 top-full h-px transition",
-          (isInsideMobileNavigation || !mobileNavIsOpen) &&
-            "bg-slate-900/7.5 dark:bg-white/7.5"
-        )}
-      />
-      <Search />
-      <div className="flex items-center gap-5 lg:hidden">
-        <MobileNavigation />
-        <a href="/docs" className="flex gap-1.5 group/logo items-center pt-1">
-          <Logo className="w-20 text-indigo-500 dark:text-white" />
-          <span className="text-slate-700 dark:text-indigo-400 text-base group-hover/logo:text-white transition-color font-semibold">
-            Docs
-          </span>
-        </a>
+      <div className="flex items-center">
+        <div className="flex items-center gap-5 lg:hidden">
+          <MobileNavigation />
+          <DocsLogo />
+        </div>
+
+        <div className="hidden lg:flex items-center space-x-4 ml-2">
+          <DocsLogo />
+          <Separator />
+        </div>
+
+        <nav className="hidden lg:block ml-4">
+          <ul role="list" className="flex items-center">
+            {menuTabs.map((tab) => (
+              <TabItem key={tab.title} href={tab.href} matcher={tab.matcher}>
+                {tab.title}
+              </TabItem>
+            ))}
+          </ul>
+        </nav>
       </div>
-      <div className="flex items-center gap-5">
-        <div className="hidden lg:block mr-3">
-          <SocialBadges />
-        </div>
-        <div className="hidden sm:flex items-center gap-3">
-          <Button
-            href={process.env.NEXT_PUBLIC_SIGNIN_URL}
-            size="sm"
-            variant="secondary"
-          >
-            Sign In
-          </Button>
-          <Button
-            href={`${process.env.NEXT_PUBLIC_SIGNUP_URL}?ref=docs-header`}
-            size="sm"
-            arrow="right"
-          >
-            Sign Up
-          </Button>
-        </div>
-        <div className="hidden lg:block md:h-5 md:w-px md:bg-slate-900/10 md:dark:bg-white/15" />
-        <div className="flex gap-4">
-          <MobileSearch />
-          <ModeToggle />
+      <div className="flex items-center justify-end flex-auto space-x-4">
+        <div
+          className={clsx(
+            "absolute inset-x-0 top-full h-px transition",
+            (isInsideMobileNavigation || !mobileNavIsOpen) &&
+              "bg-slate-900/7.5 dark:bg-white/7.5"
+          )}
+        />
+        <Search />
+
+        <div className="flex items-center gap-4">
+          {/* <div className="hidden lg:block mr-3">
+            <SocialBadges />
+          </div> */}
+          <div className="hidden sm:flex items-center gap-4">
+            {/* <Button
+              href={process.env.NEXT_PUBLIC_SIGNIN_URL}
+              size="sm"
+              variant="secondary"
+            >
+              Sign In
+            </Button> */}
+            <Button
+              href={`${process.env.NEXT_PUBLIC_SIGNUP_URL}?ref=docs-header`}
+              size="sm"
+              arrow="right"
+            >
+              Sign Up
+            </Button>
+          </div>
+          <Separator />
+          <div className="flex gap-2">
+            {/* <MobileSearch /> */}
+            <ModeToggle />
+          </div>
         </div>
       </div>
     </motion.div>

--- a/shared/Docs/Header.tsx
+++ b/shared/Docs/Header.tsx
@@ -1,5 +1,4 @@
 import { forwardRef } from "react";
-import Link from "next/link";
 import clsx from "clsx";
 import { motion, useScroll, useTransform } from "framer-motion";
 
@@ -12,32 +11,9 @@ import {
 } from "./MobileNavigation";
 import { useMobileNavigationStore } from "./MobileNavigation";
 import { ModeToggle } from "./ModeToggle";
-import { MobileSearch, Search } from "./Search";
-import SocialBadges from "./SocialBadges";
+import { HeaderSearchIcon, Search } from "./Search";
 import { menuTabs } from "./navigationStructure";
-import { useRouter } from "next/router";
-
-function TabItem({ href, children, matcher }) {
-  const router = useRouter();
-  const pathname = router.pathname;
-  const isActive = matcher.test(pathname);
-  return (
-    <li>
-      <a
-        href={href}
-        className={clsx(
-          "text-sm leading-5 transition whitespace-nowrap px-3 py-4 relative top-[3px]",
-          isActive &&
-            "font-medium text-indigo-700 dark:text-white border-b dark:border-b-white border-b-indigo-700  hover:text-indigo-900",
-          !isActive &&
-            "text-slate-600  dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
-        )}
-      >
-        <span className="relative -top-[2px]">{children}</span>
-      </a>
-    </li>
-  );
-}
+import { TabItem } from "./Navigation";
 
 function Separator() {
   return (
@@ -115,20 +91,11 @@ export const Header = forwardRef<HTMLDivElement>(function Header(
               "bg-slate-900/7.5 dark:bg-white/7.5"
           )}
         />
-        <Search />
+
+        {!isInsideMobileNavigation && <Search />}
 
         <div className="flex items-center gap-4">
-          {/* <div className="hidden lg:block mr-3">
-            <SocialBadges />
-          </div> */}
           <div className="hidden sm:flex items-center gap-4">
-            {/* <Button
-              href={process.env.NEXT_PUBLIC_SIGNIN_URL}
-              size="sm"
-              variant="secondary"
-            >
-              Sign In
-            </Button> */}
             <Button
               href={`${process.env.NEXT_PUBLIC_SIGNUP_URL}?ref=docs-header`}
               size="sm"
@@ -139,7 +106,7 @@ export const Header = forwardRef<HTMLDivElement>(function Header(
           </div>
           <Separator />
           <div className="flex gap-2">
-            {/* <MobileSearch /> */}
+            <HeaderSearchIcon />
             <ModeToggle />
           </div>
         </div>

--- a/shared/Docs/Heading.tsx
+++ b/shared/Docs/Heading.tsx
@@ -84,7 +84,7 @@ export function Heading({
   });
 
   useEffect(() => {
-    if (level === 2) {
+    if (level <= 3) {
       registerHeading({ id, ref, offsetRem: tag || label ? 8 : 6 });
     }
   });

--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -89,7 +89,7 @@ export function Layout({
               layoutScroll
               className="fixed inset-y-0 mt-14 left-0 z-40 contents w-72 overflow-y-auto border-r border-slate-900/10 px-6 pt-4 pb-8 dark:border-white/10 lg:block xl:w-80"
             >
-              <Navigation className="hidden lg:mt-6 lg:block" />
+              <Navigation className="hidden lg:block" />
             </motion.header>
 
             {hidePageSidebar ? null : (
@@ -104,7 +104,7 @@ export function Layout({
             )}
 
             <div className="relative px-4 pt-14 sm:px-6 lg:px-8 xl:pl-8 xl:pr-16 xl:mr-32 2xl:mr-10">
-              <main className="pt-16 xl:pr-16">
+              <main className="pt-6 lg:pt-8 xl:pr-8">
                 <Prose as="article">
                   {children}
                   <div

--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -82,23 +82,13 @@ export function Layout({
           <script dangerouslySetInnerHTML={{ __html: modeScript }} />
         </Head>
         <SectionProvider sections={sections}>
+          <Header />
+
           <div className="lg:ml-72 xl:ml-80">
             <motion.header
               layoutScroll
-              className="fixed inset-y-0 left-0 z-40 contents w-72 overflow-y-auto border-r border-slate-900/10 px-6 pt-4 pb-8 dark:border-white/10 lg:block xl:w-80"
+              className="fixed inset-y-0 mt-14 left-0 z-40 contents w-72 overflow-y-auto border-r border-slate-900/10 px-6 pt-4 pb-8 dark:border-white/10 lg:block xl:w-80"
             >
-              <div className="hidden lg:flex">
-                <a
-                  href="/docs"
-                  className="flex gap-1.5 group/logo items-center"
-                >
-                  <Logo className="w-20 text-indigo-500 dark:text-white" />
-                  <span className="mb-0.5 text-slate-700 dark:text-indigo-400 text-base group-hover/logo:text-slate-500 dark:group-hover/logo:text-white transition-color font-semibold">
-                    Docs
-                  </span>
-                </a>
-              </div>
-              <Header />
               <Navigation className="hidden lg:mt-6 lg:block" />
             </motion.header>
 

--- a/shared/Docs/MobileNavigation.tsx
+++ b/shared/Docs/MobileNavigation.tsx
@@ -84,7 +84,7 @@ export function MobileNavigation() {
       {!isInsideMobileNavigation && (
         <Transition.Root show={isOpen} as={Fragment}>
           <Dialog onClose={close} className="fixed inset-0 z-50 lg:hidden">
-            <Transition.Child
+            {/* <Transition.Child
               as={Fragment}
               enter="duration-300 ease-out"
               enterFrom="opacity-0"
@@ -94,7 +94,7 @@ export function MobileNavigation() {
               leaveTo="opacity-0"
             >
               <div className="fixed inset-0 top-14 bg-slate-400/20 backdrop-blur-sm dark:bg-black/40" />
-            </Transition.Child>
+            </Transition.Child> */}
 
             <Dialog.Panel>
               <Transition.Child
@@ -120,7 +120,7 @@ export function MobileNavigation() {
               >
                 <motion.div
                   layoutScroll
-                  className="fixed left-0 top-14 bottom-0 w-full overflow-y-auto bg-white px-4 pt-6 pb-4 shadow-lg shadow-slate-900/10 ring-1 ring-slate-900/7.5 dark:bg-slate-900 dark:ring-slate-800 min-[416px]:max-w-sm sm:px-6 sm:pb-10"
+                  className="fixed left-0 top-14 bottom-0 w-full overflow-y-auto bg-white px-4 pt-6 pb-4 shadow-lg shadow-slate-900/10 ring-1 ring-slate-900/7.5 dark:bg-slate-900 dark:ring-slate-800 sm:px-6 sm:pb-10"
                 >
                   <Navigation />
                 </motion.div>

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -48,7 +48,7 @@ export function TabItem({ href, children, matcher }) {
   const isActive = matcher.test(pathname);
   return (
     <li>
-      <a
+      <Link
         href={href}
         className={clsx(
           "text-sm leading-5 transition whitespace-nowrap px-3 py-4 relative top-0.5",
@@ -59,7 +59,7 @@ export function TabItem({ href, children, matcher }) {
         )}
       >
         <span className="relative -top-0.5">{children}</span>
-      </a>
+      </Link>
     </li>
   );
 }

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import clsx from "clsx";
@@ -51,9 +51,9 @@ export function TabItem({ href, children, matcher }) {
       <Link
         href={href}
         className={clsx(
-          "text-sm leading-5 transition whitespace-nowrap px-3 py-4 relative top-0.5",
+          "font-medium text-sm leading-5 transition whitespace-nowrap px-3 py-4 relative top-0.5",
           isActive &&
-            "font-medium text-indigo-700 dark:text-white border-b dark:border-b-white border-b-indigo-700  hover:text-indigo-900",
+            "text-indigo-700 dark:text-white border-b dark:border-b-white border-b-indigo-700  hover:text-indigo-900",
           !isActive &&
             "text-slate-600  dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
         )}
@@ -93,7 +93,7 @@ function NavLink({
       target={target}
       className={clsx(
         "flex justify-between items-center gap-2 py-1 pr-3 text-sm font-medium transition group", // group for nested hovers
-        isTopLevel ? "pl-0" : isAnchorLink ? "pl-3" : "pl-4",
+        isTopLevel || isAnchorLink ? "pl-0" : "pl-4",
         active
           ? "text-slate-900 dark:text-white"
           : "text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white",
@@ -119,29 +119,25 @@ const LinkOrHref = (props: any) => {
   return <Link {...props} />;
 };
 
-function VisibleSectionHighlight({ group, pathname }) {
-  let [sections, visibleSections] = useInitialValue(
-    [
-      useSectionStore((s) => s.sections),
-      useSectionStore((s) => s.visibleSections),
-    ],
-    useIsInsideMobileNavigation()
-  );
+function VisibleSectionHighlight({ listItems }) {
+  const sections = useSectionStore((s) => s.sections);
+  const visibleSections = useSectionStore((s) => s.visibleSections);
 
-  let isPresent = useIsPresent();
   let firstVisibleSectionIndex = Math.max(
     0,
-    [{ id: "_top" }, ...sections].findIndex(
-      (section) => section.id === visibleSections[0]
-    )
+    sections.findIndex((section) => section.id === visibleSections[0])
   );
-  let itemHeight = remToPx(1.76);
-  let height = isPresent
-    ? Math.max(1, visibleSections.length) * itemHeight
-    : itemHeight;
-  let top =
-    findPathIndex(group.links, pathname) * itemHeight +
-    firstVisibleSectionIndex * itemHeight;
+
+  let aboveItems = listItems?.slice(0, firstVisibleSectionIndex);
+  let visibleItems = listItems?.slice(
+    firstVisibleSectionIndex,
+    firstVisibleSectionIndex + visibleSections.length
+  );
+
+  let top = 0;
+  let height = 0;
+  for (const item of aboveItems) top += item.offsetHeight;
+  for (const item of visibleItems) height += item.offsetHeight;
 
   return (
     <motion.div
@@ -149,7 +145,7 @@ function VisibleSectionHighlight({ group, pathname }) {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1, transition: { delay: 0.2 } }}
       exit={{ opacity: 0 }}
-      className="absolute inset-x-0 top-0 bg-slate-800/2.5 will-change-transform dark:bg-white/2.5"
+      className="absolute -left-2 right-0 top-0 bg-slate-800/10 will-change-transform dark:bg-white/10"
       style={{ borderRadius: 8, height, top }}
     />
   );
@@ -175,43 +171,72 @@ function ActivePageMarker({ group, pathname }) {
 
 export function PageSidebar() {
   let isInsideMobileNavigation = useIsInsideMobileNavigation();
-  let [router, sections] = useInitialValue(
-    [useRouter(), useSectionStore((s) => s.sections)],
-    isInsideMobileNavigation
-  );
+  let router = useRouter();
+  let sections = useSectionStore((s) => s.sections);
+
+  let [pageSectionsEl, setPageSectionsEl] = useState(null);
+  let [pageSectionListItems, setPageSectionListItems] = useState(null);
+  let [windowWidth, setWindowWidth] = useState(null);
+
+  useEffect(() => {
+    const updateWindowWidth = () => setWindowWidth(window.innerWidth);
+    window.addEventListener("resize", updateWindowWidth);
+    return () => {
+      window.removeEventListener("resize", updateWindowWidth);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (pageSectionsEl) {
+      setPageSectionListItems([
+        ...(pageSectionsEl?.querySelectorAll("li") ?? []),
+      ]);
+    }
+  }, [router.pathname, windowWidth, pageSectionsEl]);
 
   return (
     <div>
       <h4 className="text-base font-medium pb-2">On this page</h4>
-      {/* TODO: Add highlighted page section back */}
-      {/* <AnimatePresence initial={!isInsideMobileNavigation}>
-        <VisibleSectionHighlight group={group} pathname={router.pathname} />
-      </AnimatePresence> */}
-      <motion.ul
-        role="list"
-        initial={{ opacity: 0 }}
-        animate={{
-          opacity: 1,
-          transition: { delay: 0.1 },
-        }}
-        exit={{
-          opacity: 0,
-          transition: { duration: 0.15 },
-        }}
-      >
-        {sections.map((section) => (
-          <li key={section.id}>
-            <NavLink
-              href={`#${section.id}`}
-              tag={section.tag}
-              isAnchorLink
-              truncate={false}
+      <div className="relative">
+        <AnimatePresence initial={!isInsideMobileNavigation}>
+          {pageSectionListItems && (
+            <VisibleSectionHighlight listItems={pageSectionListItems} />
+          )}
+        </AnimatePresence>
+        <motion.ul
+          key={router.pathname}
+          ref={setPageSectionsEl}
+          role="list"
+          initial={{ opacity: 0 }}
+          animate={{
+            opacity: 1,
+            transition: { delay: 0.1 },
+          }}
+          exit={{
+            opacity: 0,
+            transition: { duration: 0.15 },
+          }}
+        >
+          {sections.map((section) => (
+            <li
+              key={section.id}
+              className="relative"
+              style={{
+                marginLeft: `${(section.level - 1) * 12}px`,
+              }}
             >
-              {section.title}
-            </NavLink>
-          </li>
-        ))}
-      </motion.ul>
+              <NavLink
+                href={`#${section.id}`}
+                tag={section.tag}
+                isAnchorLink
+                truncate={false}
+              >
+                {section.title}
+              </NavLink>
+            </li>
+          ))}
+        </motion.ul>
+      </div>
     </div>
   );
 }
@@ -232,6 +257,13 @@ function NavigationGroup({
   // The state will still update when we re-open (re-render) the navigation.
   let isInsideMobileNavigation = useIsInsideMobileNavigation();
   let [router] = useInitialValue([useRouter()], isInsideMobileNavigation);
+
+  // hack: animation flickers on initial render so let's enable it after mount
+  let [animateAccordion, setAnimateAccordion] = useState(false);
+  useEffect(() => {
+    setAnimateAccordion(true);
+  }, []);
+
   return (
     <Accordion.Item value={group.title}>
       <li
@@ -257,7 +289,9 @@ function NavigationGroup({
           </h2>
         </Accordion.Trigger>
 
-        <Accordion.Content className="animate-accordion">
+        <Accordion.Content
+          className={animateAccordion ? "animate-accordion" : ""}
+        >
           <div
             className={clsx(
               "relative overflow-hidden",
@@ -409,6 +443,10 @@ export function Navigation(props) {
         {nestedNavigation ? (
           <>
             <Accordion.Root
+              key={
+                // re-mount on page navigation
+                router.pathname
+              }
               type="multiple"
               defaultValue={defaultOpenGroupTitles}
             >
@@ -421,36 +459,7 @@ export function Navigation(props) {
               ))}
             </Accordion.Root>
           </>
-        ) : (
-          topLevelNav.map((item, idx) =>
-            item.href ? null : (
-              <li className="mt-6" key={idx}>
-                <h2 className="text-xs font-semibold text-slate-900 dark:text-white uppercase">
-                  {item.title}
-                </h2>
-                <ul role="list" className="mt-3 flex flex-col gap-2">
-                  {item.links.map((link, idx) => (
-                    <li key={idx}>
-                      <NavLink
-                        href={link.href}
-                        isTopLevel={true}
-                        tag={link.tag}
-                        target={link.target}
-                      >
-                        <span className="flex flex-row gap-3 items-center">
-                          {link.icon && (
-                            <link.icon className="w-5 h-4 text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-200" />
-                          )}
-                          {link.title}
-                        </span>
-                      </NavLink>
-                    </li>
-                  ))}
-                </ul>
-              </li>
-            )
-          )
-        )}
+        ) : null}
 
         <li className="sticky bottom-0 z-10 mt-6 sm:hidden gap-2 flex dark:bg-slate-900">
           <Button

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -9,7 +9,7 @@ import { useIsInsideMobileNavigation } from "./MobileNavigation";
 import { useSectionStore } from "./SectionProvider";
 import { Tag } from "./Tag";
 import { remToPx } from "../../utils/remToPx";
-import { topLevelNav, type NavGroup } from "./navigationStructure";
+import { topLevelNav, menuTabs, type NavGroup } from "./navigationStructure";
 import * as Accordion from "@radix-ui/react-accordion";
 import { ChevronDownIcon } from "@heroicons/react/24/outline";
 

--- a/shared/Docs/Search.tsx
+++ b/shared/Docs/Search.tsx
@@ -526,7 +526,7 @@ export function Search() {
   }, []);
 
   return (
-    <div className="hidden lg:block lg:max-w-md lg:flex-auto">
+    <div className="hidden lg:block lg:max-w-min lg:flex-auto">
       <button
         type="button"
         className="hidden h-8 w-full items-center gap-2 rounded-full bg-white pl-2 pr-3 text-sm text-slate-500 ring-1 ring-slate-900/10 transition hover:ring-slate-900/20 dark:bg-white/5 dark:text-slate-400 dark:ring-inset dark:ring-white/10 dark:hover:ring-white/20 lg:flex focus:outline-none"

--- a/shared/Docs/Search.tsx
+++ b/shared/Docs/Search.tsx
@@ -526,7 +526,7 @@ export function Search() {
   }, []);
 
   return (
-    <div className="hidden lg:block lg:max-w-min lg:flex-auto">
+    <div className="hidden lg:block lg:max-w-sm lg:flex-auto">
       <button
         type="button"
         className="hidden h-8 w-full items-center gap-2 rounded-full bg-white pl-2 pr-3 text-sm text-slate-500 ring-1 ring-slate-900/10 transition hover:ring-slate-900/20 dark:bg-white/5 dark:text-slate-400 dark:ring-inset dark:ring-white/10 dark:hover:ring-white/20 lg:flex focus:outline-none"

--- a/shared/Docs/Search.tsx
+++ b/shared/Docs/Search.tsx
@@ -536,18 +536,18 @@ function SearchButton({ shortcutKey = null, ...buttonProps }) {
 
 /* Search input button in desktop mode */
 export function Search() {
-  let [modifierKey, setModifierKey] = useState<string>();
+  let [shortcutKey, setShortcutKey] = useState<string>();
   let { buttonProps, dialogProps } = useSearchProps();
 
   useEffect(() => {
-    setModifierKey(
-      /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? "⌘" : "Ctrl "
+    setShortcutKey(
+      /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? "⌘K" : "Ctrl+K"
     );
   }, []);
 
   return (
     <div className="hidden lg:block lg:max-w-sm lg:flex-auto">
-      <SearchButton {...buttonProps} shortcutKey={`${modifierKey}K`} />
+      <SearchButton {...buttonProps} shortcutKey={shortcutKey} />
       <SearchDialog className="hidden lg:block" {...dialogProps} />
     </div>
   );

--- a/shared/Docs/Search.tsx
+++ b/shared/Docs/Search.tsx
@@ -506,8 +506,9 @@ function useSearchProps(): SearchProps {
     dialogProps: {
       open,
       setOpen(open) {
-        let { width, height } = buttonRef.current.getBoundingClientRect();
-        if (!open || (width !== 0 && height !== 0)) {
+        let { width, height } =
+          buttonRef.current?.getBoundingClientRect() ?? {};
+        if (!open || (width && height)) {
           setOpen(open);
         }
       },
@@ -515,6 +516,25 @@ function useSearchProps(): SearchProps {
   };
 }
 
+function SearchButton({ shortcutKey = null, ...buttonProps }) {
+  return (
+    <button
+      type="button"
+      className="flex h-8 w-full items-center gap-2 rounded-full bg-white pl-2 pr-3 text-sm text-slate-500 ring-1 ring-slate-900/10 transition hover:ring-slate-900/20 dark:bg-white/5 dark:text-slate-400 dark:ring-inset dark:ring-white/10 dark:hover:ring-white/20 focus:outline-none"
+      {...buttonProps}
+    >
+      <SearchIcon className="h-5 w-5 stroke-current" />
+      Search...
+      {shortcutKey ? (
+        <kbd className="ml-auto text-xs font-sans text-slate-500 dark:text-slate-400">
+          {shortcutKey}
+        </kbd>
+      ) : null}
+    </button>
+  );
+}
+
+/* Search input button in desktop mode */
 export function Search() {
   let [modifierKey, setModifierKey] = useState<string>();
   let { buttonProps, dialogProps } = useSearchProps();
@@ -527,23 +547,25 @@ export function Search() {
 
   return (
     <div className="hidden lg:block lg:max-w-sm lg:flex-auto">
-      <button
-        type="button"
-        className="hidden h-8 w-full items-center gap-2 rounded-full bg-white pl-2 pr-3 text-sm text-slate-500 ring-1 ring-slate-900/10 transition hover:ring-slate-900/20 dark:bg-white/5 dark:text-slate-400 dark:ring-inset dark:ring-white/10 dark:hover:ring-white/20 lg:flex focus:outline-none"
-        {...buttonProps}
-      >
-        <SearchIcon className="h-5 w-5 stroke-current" />
-        Search...
-        <kbd className="ml-auto text-xs font-sans text-slate-500 dark:text-slate-400">
-          {modifierKey}K
-        </kbd>
-      </button>
+      <SearchButton {...buttonProps} shortcutKey={`${modifierKey}K`} />
       <SearchDialog className="hidden lg:block" {...dialogProps} />
     </div>
   );
 }
 
+/* Search input button in mobile sidebar */
 export function MobileSearch() {
+  let { buttonProps, dialogProps } = useSearchProps();
+  return (
+    <div className="block lg:hidden flex-auto mb-4">
+      <SearchButton {...buttonProps} />
+      <SearchDialog className="block" {...dialogProps} />
+    </div>
+  );
+}
+
+/* Search icon */
+export function HeaderSearchIcon() {
   let { buttonProps, dialogProps } = useSearchProps();
 
   return (

--- a/shared/Docs/SectionProvider.jsx
+++ b/shared/Docs/SectionProvider.jsx
@@ -9,6 +9,8 @@ import { createStore, useStore } from "zustand";
 
 import { remToPx } from "../../utils/remToPx";
 
+const PAGE_HEADER_OFFSET_REM = 4;
+
 // type Section = { id: string; headingRef: any; offsetRem: string };
 // type State = {
 //   sections?: Section[];
@@ -35,6 +37,7 @@ function createSectionStore(sections) {
               return {
                 ...section,
                 headingRef: ref,
+                level: +(ref.current?.tagName.replace('H', '') ?? 0),
                 offsetRem,
               };
             }
@@ -59,20 +62,15 @@ function useVisibleSections(sectionStore) {
         sectionIndex < sections.length;
         sectionIndex++
       ) {
-        let { id, headingRef, offsetRem } = sections[sectionIndex];
-        let offset = remToPx(offsetRem);
+        let { id, headingRef } = sections[sectionIndex];
         let top = headingRef?.current.getBoundingClientRect().top + scrollY;
-
-        if (sectionIndex === 0 && top - offset > scrollY) {
-          newVisibleSections.push("_top");
-        }
 
         let nextSection = sections[sectionIndex + 1];
         let bottom =
           (nextSection?.headingRef?.current.getBoundingClientRect().top ??
             Infinity) +
           scrollY -
-          remToPx(nextSection?.offsetRem ?? 0);
+          remToPx(nextSection?.offsetRem ?? 0) - PAGE_HEADER_OFFSET_REM;
 
         if (
           (top > scrollY && top < scrollY + innerHeight) ||

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -485,6 +485,33 @@ const sectionPythonReference: NavGroup[] = [
   },
 ];
 
+export const menuTabs = [
+  {
+    title: "Getting started",
+    icon: PlayIcon,
+    href: "/docs/quick-start",
+    matcher: /\/quick-start/,
+  },
+  {
+    title: "Guides",
+    icon: GuideIcon,
+    href: "/docs/guides",
+    matcher: /\/guides/,
+  },
+  {
+    title: "Reference",
+    icon: CogIcon,
+    href: "/docs/reference",
+    matcher: /\/reference/,
+  },
+  {
+    title: "Examples",
+    icon: CogIcon,
+    href: "/docs/examples",
+    matcher: /\/examples/,
+  },
+];
+
 export const topLevelNav = [
   {
     title: "Home",

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -73,6 +73,19 @@ const sectionGuides: NavGroup[] = [
     title: "Patterns",
     defaultOpen: true,
     links: [
+      { title: "Installing the SDK", href: `/docs/sdk/overview` },
+      { title: "Serving the API & Frameworks", href: `/docs/sdk/serve` },
+      { title: "Writing Functions", href: `/docs/functions` },
+      { title: "Sending Events", href: `/docs/events` },
+      {
+        title: "Multi-step Functions",
+        href: `/docs/functions/multi-step`,
+      },
+      { title: "Inngest Apps", href: `/docs/apps` },
+      {
+        title: "Local Development",
+        href: `/docs/local-development`,
+      },
       {
         title: "Background jobs",
         href: `/docs/guides/background-jobs`,
@@ -158,6 +171,62 @@ const sectionGuides: NavGroup[] = [
       {
         title: "Instrumenting GraphQL",
         href: `/docs/guides/instrumenting-graphql`,
+      },
+    ],
+  },
+  {
+    title: "Going to production",
+    defaultOpen: true,
+    links: [
+      {
+        title: "Working with apps",
+        href: `/docs/apps/cloud`,
+      },
+      {
+        title: "Deployment targets",
+        defaultOpen: true,
+        links: [
+          { title: "Deploy: Vercel", href: `/docs/deploy/vercel` },
+          { title: "Deploy: Netlify", href: `/docs/deploy/netlify` },
+          {
+            title: "Deploy: Cloudflare Pages",
+            href: `/docs/deploy/cloudflare`,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Inngest Cloud",
+    links: [
+      {
+        title: "Working with environments",
+        href: `/docs/platform/environments`,
+      },
+      {
+        title: "Creating an event key",
+        href: `/docs/events/creating-an-event-key`,
+      },
+      {
+        title: "Consuming webhook events",
+        href: `/docs/platform/webhooks`,
+      },
+      {
+        title: "Replaying functions",
+        href: `/docs/platform/replay`,
+      },
+    ],
+  },
+  {
+    title: "Usage Limits",
+    links: [
+      {
+        title: "Inngest Cloud",
+        href: `/docs/usage-limits/inngest`,
+      },
+      {
+        title: "Serverless providers",
+        href: `/docs/usage-limits/providers`,
       },
     ],
   },

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -51,6 +51,7 @@ const sectionGettingStarted: NavGroup[] = [
   },
   {
     title: "Learn the basics",
+    defaultOpen: true,
     links: [
       { title: "Installing the SDK", href: `/docs/sdk/overview` },
       { title: "Serving the API & Frameworks", href: `/docs/sdk/serve` },
@@ -73,19 +74,6 @@ const sectionGuides: NavGroup[] = [
     title: "Patterns",
     defaultOpen: true,
     links: [
-      { title: "Installing the SDK", href: `/docs/sdk/overview` },
-      { title: "Serving the API & Frameworks", href: `/docs/sdk/serve` },
-      { title: "Writing Functions", href: `/docs/functions` },
-      { title: "Sending Events", href: `/docs/events` },
-      {
-        title: "Multi-step Functions",
-        href: `/docs/functions/multi-step`,
-      },
-      { title: "Inngest Apps", href: `/docs/apps` },
-      {
-        title: "Local Development",
-        href: `/docs/local-development`,
-      },
       {
         title: "Background jobs",
         href: `/docs/guides/background-jobs`,
@@ -122,6 +110,7 @@ const sectionGuides: NavGroup[] = [
   },
   {
     title: "How to",
+    defaultOpen: true,
     links: [
       {
         title: "Error handling",
@@ -151,6 +140,7 @@ const sectionGuides: NavGroup[] = [
   },
   {
     title: "Use cases",
+    defaultOpen: true,
     links: [
       {
         title: "User-defined Workflows",
@@ -183,7 +173,7 @@ const sectionGuides: NavGroup[] = [
         href: `/docs/apps/cloud`,
       },
       {
-        title: "Deployment targets",
+        title: "Platform",
         defaultOpen: true,
         links: [
           { title: "Deploy: Vercel", href: `/docs/deploy/vercel` },
@@ -198,6 +188,7 @@ const sectionGuides: NavGroup[] = [
   },
   {
     title: "Inngest Cloud",
+    defaultOpen: true,
     links: [
       {
         title: "Working with environments",
@@ -219,6 +210,7 @@ const sectionGuides: NavGroup[] = [
   },
   {
     title: "Usage Limits",
+    defaultOpen: true,
     links: [
       {
         title: "Inngest Cloud",
@@ -242,7 +234,7 @@ const sectionPlatform: NavGroup[] = [
         href: `/docs/apps/cloud`,
       },
       {
-        title: "Deployment targets",
+        title: "Platform",
         defaultOpen: true,
         links: [
           { title: "Deploy: Vercel", href: `/docs/deploy/vercel` },
@@ -554,6 +546,295 @@ const sectionPythonReference: NavGroup[] = [
   },
 ];
 
+const sectionReference: NavGroup[] = [
+  {
+    title: "TypeScript SKD",
+    defaultOpen: true,
+    links: [
+      {
+        title: "Overview",
+        // TODO - Allow this to be flattened w/ NavGroup
+        links: [
+          {
+            title: "Introduction",
+            href: `/docs/reference/typescript`,
+          },
+        ],
+      },
+      {
+        title: "Inngest Client",
+        links: [
+          {
+            title: "Create the client",
+            href: `/docs/reference/client/create`,
+          },
+        ],
+      },
+      {
+        title: "Functions",
+        links: [
+          {
+            title: "Create function",
+            href: `/docs/reference/functions/create`,
+          },
+          {
+            title: "Errors",
+            href: `/docs/reference/typescript/functions/errors`,
+          },
+          {
+            title: "Handling failures",
+            href: `/docs/reference/functions/handling-failures`,
+          },
+          {
+            title: "Cancel running functions",
+            href: `/docs/functions/cancellation`,
+            // href: `/docs/reference/functions/cancel-running-functions`,
+          },
+          {
+            title: "Concurrency",
+            href: `/docs/functions/concurrency`,
+            // href: `/docs/reference/functions/concurrency`,
+          },
+          {
+            title: "Rate limit",
+            href: `/docs/reference/functions/rate-limit`,
+          },
+          {
+            title: "Debounce",
+            href: `/docs/reference/functions/debounce`,
+          },
+          {
+            title: "Function run priority",
+            href: `/docs/reference/functions/run-priority`,
+          },
+          // {
+          //   title: "Logging",
+          //   href: `/docs/reference/functions/logging`,
+          // },
+          {
+            title: "Referencing functions",
+            href: `/docs/functions/references`,
+          },
+        ],
+      },
+      {
+        title: "Steps",
+        links: [
+          {
+            title: "step.run()",
+            href: `/docs/reference/functions/step-run`,
+            className: "font-mono",
+          },
+          {
+            title: "step.sleep()",
+            href: `/docs/reference/functions/step-sleep`,
+            className: "font-mono",
+          },
+          {
+            title: "step.sleepUntil()",
+            href: `/docs/reference/functions/step-sleep-until`,
+            className: "font-mono",
+          },
+          {
+            title: "step.invoke()",
+            href: `/docs/reference/functions/step-invoke`,
+            className: "font-mono",
+          },
+          {
+            title: "step.waitForEvent()",
+            href: `/docs/reference/functions/step-wait-for-event`,
+            className: "font-mono",
+          },
+          {
+            title: "step.sendEvent()",
+            href: `/docs/reference/functions/step-send-event`,
+            className: "font-mono",
+          },
+        ],
+      },
+      {
+        title: "Events",
+        links: [
+          {
+            title: "Send",
+            href: `/docs/reference/events/send`,
+          },
+        ],
+      },
+      {
+        title: "Serve",
+        links: [
+          // {
+          //   title: "Framework handlers",
+          //   href: `/docs/sdk/serve`,
+          // },
+          {
+            title: "Configuration",
+            href: `/docs/reference/serve`,
+          },
+          { title: "Streaming", href: `/docs/streaming` },
+        ],
+      },
+      {
+        title: "Middleware",
+        links: [
+          {
+            title: "Overview",
+            href: `/docs/reference/middleware/overview`,
+          },
+          {
+            title: "Creating middleware",
+            href: `/docs/reference/middleware/create`,
+          },
+          {
+            title: "Lifecycle",
+            href: `/docs/reference/middleware/lifecycle`,
+          },
+          {
+            title: "Examples",
+            href: `/docs/reference/middleware/examples`,
+          },
+          {
+            title: "TypeScript",
+            href: `/docs/reference/middleware/typescript`,
+          },
+        ],
+      },
+      {
+        title: "Using the SDK",
+        links: [
+          {
+            title: "Environment variables",
+            href: `/docs/sdk/environment-variables`,
+          },
+          {
+            title: "Using TypeScript",
+            href: `/docs/typescript`,
+          },
+          {
+            title: "ESLint plugin",
+            href: `/docs/sdk/eslint`,
+          },
+          { title: "Upgrading to v3", href: `/docs/sdk/migration` },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Python SDK",
+    links: [
+      {
+        title: "Overview",
+        // TODO - Allow this to be flattened w/ NavGroup
+        links: [
+          {
+            title: "Introduction",
+            href: `/docs/reference/python`,
+          },
+          {
+            title: "Quick start",
+            href: `/docs/reference/python/overview/quick-start`,
+          },
+          {
+            title: "Environment variables",
+            href: `/docs/reference/python/overview/env-vars`,
+          },
+          {
+            title: "Production mode",
+            href: `/docs/reference/python/overview/prod-mode`,
+          },
+        ],
+      },
+      {
+        title: "Client",
+        links: [
+          {
+            title: "Overview",
+            href: `/docs/reference/python/client/overview`,
+          },
+          {
+            title: "Send events",
+            href: `/docs/reference/python/client/send`,
+          },
+        ],
+      },
+      {
+        title: "Functions",
+        links: [
+          {
+            title: "Create function",
+            href: `/docs/reference/python/functions/create`,
+          },
+        ],
+      },
+      {
+        title: "Steps",
+        links: [
+          {
+            title: "invoke",
+            href: `/docs/reference/python/steps/invoke`,
+          },
+          {
+            title: "invoke_by_id",
+            href: `/docs/reference/python/steps/invoke_by_id`,
+          },
+          {
+            title: "parallel",
+            href: `/docs/reference/python/steps/parallel`,
+          },
+          {
+            title: "run",
+            href: `/docs/reference/python/steps/run`,
+          },
+          {
+            title: "send_event",
+            href: `/docs/reference/python/steps/send-event`,
+          },
+          {
+            title: "sleep",
+            href: `/docs/reference/python/steps/sleep`,
+          },
+          {
+            title: "sleep_until",
+            href: `/docs/reference/python/steps/sleep-until`,
+          },
+          {
+            title: "wait_for_event",
+            href: `/docs/reference/python/steps/wait-for-event`,
+          },
+        ],
+      },
+      {
+        title: "Middleware",
+        links: [
+          {
+            title: "Overview",
+            href: `/docs/reference/python/middleware/overview`,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Go SDK",
+    links: [
+      {
+        title: "Documentation",
+        href: "https://pkg.go.dev/github.com/inngest/inngestgo",
+      },
+    ],
+  },
+  {
+    title: "REST API",
+    links: [
+      {
+        title: "Documentation",
+        href: "https://api-docs.inngest.com/docs/inngest-api/1j9i5603g5768-introduction",
+      },
+    ],
+  },
+];
+
 export const menuTabs = [
   {
     title: "Getting started",
@@ -573,12 +854,13 @@ export const menuTabs = [
     href: "/docs/reference",
     matcher: /\/reference/,
   },
-  {
-    title: "Examples",
-    icon: CogIcon,
-    href: "/docs/examples",
-    matcher: /\/examples/,
-  },
+  // will add this in the future
+  // {
+  //   title: "Examples",
+  //   icon: CogIcon,
+  //   href: "/docs/examples",
+  //   matcher: /\/examples/,
+  // },
 ];
 
 export const topLevelNav = [
@@ -599,6 +881,13 @@ export const topLevelNav = [
     href: "/docs/guides",
     matcher: /\/guides/,
     sectionLinks: sectionGuides,
+  },
+  {
+    title: "Reference",
+    icon: CogIcon,
+    href: "/docs/reference",
+    matcher: /\/reference/,
+    sectionLinks: sectionReference,
   },
   {
     title: "Platform",

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -41,18 +41,13 @@ export type NavSection = NavLink & {
 
 const sectionGettingStarted: NavGroup[] = [
   {
-    title: "Quick start tutorials",
-    links: [
-      {
-        title: "Next.js",
-        href: "/docs/quick-start",
-      },
-    ],
-  },
-  {
     title: "Learn the basics",
     defaultOpen: true,
     links: [
+      {
+        title: "Overview",
+        href: "/docs",
+      },
       { title: "Installing the SDK", href: `/docs/sdk/overview` },
       { title: "Serving the API & Frameworks", href: `/docs/sdk/serve` },
       { title: "Writing Functions", href: `/docs/functions` },
@@ -65,6 +60,20 @@ const sectionGettingStarted: NavGroup[] = [
       {
         title: "Local Development",
         href: `/docs/local-development`,
+      },
+    ],
+  },
+  {
+    title: "Quick start tutorials",
+    defaultOpen: true,
+    links: [
+      {
+        title: "Next.js",
+        href: "/docs/quick-start",
+      },
+      {
+        title: "Python",
+        href: "/docs/getting-started/quick-start/python",
       },
     ],
   },
@@ -548,74 +557,62 @@ const sectionPythonReference: NavGroup[] = [
 
 const sectionReference: NavGroup[] = [
   {
-    title: "TypeScript SKD",
+    title: "TypeScript SDK",
     defaultOpen: true,
     links: [
       {
-        title: "Overview",
-        // TODO - Allow this to be flattened w/ NavGroup
-        links: [
-          {
-            title: "Introduction",
-            href: `/docs/reference/typescript`,
-          },
-        ],
+        title: "Introduction",
+        href: `/docs/reference/typescript`,
       },
       {
-        title: "Inngest Client",
-        links: [
-          {
-            title: "Create the client",
-            href: `/docs/reference/client/create`,
-          },
-        ],
+        title: "Create the client",
+        href: `/docs/reference/client/create`,
       },
       {
-        title: "Functions",
-        links: [
-          {
-            title: "Create function",
-            href: `/docs/reference/functions/create`,
-          },
-          {
-            title: "Errors",
-            href: `/docs/reference/typescript/functions/errors`,
-          },
-          {
-            title: "Handling failures",
-            href: `/docs/reference/functions/handling-failures`,
-          },
-          {
-            title: "Cancel running functions",
-            href: `/docs/functions/cancellation`,
-            // href: `/docs/reference/functions/cancel-running-functions`,
-          },
-          {
-            title: "Concurrency",
-            href: `/docs/functions/concurrency`,
-            // href: `/docs/reference/functions/concurrency`,
-          },
-          {
-            title: "Rate limit",
-            href: `/docs/reference/functions/rate-limit`,
-          },
-          {
-            title: "Debounce",
-            href: `/docs/reference/functions/debounce`,
-          },
-          {
-            title: "Function run priority",
-            href: `/docs/reference/functions/run-priority`,
-          },
-          // {
-          //   title: "Logging",
-          //   href: `/docs/reference/functions/logging`,
-          // },
-          {
-            title: "Referencing functions",
-            href: `/docs/functions/references`,
-          },
-        ],
+        title: "Create a function",
+        href: `/docs/reference/functions/create`,
+      },
+      {
+        title: "Send events",
+        href: `/docs/reference/events/send`,
+      },
+      {
+        title: "Errors",
+        href: `/docs/reference/typescript/functions/errors`,
+      },
+      {
+        title: "Handling failures",
+        href: `/docs/reference/functions/handling-failures`,
+      },
+      {
+        title: "Cancel running functions",
+        href: `/docs/functions/cancellation`,
+        // href: `/docs/reference/functions/cancel-running-functions`,
+      },
+      {
+        title: "Concurrency",
+        href: `/docs/functions/concurrency`,
+        // href: `/docs/reference/functions/concurrency`,
+      },
+      {
+        title: "Rate limit",
+        href: `/docs/reference/functions/rate-limit`,
+      },
+      {
+        title: "Debounce",
+        href: `/docs/reference/functions/debounce`,
+      },
+      {
+        title: "Function run priority",
+        href: `/docs/reference/functions/run-priority`,
+      },
+      // {
+      //   title: "Logging",
+      //   href: `/docs/reference/functions/logging`,
+      // },
+      {
+        title: "Referencing functions",
+        href: `/docs/functions/references`,
       },
       {
         title: "Steps",
@@ -649,15 +646,6 @@ const sectionReference: NavGroup[] = [
             title: "step.sendEvent()",
             href: `/docs/reference/functions/step-send-event`,
             className: "font-mono",
-          },
-        ],
-      },
-      {
-        title: "Events",
-        links: [
-          {
-            title: "Send",
-            href: `/docs/reference/events/send`,
           },
         ],
       },
@@ -724,48 +712,32 @@ const sectionReference: NavGroup[] = [
     title: "Python SDK",
     links: [
       {
-        title: "Overview",
-        // TODO - Allow this to be flattened w/ NavGroup
-        links: [
-          {
-            title: "Introduction",
-            href: `/docs/reference/python`,
-          },
-          {
-            title: "Quick start",
-            href: `/docs/reference/python/overview/quick-start`,
-          },
-          {
-            title: "Environment variables",
-            href: `/docs/reference/python/overview/env-vars`,
-          },
-          {
-            title: "Production mode",
-            href: `/docs/reference/python/overview/prod-mode`,
-          },
-        ],
+        title: "Introduction",
+        href: `/docs/reference/python`,
       },
       {
-        title: "Client",
-        links: [
-          {
-            title: "Overview",
-            href: `/docs/reference/python/client/overview`,
-          },
-          {
-            title: "Send events",
-            href: `/docs/reference/python/client/send`,
-          },
-        ],
+        title: "Quick start",
+        href: `/docs/reference/python/overview/quick-start`,
       },
       {
-        title: "Functions",
-        links: [
-          {
-            title: "Create function",
-            href: `/docs/reference/python/functions/create`,
-          },
-        ],
+        title: "Inngest Client",
+        href: `/docs/reference/python/client/overview`,
+      },
+      {
+        title: "Create function",
+        href: `/docs/reference/python/functions/create`,
+      },
+      {
+        title: "Send events",
+        href: `/docs/reference/python/client/send`,
+      },
+      {
+        title: "Environment variables",
+        href: `/docs/reference/python/overview/env-vars`,
+      },
+      {
+        title: "Production mode",
+        href: `/docs/reference/python/overview/prod-mode`,
       },
       {
         title: "Steps",
@@ -835,26 +807,33 @@ const sectionReference: NavGroup[] = [
   },
 ];
 
+const matchers = {
+  guides: /^\/docs\/guides/,
+  reference: /^\/docs\/reference/,
+  examples: /^\/docs\/examples/,
+  // should match everything except above
+  default: /^\/docs(?!\/guides|\/reference|\/examples)/,
+};
+
 export const menuTabs = [
   {
     title: "Getting started",
     icon: PlayIcon,
     href: "/docs/quick-start",
-    matcher: /\/quick-start/,
+    matcher: matchers.default,
   },
   {
     title: "Guides",
     icon: GuideIcon,
     href: "/docs/guides",
-    matcher: /\/guides/,
+    matcher: matchers.guides,
   },
   {
     title: "Reference",
     icon: CogIcon,
     href: "/docs/reference",
-    matcher: /\/reference/,
+    matcher: matchers.reference,
   },
-  // will add this in the future
   // {
   //   title: "Examples",
   //   icon: CogIcon,
@@ -879,14 +858,14 @@ export const topLevelNav = [
     title: "Guides",
     icon: GuideIcon,
     href: "/docs/guides",
-    matcher: /\/guides/,
+    matcher: matchers.guides,
     sectionLinks: sectionGuides,
   },
   {
     title: "Reference",
     icon: CogIcon,
     href: "/docs/reference",
-    matcher: /\/reference/,
+    matcher: matchers.reference,
     sectionLinks: sectionReference,
   },
   {


### PR DESCRIPTION
## Overview

➡️ [Preview](https://website-git-sylwia-tabs-inngest.vercel.app/docs)

This PR introduces the following changes:
- refurbished Nav Bar (in accordance with the feedback from our designers)
- improved mobile navigation (in accordance with the feedback from our designers)
- tabs in the Nav Bar
- [reference landing page](https://website-git-sylwia-tabs-inngest.vercel.app/docs/reference) (very minimal)
- enabling all the sidebar sections to be opened at the same time (something which will change)
- moving all reference sites to one place

## Code quality

There is a lot of debris because it is an (incremental) work in progress. Please be understanding.

---
## Outdated: RFC

Previously, this PR was an RFC and I'm keeping the contents for posteriority.

<details>
<summary>Content from RFC</summary>
## Request for comments

This is a work-in-progress PR to request comments on how to best approach the cluttered Nav Bar -- both in desktop and mobile version.

## The problem

I have added four "Tabs" to the docs nav bar, which makes it a bit cluttered:

### Light mode
<img width="1470" alt="Screenshot 2024-03-18 at 10 34 57 AM" src="https://github.com/inngest/website/assets/45401242/12651d34-7374-46fa-a0c6-dfcf8eb1a6ed">

### Dark mode
<img width="1470" alt="Screenshot 2024-03-18 at 10 34 54 AM" src="https://github.com/inngest/website/assets/45401242/40f78734-11a5-42b4-83e5-b01918dd2308">

Before I move onto making further decisions or introduce more styling changes (reducing margins,  and so on), I decided to stop to brainstorm best path forward.

## Solutions - desktop
I brainstormed some solutions, looked at available patterns elsewhere and compiled these ideas into a list below. Please note that the mockups are made in Preview so they can be a bit uneven etc. Also, maybe we can come up with something else altogether or combine a few solutions -- I'm open to suggestions.

### 1. Social icons in the sidebar
We could move the social icons to the bottom of the sidebar, and then move search box to the right. The con here is that the social icons are then less discoverable but do we need them to be prominent in the docs anyway?
<img width="1470" alt="Screenshot 2024-03-18 at 10 34 57 AM copy" src="https://github.com/inngest/website/assets/45401242/640b985b-eccf-4015-add3-898726a6b7e8">

### 2. Make navbar one panel (most work)
Currently, the top part of the website is divided into two panels, which steals a bit of the real estate. If we make it one panel, we could use the space more efficiently, for example:
<img width="1470" alt="Screenshot 2024-03-18 at 10 34 57 AM" src="https://github.com/inngest/website/assets/45401242/f25e4c73-6b7f-49f4-a38d-bcd274f1902e">

### 3. Add search bar to the left panel of the nav bar
I'm not sure how intuitive and visually pleasing it is but adding it here for the sake of exploration:
<img width="1470" alt="Screenshot 2024-03-18 at 10 46 07 AM" src="https://github.com/inngest/website/assets/45401242/75624978-d476-4c5a-809a-461edc8ab591">

### 4. Remove one of the "sign up/sign in" buttons
In doing so, we would save some space but add one additional screen for some of the users -- for example, if we keep "Sign in", the folks without account will have to then click "don't have an account yet? sign up", which is a pattern on some websites.
<img width="1464" alt="Screenshot 2024-03-18 at 10 51 48 AM" src="https://github.com/inngest/website/assets/45401242/23dd0272-12a0-44a4-a37e-815dbfe8b20c">

### 5. Add an additional menu
We could also add a secondary menu for the tabs but this could perhaps clash with the breadcrumbs we will introduce later?

<img width="1470" alt="Screenshot 2024-03-18 at 12 13 49 PM" src="https://github.com/inngest/website/assets/45401242/b069cfc5-7f85-492d-b654-651cd18a9275">



## Solutions -- mobile
Perhaps the four tabs could be a constant element at the top of the menu followed by the sections of the current tab?
<img width="529" alt="Screenshot 2024-03-18 at 10 58 46 AM" src="https://github.com/inngest/website/assets/45401242/0799a250-2415-4849-b7e6-d0b0a0d984a9">

## Other Questions
I am not yet sure if "Getting started" should be a tab.
- **What problem we are solving here:** 
  - with different tabs, this important section (containing quickstarts, explanation what Inngest is, how it works, etc.) may be less discoverable if it's a section within "Guides" menu. 
  - Not everyone will land on our docs through the homepage or Guides so by placing it as a tab, we ensure everyone who needs it will see it
-  **Cons:** if this is a tab, it takes space in the nav bar
I worry it is taking too much space or attention but at the same time, we need people to quickly find all the information they need. Opinions?
</detail>