### PR TITLE
INN-2880 Add a note for `fetch` failures in the TS SDK

### DIFF
--- a/pages/docs/faq.mdx
+++ b/pages/docs/faq.mdx
@@ -9,7 +9,9 @@
 - [My app's serve endpoint requires authentication. What should I
   do?](#my-app-s-serve-endpoint-requires-authentication-what-should-i-do)
 - [Why am I getting a `killed` error when running the Dev Server?](#why-am-i-getting-a-killed-error-when-running-the-dev-server)
-- [Why am I getting a `NON_DETERMINISTIC_FUNCTION` error?](#why-am-i-getting-a-non-deterministic-function-error)
+- [Why am I getting a `NON_DETERMINISTIC_FUNCTION`
+  error?](#why-am-i-getting-a-non-deterministic-function-error)
+- [Why am I getting an `Illegal invocation` error?](#why-am-i-getting-an-illegal-invocation-error)
 
 ## How do I run crons only in production?
 
@@ -71,3 +73,26 @@ This is an error present in v2.x.x of the TypeScript SDK that can be thrown when
 If you're seeing this error, we encourage you to upgrade to v3.x.x of the TypeScript SDK, which will recover and continue gracefully from this circumstance.
 
 For more information, see the [Upgrading from v2 to v3](/docs/sdk/migration) migration guide.
+
+## Why am I getting an `Illegal invocation` error?
+When making requests to an Inngest Server, the TypeScript SDK uses
+[`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). The
+actual implementation of this varies across different runtimes, versions, and
+environments. The SDK tries to account for these differences internally, but
+sometimes providing a custom `fetch` function is necessary or wanted.
+
+This error is usually indicative of providing a custom `fetch` function to
+either a `new Inngest()` or `serve()` call, but not carrying over its
+[binding](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind).
+This is a common JavaScript gotcha, where bound methods lose their binding was
+passed into an object.
+
+To resolve, make sure that you rebind the `fetch` function as it is passed. This
+is commonly to `globalThis`, though your specific runtime/version/environment
+may vary.
+
+```ts
+new Inngest({
+  fetch: fetch.bind(globalThis),
+});
+```

--- a/pages/docs/faq.mdx
+++ b/pages/docs/faq.mdx
@@ -84,11 +84,11 @@ sometimes providing a custom `fetch` function is necessary or wanted.
 This error is usually indicative of providing a custom `fetch` function to
 either a `new Inngest()` or `serve()` call, but not carrying over its
 [binding](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind).
-This is a common JavaScript gotcha, where bound methods lose their binding was
+This is a common JavaScript gotcha, where bound methods lose their binding when
 passed into an object.
 
 To resolve, make sure that you rebind the `fetch` function as it is passed. This
-is commonly to `globalThis`, though your specific runtime/version/environment
+is commonly bound to `globalThis`, though your specific runtime/version/environment
 may vary.
 
 ```ts

--- a/pages/docs/reference/client/create.mdx
+++ b/pages/docs/reference/client/create.mdx
@@ -37,7 +37,11 @@ const inngest = new Inngest({
     An Inngest [Event Key](/docs/events/creating-an-event-key). Alternatively, set the [`INNGEST_EVENT_KEY`](/docs/sdk/environment-variables#inngest-event-key) environment variable.
   </Property>
   <Property name="fetch" type="Fetch API compatible interface">
-    Override the default [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation. Defaults to the runtime's native Fetch API.
+    Override the default
+    [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+    implementation. Defaults to the runtime's native Fetch API.
+
+    If you need to specify this, make sure that you preserve the function's [binding](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind), either by using `.bind` or by wrappng it in an anonymous function.
   </Property>
   <Property name="isDev" type="boolean" version="v3.15.0+">
     Set to `true` to force Dev mode, setting default local URLs and turning off


### PR DESCRIPTION
## Summary

Providing a custom `fetch` implementation in the TypeScript SDK is rarely needed, but also has some gotchas when specifying it.

This adds a new FAQ and an adjustment to the reference docs detailing the gotcha and how to avoid it.

It also pairs with inngest/inngest-js#521 to push the user towards the right solution.

## Related

- INN-2880
- inngest/inngest-js#521