### PR TITLE
Page-specific menu: highlights and nested items

### DIFF
--- a/mdx/rehype.mjs
+++ b/mdx/rehype.mjs
@@ -56,7 +56,7 @@ export function rehypeShiki() {
 }
 
 const tagsToAddIds = ["h1", "h2", "h3", "h4"];
-const tagsToIncludeInSectionIndex = ["h1", "h2"];
+const tagsToIncludeInSectionIndex = ["h1", "h2", "h3"];
 function rehypeSlugify() {
   return (tree) => {
     let slugify = slugifyWithCounter();

--- a/mdx/rehype.mjs
+++ b/mdx/rehype.mjs
@@ -55,7 +55,8 @@ export function rehypeShiki() {
   };
 }
 
-const tagsToAddIds = ["h2", "h3", "h4"];
+const tagsToAddIds = ["h1", "h2", "h3", "h4"];
+const tagsToIncludeInSectionIndex = ["h1", "h2"];
 function rehypeSlugify() {
   return (tree) => {
     let slugify = slugifyWithCounter();
@@ -101,7 +102,10 @@ function getSections(node) {
   let sections = [];
 
   for (let child of node.children ?? []) {
-    if (child.type === "element" && child.tagName === "h2") {
+    if (
+      child.type === "element" &&
+      tagsToIncludeInSectionIndex.includes(child.tagName)
+    ) {
       sections.push(`{
         title: ${JSON.stringify(toString(child))},
         id: ${JSON.stringify(child.properties.id)},

--- a/shared/Docs/Heading.tsx
+++ b/shared/Docs/Heading.tsx
@@ -84,7 +84,7 @@ export function Heading({
   });
 
   useEffect(() => {
-    if (level === 2) {
+    if (level <= 3) {
       registerHeading({ id, ref, offsetRem: tag || label ? 8 : 6 });
     }
   });

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -93,7 +93,7 @@ function NavLink({
       target={target}
       className={clsx(
         "flex justify-between items-center gap-2 py-1 pr-3 text-sm font-medium transition group", // group for nested hovers
-        isTopLevel ? "pl-0" : isAnchorLink ? "pl-3" : "pl-4",
+        isTopLevel || isAnchorLink ? "pl-0" : "pl-4",
         active
           ? "text-slate-900 dark:text-white"
           : "text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white",
@@ -119,7 +119,7 @@ const LinkOrHref = (props: any) => {
   return <Link {...props} />;
 };
 
-function VisibleSectionHighlight({ group, pathname }) {
+function VisibleSectionHighlight({ pathname }) {
   let [sections, visibleSections] = useInitialValue(
     [
       useSectionStore((s) => s.sections),
@@ -131,17 +131,15 @@ function VisibleSectionHighlight({ group, pathname }) {
   let isPresent = useIsPresent();
   let firstVisibleSectionIndex = Math.max(
     0,
-    [{ id: "_top" }, ...sections].findIndex(
-      (section) => section.id === visibleSections[0]
-    )
+    sections.findIndex((section) => section.id === visibleSections[0])
   );
+  // TODO: calculate
   let itemHeight = remToPx(1.76);
   let height = isPresent
     ? Math.max(1, visibleSections.length) * itemHeight
     : itemHeight;
-  let top =
-    findPathIndex(group.links, pathname) * itemHeight +
-    firstVisibleSectionIndex * itemHeight;
+
+  let top = firstVisibleSectionIndex * itemHeight;
 
   return (
     <motion.div
@@ -149,7 +147,7 @@ function VisibleSectionHighlight({ group, pathname }) {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1, transition: { delay: 0.2 } }}
       exit={{ opacity: 0 }}
-      className="absolute inset-x-0 top-0 bg-slate-800/2.5 will-change-transform dark:bg-white/2.5"
+      className="absolute -left-2 right-0 top-0 bg-slate-800/10 will-change-transform dark:bg-white/2.5"
       style={{ borderRadius: 8, height, top }}
     />
   );
@@ -183,35 +181,42 @@ export function PageSidebar() {
   return (
     <div>
       <h4 className="text-base font-medium pb-2">On this page</h4>
-      {/* TODO: Add highlighted page section back */}
-      {/* <AnimatePresence initial={!isInsideMobileNavigation}>
-        <VisibleSectionHighlight group={group} pathname={router.pathname} />
-      </AnimatePresence> */}
-      <motion.ul
-        role="list"
-        initial={{ opacity: 0 }}
-        animate={{
-          opacity: 1,
-          transition: { delay: 0.1 },
-        }}
-        exit={{
-          opacity: 0,
-          transition: { duration: 0.15 },
-        }}
-      >
-        {sections.map((section) => (
-          <li key={section.id}>
-            <NavLink
-              href={`#${section.id}`}
-              tag={section.tag}
-              isAnchorLink
-              truncate={false}
+      <div className="relative">
+        <AnimatePresence initial={!isInsideMobileNavigation}>
+          <VisibleSectionHighlight pathname={router.pathname} />
+        </AnimatePresence>
+        <motion.ul
+          role="list"
+          initial={{ opacity: 0 }}
+          animate={{
+            opacity: 1,
+            transition: { delay: 0.1 },
+          }}
+          exit={{
+            opacity: 0,
+            transition: { duration: 0.15 },
+          }}
+        >
+          {sections.map((section) => (
+            <li
+              key={section.id}
+              className="relative"
+              style={{
+                marginLeft: `${(section.level - 1) * 12}px`,
+              }}
             >
-              {section.title}
-            </NavLink>
-          </li>
-        ))}
-      </motion.ul>
+              <NavLink
+                href={`#${section.id}`}
+                tag={section.tag}
+                isAnchorLink
+                truncate={false}
+              >
+                {section.title}
+              </NavLink>
+            </li>
+          ))}
+        </motion.ul>
+      </div>
     </div>
   );
 }

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -171,12 +171,10 @@ function ActivePageMarker({ group, pathname }) {
 
 export function PageSidebar() {
   let isInsideMobileNavigation = useIsInsideMobileNavigation();
-  let [router, sections] = useInitialValue(
-    [useRouter(), useSectionStore((s) => s.sections)],
-    isInsideMobileNavigation
-  );
+  let router = useRouter();
+  let sections = useSectionStore((s) => s.sections);
 
-  let pageSectionsRef = useRef(null);
+  let [pageSectionsEl, setPageSectionsEl] = useState(null);
   let [pageSectionListItems, setPageSectionListItems] = useState(null);
   let [windowWidth, setWindowWidth] = useState(null);
 
@@ -189,10 +187,12 @@ export function PageSidebar() {
   }, []);
 
   useEffect(() => {
-    setPageSectionListItems([
-      ...pageSectionsRef.current?.querySelectorAll("li"),
-    ]);
-  }, [windowWidth]);
+    if (pageSectionsEl) {
+      setPageSectionListItems([
+        ...(pageSectionsEl?.querySelectorAll("li") ?? []),
+      ]);
+    }
+  }, [router.pathname, windowWidth, pageSectionsEl]);
 
   return (
     <div>
@@ -204,7 +204,8 @@ export function PageSidebar() {
           )}
         </AnimatePresence>
         <motion.ul
-          ref={pageSectionsRef}
+          key={router.pathname}
+          ref={setPageSectionsEl}
           role="list"
           initial={{ opacity: 0 }}
           animate={{

--- a/shared/Docs/SectionProvider.jsx
+++ b/shared/Docs/SectionProvider.jsx
@@ -35,6 +35,7 @@ function createSectionStore(sections) {
               return {
                 ...section,
                 headingRef: ref,
+                level: +(ref.current?.tagName.replace('H', '') ?? 0),
                 offsetRem,
               };
             }
@@ -63,9 +64,9 @@ function useVisibleSections(sectionStore) {
         let offset = remToPx(offsetRem);
         let top = headingRef?.current.getBoundingClientRect().top + scrollY;
 
-        if (sectionIndex === 0 && top - offset > scrollY) {
-          newVisibleSections.push("_top");
-        }
+        // if (sectionIndex === 0 && top - offset > scrollY) {
+        //   newVisibleSections.push("_top");
+        // }
 
         let nextSection = sections[sectionIndex + 1];
         let bottom =

--- a/shared/Docs/SectionProvider.jsx
+++ b/shared/Docs/SectionProvider.jsx
@@ -9,6 +9,8 @@ import { createStore, useStore } from "zustand";
 
 import { remToPx } from "../../utils/remToPx";
 
+const PAGE_HEADER_OFFSET_REM = 4;
+
 // type Section = { id: string; headingRef: any; offsetRem: string };
 // type State = {
 //   sections?: Section[];
@@ -60,20 +62,15 @@ function useVisibleSections(sectionStore) {
         sectionIndex < sections.length;
         sectionIndex++
       ) {
-        let { id, headingRef, offsetRem } = sections[sectionIndex];
-        let offset = remToPx(offsetRem);
+        let { id, headingRef } = sections[sectionIndex];
         let top = headingRef?.current.getBoundingClientRect().top + scrollY;
-
-        // if (sectionIndex === 0 && top - offset > scrollY) {
-        //   newVisibleSections.push("_top");
-        // }
 
         let nextSection = sections[sectionIndex + 1];
         let bottom =
           (nextSection?.headingRef?.current.getBoundingClientRect().top ??
             Infinity) +
           scrollY -
-          remToPx(nextSection?.offsetRem ?? 0);
+          remToPx(nextSection?.offsetRem ?? 0) - PAGE_HEADER_OFFSET_REM;
 
         if (
           (top > scrollY && top < scrollY + innerHeight) ||

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -552,70 +552,58 @@ const sectionReference: NavGroup[] = [
     defaultOpen: true,
     links: [
       {
-        title: "Overview",
-        // TODO - Allow this to be flattened w/ NavGroup
-        links: [
-          {
-            title: "Introduction",
-            href: `/docs/reference/typescript`,
-          },
-        ],
+        title: "Introduction",
+        href: `/docs/reference/typescript`,
       },
       {
-        title: "Inngest Client",
-        links: [
-          {
-            title: "Create the client",
-            href: `/docs/reference/client/create`,
-          },
-        ],
+        title: "Create the client",
+        href: `/docs/reference/client/create`,
       },
       {
-        title: "Functions",
-        links: [
-          {
-            title: "Create function",
-            href: `/docs/reference/functions/create`,
-          },
-          {
-            title: "Errors",
-            href: `/docs/reference/typescript/functions/errors`,
-          },
-          {
-            title: "Handling failures",
-            href: `/docs/reference/functions/handling-failures`,
-          },
-          {
-            title: "Cancel running functions",
-            href: `/docs/functions/cancellation`,
-            // href: `/docs/reference/functions/cancel-running-functions`,
-          },
-          {
-            title: "Concurrency",
-            href: `/docs/functions/concurrency`,
-            // href: `/docs/reference/functions/concurrency`,
-          },
-          {
-            title: "Rate limit",
-            href: `/docs/reference/functions/rate-limit`,
-          },
-          {
-            title: "Debounce",
-            href: `/docs/reference/functions/debounce`,
-          },
-          {
-            title: "Function run priority",
-            href: `/docs/reference/functions/run-priority`,
-          },
-          // {
-          //   title: "Logging",
-          //   href: `/docs/reference/functions/logging`,
-          // },
-          {
-            title: "Referencing functions",
-            href: `/docs/functions/references`,
-          },
-        ],
+        title: "Create a function",
+        href: `/docs/reference/functions/create`,
+      },
+      {
+        title: "Send events",
+        href: `/docs/reference/events/send`,
+      },
+      {
+        title: "Errors",
+        href: `/docs/reference/typescript/functions/errors`,
+      },
+      {
+        title: "Handling failures",
+        href: `/docs/reference/functions/handling-failures`,
+      },
+      {
+        title: "Cancel running functions",
+        href: `/docs/functions/cancellation`,
+        // href: `/docs/reference/functions/cancel-running-functions`,
+      },
+      {
+        title: "Concurrency",
+        href: `/docs/functions/concurrency`,
+        // href: `/docs/reference/functions/concurrency`,
+      },
+      {
+        title: "Rate limit",
+        href: `/docs/reference/functions/rate-limit`,
+      },
+      {
+        title: "Debounce",
+        href: `/docs/reference/functions/debounce`,
+      },
+      {
+        title: "Function run priority",
+        href: `/docs/reference/functions/run-priority`,
+      },
+      // {
+      //   title: "Logging",
+      //   href: `/docs/reference/functions/logging`,
+      // },
+      {
+        title: "Referencing functions",
+        href: `/docs/functions/references`,
       },
       {
         title: "Steps",
@@ -649,15 +637,6 @@ const sectionReference: NavGroup[] = [
             title: "step.sendEvent()",
             href: `/docs/reference/functions/step-send-event`,
             className: "font-mono",
-          },
-        ],
-      },
-      {
-        title: "Events",
-        links: [
-          {
-            title: "Send",
-            href: `/docs/reference/events/send`,
           },
         ],
       },
@@ -724,48 +703,32 @@ const sectionReference: NavGroup[] = [
     title: "Python SDK",
     links: [
       {
-        title: "Overview",
-        // TODO - Allow this to be flattened w/ NavGroup
-        links: [
-          {
-            title: "Introduction",
-            href: `/docs/reference/python`,
-          },
-          {
-            title: "Quick start",
-            href: `/docs/reference/python/overview/quick-start`,
-          },
-          {
-            title: "Environment variables",
-            href: `/docs/reference/python/overview/env-vars`,
-          },
-          {
-            title: "Production mode",
-            href: `/docs/reference/python/overview/prod-mode`,
-          },
-        ],
+        title: "Introduction",
+        href: `/docs/reference/python`,
       },
       {
-        title: "Client",
-        links: [
-          {
-            title: "Overview",
-            href: `/docs/reference/python/client/overview`,
-          },
-          {
-            title: "Send events",
-            href: `/docs/reference/python/client/send`,
-          },
-        ],
+        title: "Quick start",
+        href: `/docs/reference/python/overview/quick-start`,
       },
       {
-        title: "Functions",
-        links: [
-          {
-            title: "Create function",
-            href: `/docs/reference/python/functions/create`,
-          },
-        ],
+        title: "Inngest Client",
+        href: `/docs/reference/python/client/overview`,
+      },
+      {
+        title: "Create function",
+        href: `/docs/reference/python/functions/create`,
+      },
+      {
+        title: "Send events",
+        href: `/docs/reference/python/client/send`,
+      },
+      {
+        title: "Environment variables",
+        href: `/docs/reference/python/overview/env-vars`,
+      },
+      {
+        title: "Production mode",
+        href: `/docs/reference/python/overview/prod-mode`,
       },
       {
         title: "Steps",
@@ -854,13 +817,12 @@ export const menuTabs = [
     href: "/docs/reference",
     matcher: /\/reference/,
   },
-  // will add this in the future
-  // {
-  //   title: "Examples",
-  //   icon: CogIcon,
-  //   href: "/docs/examples",
-  //   matcher: /\/examples/,
-  // },
+  {
+    title: "Examples",
+    icon: CogIcon,
+    href: "/docs/examples",
+    matcher: /\/examples/,
+  },
 ];
 
 export const topLevelNav = [


### PR DESCRIPTION
# Overview

This PR introduces section highlighting in the page-specific side menu, as well as nested list items (h1, h2, h3).

➡️ Preview

## Considerations

The previous implementation (theme's default) did not work because:
- The list items were truncated
  - this is not great for discoverability or accessibility, and would be a terrible experience on Reference pages where many items start with the same name (for example, `step.`)
- The list was not nested
  - We need the list to be nested because of how Reference pages will be organized

Moreover:
- The page needs to be responsive (if we resize the window, the side menu should recalculate)

## Code quality

There's a weird bit where I use `useState` in `useEffect` which doesn't feel very elegant. This is done to ensure that the correct hight and position of the highlight is calculated. I'm out of ideas here and I welcome corrections.

## Screenshots

The screenshots show four scenarios:
- light/dark mode
- nestedness
- one/many elements visible at the same time
- window resizing / menu relalculates

### Light mode
<img width="1469" alt="Screenshot 2024-03-26 at 9 02 23 PM" src="https://github.com/inngest/website/assets/45401242/6b85d51c-7c10-4c2c-97cb-df96033b5350">

### Dark mode
<img width="1469" alt="Screenshot 2024-03-26 at 9 02 35 PM" src="https://github.com/inngest/website/assets/45401242/1ede45bd-3a9a-462c-bea8-bd3590202ff5">

### Reference page
An example why a three-level menu is needed:
<img width="1469" alt="Screenshot 2024-03-26 at 9 04 14 PM" src="https://github.com/inngest/website/assets/45401242/9023d38a-a639-4b63-9c28-43068046e96b">

### Window resizing
https://github.com/inngest/website/assets/45401242/de6b07aa-a345-4290-a152-909d53774b1b


