### PR TITLE
Hotfix: Reference tab matching issue

### DIFF
--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -831,7 +831,9 @@ const matchers = {
   guides: (pathname) =>
     /^\/docs\/guides/.test(pathname) || linkSearch(sectionGuides, pathname),
   // reference: /^\/docs\/reference/,
-  reference: (pathname) => linkSearch(sectionReference, pathname),
+  reference: (pathname) =>
+    /^\/docs\/reference/.test(pathname) ||
+    linkSearch(sectionReference, pathname),
   examples: /^\/docs\/examples/,
   // should match everything except above
   // default: /^\/docs(?!\/guides|\/reference|\/examples)/,


### PR DESCRIPTION
Before this, my previous change broke the left nav from being visible when on `/docs/reference`