### PR TITLE
Adds FAQ + security back

### DIFF
--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -61,6 +61,10 @@ const sectionGettingStarted: NavGroup[] = [
         title: "Local Development",
         href: `/docs/local-development`,
       },
+      {
+        title: "Security",
+        href: `/docs/security`,
+      },
     ],
   },
   {
@@ -148,6 +152,10 @@ const sectionGuides: NavGroup[] = [
       {
         title: "Using multiple triggers",
         href: `/docs/guides/multiple-triggers`,
+      },
+      {
+        title: "FAQs",
+        href: `/docs/faq`,
       },
     ],
   },


### PR DESCRIPTION
@djfarrelly I've added `security` to `/getting-started` because my assumption is that we want it to be immediately findable. What do you think?