### PR TITLE
Add scheduled functions example

### DIFF
--- a/pages/docs/examples/index.mdx
+++ b/pages/docs/examples/index.mdx
@@ -1,6 +1,6 @@
 import { ResourceGrid, Resource } from 'src/shared/Docs/Resources'
 import { EnvelopeIcon } from "@heroicons/react/24/outline";
-import { RiBracesFill } from "@remixicon/react";
+import { RiBracesFill, RiCalendarScheduleFill } from "@remixicon/react";
 
 export const hidePageSidebar = true;
 
@@ -19,11 +19,19 @@ Explore the features built with Inngest:
 }}/>
 
 <Resource resource={{
+  href: "/docs/examples/scheduling-one-off-function",
+  name: "Scheduling a one-off function",
+  icon: RiCalendarScheduleFill,
+  description: "Schedule a function to run at a specific time.",
+  pattern: 2,
+}}/>
+
+<Resource resource={{
   href: "/docs/examples/fetch-run-status-and-output",
   name: "Fetch run status and output",
   icon: RiBracesFill,
   description: "Get the result of a run using an Event ID.",
-  pattern: 2,
+  pattern: 3,
 }}/>
 
 </ResourceGrid>

--- a/pages/docs/examples/scheduling-one-off-function.mdx
+++ b/pages/docs/examples/scheduling-one-off-function.mdx
@@ -1,14 +1,14 @@
 import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 import { RiSendPlaneFill } from "@remixicon/react";
 
-export const description = "See how to schedule a function to run at a specific time in the future."
+export const description = "Schedule a function to run at a specific time in the future."
 
 # Scheduling a one-off function
 
 Inngest provides a way to delay a function run to a specific time in the future. This is useful when:
 
-* You want to schedule work in the future based on user input
-* You want to slightly delay execution of a non-urgent function for a few seconds or minutes
+* You want to schedule work in the future based on user input.
+* You want to slightly delay execution of a non-urgent function for a few seconds or minutes.
 
 This page provides a quick example of how to delay a function run to a specific time in the future using the [event payload's](/docs/events#event-payload-format) `ts` field.
 

--- a/pages/docs/examples/scheduling-one-off-function.mdx
+++ b/pages/docs/examples/scheduling-one-off-function.mdx
@@ -1,0 +1,77 @@
+import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
+import { RiSendPlaneFill } from "@remixicon/react";
+
+export const description = "See how to schedule a function to run at a specific time in the future."
+
+# Scheduling a one-off function
+
+Inngest provides a way to delay a function run to a specific time in the future. This is useful when:
+
+* You want to schedule work in the future based on user input
+* You want to slightly delay execution of a non-urgent function for a few seconds or minutes
+
+This page provides a quick example of how to delay a function run to a specific time in the future using the [event payload's](/docs/events#event-payload-format) `ts` field.
+
+## Quick Snippet
+
+Here is a basic function that sends a reminder to a user at a given email.
+
+```typescript
+const sendReminder = inngest.createFunction(
+  { id: "send-reminder" },
+  { event: "notifications/reminder.scheduled" },
+  async ({ event, step }) => {
+    const { user, message } = event.data;
+
+    const { id } = await emailApi.send({
+      to: user.email,
+      subject: "Reminder for your upcoming event",
+      body: message,
+    });
+
+    return { id }
+  }
+);
+```
+
+### Triggering the function with a timestamp
+
+To trigger this function, you will send an event `"notifications/reminder.scheduled"` using `inngest.send()` with the necessary data. The `ts` field in the [event payload](/docs/events#event-payload-format) should be set to the Unix timestamp of the time you want the function to run. For example, to schedule a reminder for 5 minutes in the future:
+
+```typescript
+await inngest.send({
+  name: "notifications/reminder.scheduled",
+  data: {
+    user: { email: "johnny.utah@fbi.gov" }
+    message: "Don't forget to catch the wave at 3pm",
+  },
+  // Include the timestamp for 5 minutes in the future:
+  ts: Date.now() + 5 * 60 * 1000,
+});
+```
+
+### Alternatives
+
+Depending on your use case, you may want to consider using [scheduled functions (cron jobs)](/docs/guides/scheduled-functions) for scheduling periodic work or use [`step.sleepUntil()`](/docs/reference/functions/step-sleep-until) to add mid-function delays for a layer time.
+
+## More context
+
+Check the resources below to learn more about scheduling functions with Inngest.
+
+<ResourceGrid cols={2}>
+
+<Resource resource={{
+  href: "/docs/events",
+  name: "Guide: Sending events",
+  icon: RiSendPlaneFill,
+  description: "Learn how to send events to trigger functions in Inngest.",
+  pattern: 1,
+}}/>
+
+</ResourceGrid>
+
+## Related concepts
+
+- [Scheduled functions (cron jobs)](/docs/guides/scheduled-functions)
+- [`step.sleepUntil()`](/docs/reference/functions/step-sleep-until)
+

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -609,6 +609,10 @@ const sectionExamples: NavGroup[] = [
         href: `/docs/examples/email-sequence`,
       },
       {
+        title: "Scheduling a one-off function",
+        href: `/docs/examples/scheduling-one-off-function`,
+      },
+      {
         title: "Fetch run status and output",
         href: `/docs/examples/fetch-run-status-and-output`,
       },


### PR DESCRIPTION
A great feature that isn't very clear in our docs should get a simple example.

Open to feedback on title, URL, etc. Alternatives could be using "delay" in more places.