### PR TITLE
Update Python docs for new step.run args

### DIFF
--- a/pages/docs/guides/error-handling.mdx
+++ b/pages/docs/guides/error-handling.mdx
@@ -154,10 +154,10 @@ inngestgo.CreateFunction(
 )
 def sync_systems(ctx: inngest.Context, step: inngest.StepSync) -> None:
     # Can be retried up to 4 times
-    data = step.run("Get data", lambda: get_data_from_external_source())
+    data = step.run("Get data", get_data_from_external_source)
 
     # Can also be retried up to 4 times
-    step.run("Save data", lambda: db.syncs.insert_one(data))
+    step.run("Save data", db.syncs.insert_one, data)
 ```
 </CodeGroup>
 
@@ -452,13 +452,13 @@ from inngest.errors import NonRetriableError
 )
 def user_weekly_digest(ctx: inngest.Context, step: inngest.StepSync) -> None:
     try:
-        user = step.run("Get user email", lambda: db.users.find_one(ctx.event.data["userId"]))
+        user = step.run("Get user email", db.users.find_one, ctx.event.data["userId"])
     except Exception as err:
         if err.name == "UserNotFoundError":
             raise NonRetriableError("User no longer exists; stopping")
         raise
 
-    step.run("Send digest", lambda: send_digest(user["email"]))
+    step.run("Send digest", send_digest, user["email"])
 ```
 </CodeGroup>
 

--- a/pages/docs/reference/python/steps/run.mdx
+++ b/pages/docs/reference/python/steps/run.mdx
@@ -1,6 +1,6 @@
 # Run
 
-Run steps in parallel.
+Turn a normal function into a durable function. Any function passed to `step.run` will be executed in a durable way, including retries and memoization.
 
 
 ## Arguments
@@ -10,8 +10,12 @@ Run steps in parallel.
         Step ID. Should be unique within the function.
     </Property>
 
-    <Property name="handler" required type="Callable[[], object]">
+    <Property name="handler" required type="Callable">
         A callable that has no arguments and returns a JSON serializable value.
+    </Property>
+
+    <Property name="*handler_args">
+        Positional arguments for the handler. This is type-safe since we infer the types from the handler using generics.
     </Property>
 </Properties>
 
@@ -25,10 +29,31 @@ Run steps in parallel.
 async def fn(
     ctx: inngest.Context,
     step: inngest.Step,
-) -> int:
-    async def my_step() -> int:
-        # Do stuff
-        return 1
+) -> None:
+    # Pass a function to step.run
+    await step.run("my_fn", my_fn)
 
-    return await step.run("my_step", my_step)
+    # Args are passed after the function
+    await step.run("my_fn_with_args", my_fn_with_args, 1, "a")
+
+    # Kwargs require functools.partial
+    await step.run(
+        "my_fn_with_args_and_kwargs",
+        functools.partial(my_fn_with_args_and_kwargs, 1, b="a"),
+    )
+
+    # Defining functions like this gives you easy access to scoped variables
+    def use_scoped_variable() -> None:
+        print(ctx.event.data["user_id"])
+
+    await step.run("use_scoped_variable", use_scoped_variable)
+
+async def my_fn() -> None:
+    pass
+
+async def my_fn_with_args(a: int, b: str) -> None:
+    pass
+
+async def my_fn_with_args_and_kwargs(a: int, *, b: str) -> None:
+    pass
 ```


### PR DESCRIPTION
Update Python docs to reflect the new ability to specify `step.run` callback args in a variadic way:
```py
step.run("my-step", my_fn, arg_1, arg_2)
```