### PR TITLE
Fix throttle burst param type

### DIFF
--- a/pages/docs/guides/throttling.mdx
+++ b/pages/docs/guides/throttling.mdx
@@ -17,7 +17,7 @@ inngest.createFunction(
     throttle: {
       limit: 1,
       period: "5s",
-      burst: "2",
+      burst: 2,
       key: "event.data.user_id",
     },
   }


### PR DESCRIPTION
It's a number, not a string