### PR TITLE
WIP: fixes Python Reference Sidebar

### DIFF
--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -394,9 +394,11 @@ export function Navigation(props) {
     () =>
       [
         activeGroup,
-        ...(nestedNavigation?.sectionLinks.filter(
-          (group) => group.defaultOpen
-        ) ?? []),
+        ...(activeGroup
+          ? []
+          : nestedNavigation?.sectionLinks.filter(
+              (group) => group.defaultOpen
+            ) ?? []),
       ]
         .filter(Boolean)
         .map((group) => group.title),


### PR DESCRIPTION
In reference to [Aaron's bug report](https://inngest.slack.com/archives/C068B3TL06L/p1715308466596939).

The reason the TypeScript nav bar is open is that it has `defaultOpen: true`, and currently the logic is that we show the current page's parent navigation AND everything with `defaultOpen: true`.

This change makes it so that the `defaultOpen: true` elements are only shown as open when there is no currently active route.

This may not be what we want, though, because on the "Getting Started" route the "Learn the Basics" section is now closed by default because the "Getting started" route is actually a Next.js subpage under Quickstarts. A solution here is to maybe make a separate landing page for the "Getting Started" route. This would mean, though, that when someone is working through a QuickStart, they don't see the "Getting Started" nav bar. We could move them to be a sub-section the "Getting Started" sidebar, though.