### PR TITLE
Update pages with duplicate names

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -26,6 +26,7 @@ const permanentRedirects = [
   ["/docs/sdk/reference/serve", "/docs/reference/serve"],
   ["/docs/events/webhooks", "/docs/platform/webhooks"],
   ["/docs/functions/retries", "/docs/reference/typescript/functions/errors"],
+  ["/docs/functions/cancellation", "/docs/guides/cancel-running-functions"],
   [
     "/docs/reference/python/overview/quick-start",
     "/docs/getting-started/quick-start/python",

--- a/pages/blog/_posts/2023-12-22-2023-wrapped.mdx
+++ b/pages/blog/_posts/2023-12-22-2023-wrapped.mdx
@@ -36,7 +36,7 @@ Over this year, Inngest has become an even more fully-featured and reliable tool
 This year we shipped major updates to our TypeScript SDK, [recently releasing v3](https://www.inngest.com/blog/releasing-ts-sdk-3). This year, we’ve added all these crucial features:
 
 - [Steps](https://www.inngest.com/docs/reference/functions/step-run),
-- [Cancelling running functions with events](https://www.inngest.com/docs/functions/cancellation),
+- [Cancelling running functions with events](/docs/guides/cancel-running-functions),
 - [Custom failure handling](https://www.inngest.com/docs/reference/functions/handling-failures),
 - [Invoking functions from within a function](https://www.inngest.com/docs/reference/functions/step-invoke) to compose complex flows,
 - [Middleware](https://www.inngest.com/docs/reference/middleware/create) - enabling logging, encryption, tracing, and others,

--- a/pages/blog/_posts/running-chained-llms-typescript-in-production.mdx
+++ b/pages/blog/_posts/running-chained-llms-typescript-in-production.mdx
@@ -122,7 +122,7 @@ You can then start to chain LLMs without building out complex queues, state, or 
 Beyond this simple case, you can extend your functions to:
 
 - [Automatically parallelize calls](/docs/guides/step-parallelism) using *actual parallelism* to speed up your chain
-- [Automatically cancel](/docs/functions/cancellation?ref=blog-chained-llms) if desired, eg. on window close, to save on model costs
+- [Automatically cancel](/docs/guides/cancel-running-functions?ref=blog-chained-llms) if desired, eg. on window close, to save on model costs
 - [Manage concurrency](/docs/functions/concurrency?ref=blog-chained-llms), ensuring that you automatically enqueue functions if they exceed rate limits
 - [Handle failures](/docs/functions/retries?ref=blog-chained-llms), allowing you to create cleanup code or notify users on error.
 - We also provide [branch environments](/docs/platform/environments?ref=blog-chained-llms) across platforms, and work with your current CI/CD process — as functions are served via HTTP anywhere they’re accessible.

--- a/pages/docs/guides/background-jobs.mdx
+++ b/pages/docs/guides/background-jobs.mdx
@@ -118,4 +118,4 @@ Now that you've created a background function you might want to learn how to:
 
 - [Run Inngest locally to test functions](/docs/local-development)
 - [Enqueue jobs in the future](/docs/guides/enqueueing-future-jobs)
-- [Cancel running functions](/docs/functions/cancellation)
+- [Cancel running functions](/docs/guides/cancel-running-functions)

--- a/pages/docs/guides/cancel-running-functions.mdx
+++ b/pages/docs/guides/cancel-running-functions.mdx
@@ -89,7 +89,7 @@ Here is an example of these two events which will be matched on the `data.remind
 * You can configure multiple events to cancel a function, up to five.
 * You can write a more complex matching statement using the `if` field.
 
-Learn more in the full [reference](/docs/reference/typescript/cancel-on).
+Learn more in the full [reference](/docs/reference/typescript/functions/cancel-on).
 
 
 {/* TODO

--- a/pages/docs/guides/cancel-running-functions.mdx
+++ b/pages/docs/guides/cancel-running-functions.mdx
@@ -29,7 +29,7 @@ const scheduleReminder = inngest.createFunction(
     cancelOn: [{
       event: "tasks/reminder.deleted", // The event name that cancels this function
       // Ensure the cancelation event (async) and the triggering event (event)'s reminderId are the same:
-      if: "async.data.reminderId == event.data.reminderId", 
+      if: "async.data.reminderId == event.data.reminderId",
     }],
   }
   { event: "tasks/reminder.created" },
@@ -89,7 +89,7 @@ Here is an example of these two events which will be matched on the `data.remind
 * You can configure multiple events to cancel a function, up to five.
 * You can write a more complex matching statement using the `if` field.
 
-Learn more in the full [reference](/docs/functions/cancellation).
+Learn more in the full [reference](/docs/reference/typescript/cancel-on).
 
 
 {/* TODO

--- a/pages/docs/guides/sending-events-from-functions.mdx
+++ b/pages/docs/guides/sending-events-from-functions.mdx
@@ -7,7 +7,7 @@ In some workflows or pipeline functions, you may want to broadcast events from w
 * You want to decouple logic into separate functions that can be re-used across your system
 * You want to send an event to [fan-out](/docs/guides/fan-out-jobs) to multiple other functions
 * Your function is handling many items that you want to process in parallel functions
-* You want to [cancel](/docs/functions/cancellation) another function
+* You want to [cancel](/docs/guides/cancel-running-functions) another function
 * You want to send data to another function [waiting for an event](/docs/reference/functions/step-wait-for-event)
 
 If your function needs to handle the result of another function, or wait until that other function has completed, you should use [direct function invocation with `step.invoke()`](/docs/guides/invoking-functions-directly) instead.

--- a/pages/docs/guides/writing-expressions.mdx
+++ b/pages/docs/guides/writing-expressions.mdx
@@ -3,7 +3,7 @@
 Expressions are used in a number of ways for configuring your functions. They are used for:
 
 * Defining keys for [concurrency](/docs/functions/concurrency), [rate limiting](/docs/reference/functions/rate-limit), [debounce](/docs/reference/functions/debounce), or [idempotency](/docs/guides/handling-idempotency)
-* Conditionally matching events for [wait for event](/docs/reference/functions/step-wait-for-event), [cancellation](/docs/functions/cancellation), or the [function trigger's `if` option](/docs/reference/functions/create#trigger)
+* Conditionally matching events for [wait for event](/docs/reference/functions/step-wait-for-event), [cancellation](/docs/guides/cancel-running-functions), or the [function trigger's `if` option](/docs/reference/functions/create#trigger)
 * Returning values for function [run priority](/docs/reference/functions/run-priority)
 
 All expressions are defined using the [Common Expression Language (CEL)](https://github.com/google/cel-go). CEL offers simple, fast, non-turing complete expressions. It allows Inngest to evaluate millions of expressions for all users at scale.
@@ -18,7 +18,7 @@ Within the scope of Inngest, expressions should evaluate to either a boolean or 
 ## Variables
 
 - `event` refers to the event that triggered the function run, in every case.
-- `async` refers to a new event in `step.waitForEvent` and [cancellation](/docs/functions/cancellation).  It's the incoming event which is matched asynchronously.  This is only present when matching new events in a function run.
+- `async` refers to a new event in `step.waitForEvent` and [cancellation](/docs/guides/cancel-running-functions).  It's the incoming event which is matched asynchronously.  This is only present when matching new events in a function run.
 
 ## Examples
 

--- a/pages/docs/reference/functions/create.mdx
+++ b/pages/docs/reference/functions/create.mdx
@@ -148,7 +148,7 @@ The `createFunction` method accepts a series of arguments to define your functio
     A function that will be called only when this Inngest function fails after all retries have been attempted ([reference](/docs/reference/functions/handling-failures))
   </Property>
   <Property name="cancelOn" type="array of objects">
-    Define events that can be used to cancel a running or sleeping function ([reference](/docs/functions/cancellation))
+    Define events that can be used to cancel a running or sleeping function ([reference](/docs/reference/typescript/cancel-on))
     <Properties nested={true} collapse={true}>
       <Property name="event" type="string" required>
         The event name which will be used to cancel

--- a/pages/docs/reference/functions/create.mdx
+++ b/pages/docs/reference/functions/create.mdx
@@ -148,7 +148,7 @@ The `createFunction` method accepts a series of arguments to define your functio
     A function that will be called only when this Inngest function fails after all retries have been attempted ([reference](/docs/reference/functions/handling-failures))
   </Property>
   <Property name="cancelOn" type="array of objects">
-    Define events that can be used to cancel a running or sleeping function ([reference](/docs/reference/typescript/cancel-on))
+    Define events that can be used to cancel a running or sleeping function ([reference](/docs/reference/typescript/functions/cancel-on))
     <Properties nested={true} collapse={true}>
       <Property name="event" type="string" required>
         The event name which will be used to cancel

--- a/pages/docs/reference/python/functions/create.mdx
+++ b/pages/docs/reference/python/functions/create.mdx
@@ -37,7 +37,7 @@ The `create_function` decorator accepts a configuration and wraps a plain functi
   </Property>
 
   <Property name="cancel" type="Cancel">
-    Define an event that can be used to cancel a running or sleeping function ([reference](/docs/functions/cancellation))
+    Define an event that can be used to cancel a running or sleeping function ([guide](/docs/guides/cancel-running-functions))
     <Properties nested collapse>
       <Property name="event" type="str" required>
         The event name which will be used to cancel

--- a/pages/docs/reference/typescript/functions/cancel-on.mdx
+++ b/pages/docs/reference/typescript/functions/cancel-on.mdx
@@ -1,6 +1,6 @@
 import { InformationCircleIcon } from '@heroicons/react/24/outline'
 
-# Cancel running functions
+# Cancel on
 
 Stop the execution of a running function when a specific event is received using `cancelOn`.
 
@@ -85,7 +85,7 @@ Match expressions can be simple equalities or be more complex. Read [our guide t
 
 <Properties>
   <Property name="cancelOn" type="array of objects">
-    Define events that can be used to cancel a running or sleeping function ([reference](/docs/functions/cancellation))
+    Define events that can be used to cancel a running or sleeping function
     <Properties nested={true}>
       <Property name="event" type="string" required>
         The event name which will be used to cancel

--- a/pages/patterns/_patterns/event-coordination-for-lost-customers.mdx
+++ b/pages/patterns/_patterns/event-coordination-for-lost-customers.mdx
@@ -108,4 +108,4 @@ These are both possible within Inngest and using traditional queueing systems, a
 - [Reference: `step.waitForEvent()`](/docs/reference/functions/step-wait-for-event)
 - [Reference: `step.run()`](/docs/reference/functions/step-run)
 - [Reference: `step.sleep()`](/docs/reference/functions/step-sleep)
-- [Reference: `cancelOn`](/docs/functions/cancellation)
+- [Guide: Cancel running functions](/docs/guides/cancel-running-functions)

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -660,9 +660,8 @@ const sectionReference: NavGroup[] = [
         href: `/docs/reference/functions/handling-failures`,
       },
       {
-        title: "Cancel running functions",
-        href: `/docs/functions/cancellation`,
-        // href: `/docs/reference/functions/cancel-running-functions`,
+        title: "Cancel on",
+        href: `/docs/reference/typescript/functions/cancel-on`,
       },
       {
         title: "Concurrency",


### PR DESCRIPTION
These pages had the same name which caused confusion in docs search and likely SEO weirdness. The guide should be the goto link with the reference only living on purely for reference. We may delete the reference at some point in the future.