### PR TITLE
Corrected code snippet + typo batch edits

### DIFF
--- a/pages/ai.tsx
+++ b/pages/ai.tsx
@@ -530,7 +530,7 @@ const DevelopmentCopy = () => {
               can use
             </li>
             <li className="flex items-center mb-4">
-              <Check size={14} className="mr-2" /> Simple, retryable steps using
+              <Check size={14} className="mr-2" /> Simple, retriable steps using
               `step.run`
             </li>
             <li className="flex items-center mb-4">

--- a/pages/blog/_posts/5-lessons-learned-from-taking-next-js-app-router-to-production.md
+++ b/pages/blog/_posts/5-lessons-learned-from-taking-next-js-app-router-to-production.md
@@ -14,7 +14,7 @@ We recently redesigned the Inngest Dashboard to account for new features (branch
 
 ## Why use the App Router?
 
-Before we dive in, it's good to understand _why_ to use the App Router. [There are several](https://www.youtube.com/watch?v=DrxiNfbr63s) [resources](https://www.youtube.com/watch?v=gSSsZReIFRk) from the Next.js team explaining the benefits of the the new router, but why did _our team_ decide to use it now?
+Before we dive in, it's good to understand _why_ to use the App Router. [There are several](https://www.youtube.com/watch?v=DrxiNfbr63s) [resources](https://www.youtube.com/watch?v=gSSsZReIFRk) from the Next.js team explaining the benefits of the new router, but why did _our team_ decide to use it now?
 
 Our previous app was built using [Create React App](https://create-react-app.dev/) and React Router, so switching to Next.js in general gave us some clear benefits:
 

--- a/pages/blog/_posts/accidentally-quadratic-evaluating-trillions-of-event-matches-in-real-time.mdx
+++ b/pages/blog/_posts/accidentally-quadratic-evaluating-trillions-of-event-matches-in-real-time.mdx
@@ -14,7 +14,7 @@ With Inngest, we allow developers to build event-driven functions that are able 
 
 ## Dynamic Event Filtering
 
-This is the core of the challenge that we have with Inngest. Inngest allows developers to create event-driven functions that can wait for additional events that match specific [filter expressions](/docs/reference/functions/step-wait-for-event#advanced-event-matching-with-if), or declare that functions should automatically be [be canceled by specific events](/docs/guides/cancel-running-functions). The hard part is abstracted away from the developer with a line of code.
+This is the core of the challenge that we have with Inngest. Inngest allows developers to create event-driven functions that can wait for additional events that match specific [filter expressions](/docs/reference/functions/step-wait-for-event#advanced-event-matching-with-if), or declare that functions should automatically be [be cancelled by specific events](/docs/guides/cancel-running-functions). The hard part is abstracted away from the developer with a line of code.
 
 As an example, this code allows the developer to pause a function in the middle of execution to wait for an `app/onboarding.completed` event with a payload that matches the value of the `data.userId` exactly:
 
@@ -43,7 +43,7 @@ As Inngest is event-driven, there are two types of event matching that happens i
 
 The first type are long-lived matchers which trigger functions to run. These are mostly generic matchers based on an event name, for example `app/user.created`.
 
-The second type are ephemeral matchers which only exist during the life of a running function. These matchers contain explicit matching statements that are relevant to the running function itself. For example, if a function is started using the `app/user.created` event, the function should only be canceled by an `app/user.deleted` event with a matching `userId`.
+The second type are ephemeral matchers which only exist during the life of a running function. These matchers contain explicit matching statements that are relevant to the running function itself. For example, if a function is started using the `app/user.created` event, the function should only be cancelled by an `app/user.deleted` event with a matching `userId`.
 
 ```js
 inngest.createFunction(
@@ -63,7 +63,7 @@ To visualize how ephemeral event matchers are created and removed through the li
 These ephemeral matching statements might be used in various use cases:
 
 - A human-in-the-middle AI workflow that needs to pause and wait for approval to continue execution.
-- A function that schedules the publishing of a blog post that must be canceled if the user updates the status back to a draft.
+- A function that schedules the publishing of a blog post that must be cancelled if the user updates the status back to a draft.
 - A data pipeline that needs to restart (cancel + start again) if data in the source changes.
 - An onboarding email campaign that changes depending on if a user does or does not complete a funnel action within a desired time.
 

--- a/pages/blog/_posts/ai-in-production-managing-capacity-with-flow-control.mdx
+++ b/pages/blog/_posts/ai-in-production-managing-capacity-with-flow-control.mdx
@@ -1,6 +1,6 @@
 ---
 heading: 'AI in production: Managing capacity with flow control'
-subtitle: What do you need to to take your LLM based product from demo to production?
+subtitle: What do you need to take your LLM based product from demo to production?
 showSubtitle: true
 image: /assets/blog/ai-in-production-managing-capacity-with-flow-control.png
 imageCredits: Image by <a href="https://unsplash.com/@didsss">Didssph</a> on <a href="https://unsplash.com/">Unsplash</a>

--- a/pages/blog/_posts/ai-personalization-and-the-future-of-developer-docs.md
+++ b/pages/blog/_posts/ai-personalization-and-the-future-of-developer-docs.md
@@ -126,7 +126,7 @@ We make sure to use Inngest’s step tooling here to provide retries to the repl
 
 AI’s here to stay, and more obvious patterns are emerging for how it can help us. There are fantastic examples of AI helping us learn already being demonstrated, such as [Supabase's Clippy](https://supabase.com/blog/chatgpt-supabase-docs?ref=inngest), [Astro's Houston](https://houston.astro.build/) and [Dagster's support bot](https://dagster.io/blog/chatgpt-langchain).
 
-Even specific to just software, personalizing learning experiences will accelerate the pace at which we can build and communicate concepts across the entire community; examples such as this are just the beginning.
+Even specific to just software, personalizing learning experiences will accelerate the pace at which we can build and communicate concepts across the entire community; examples such as this one are just the beginning.
 
 Make sure to check out Inngest’s offering and see how we might be able to solve your problem today.
 

--- a/pages/blog/_posts/announcing-replay-the-death-of-the-dead-letter-queue.mdx
+++ b/pages/blog/_posts/announcing-replay-the-death-of-the-dead-letter-queue.mdx
@@ -66,7 +66,7 @@ Additionally, with a durable execution engine, Inngest is also responsible for e
 
 As Inngest's durable execution engine is built on top of queues, we can use this history to re-queue all of the jobs to re-execute the code that runs on your own infrastructure.
 
-Combined together, we can easily query for all jobs between two timestamps and filter only jobs that failed (or were canceled). It is as simple as selecting a function, the time range, and filter by the result of the job and clicking a button – no scripts needed!
+Combined together, we can easily query for all jobs between two timestamps and filter only jobs that failed (or were cancelled). It is as simple as selecting a function, the time range, and filter by the result of the job and clicking a button – no scripts needed!
 
 ![A graphic of a selected group of failed functions and a button with the text Replay Functions written on it](/assets/blog/announcing-replay/button-graphic.png)
 

--- a/pages/blog/_posts/build-more-reliable-workflows-with-events.mdx
+++ b/pages/blog/_posts/build-more-reliable-workflows-with-events.mdx
@@ -41,7 +41,7 @@ We don't think writing step functions or workflows as a large JSON configuration
 
 We also believe it should be simple to run, from local development, to production where code can be [deployed to any number of platforms](/docs/apps/cloud?ref=blog-build-more-reliable-workflows-with-events).
 
-Let's take a use case to demonstrate our approach. A product is a CRM tool that enables a user to upload a large CSV file with contacts information. The API triggers this to run with the event `api/contact_list.uploaded`. This advanced CRM tool validates the upload then uses third party APIs to enrich the data with information about the contact's business then waits for the user to review and filter this list down before inserting all data into the the CRM database. When the user approve or rejects and selects filers, the API will send another event: `api/contact_list.reviewed`. Here's what the code could look like:
+Let's take a use case to demonstrate our approach. A product is a CRM tool that enables a user to upload a large CSV file with contacts information. The API triggers this to run with the event `api/contact_list.uploaded`. This advanced CRM tool validates the upload then uses third party APIs to enrich the data with information about the contact's business then waits for the user to review and filter this list down before inserting all data into the CRM database. When the user approve or rejects and selects filers, the API will send another event: `api/contact_list.reviewed`. Here's what the code could look like:
 
 
 ```typescript

--- a/pages/blog/_posts/building-webhooks-that-scale.md
+++ b/pages/blog/_posts/building-webhooks-that-scale.md
@@ -29,7 +29,7 @@ If you’re already familiar with what a webhook is, you need to be aware of wha
 
 ## v0.1 - Handling webhooks on your existing backend
 
-Your version zero of your webhook likely starts with just adding a new endpoint onto your existing backend or API server to to handle your new webhook. This approach works for an MVP, but it’s only viable at low throughput to start.
+Your version zero of your webhook likely starts with just adding a new endpoint onto your existing backend or API server to handle your new webhook. This approach works for an MVP, but it’s only viable at low throughput to start.
 
 ![A simple webhook as part of your API server](/assets/blog/building-webhooks-that-scale/simple-webhook.png)
 

--- a/pages/blog/_posts/how-durable-workflow-engines-work.mdx
+++ b/pages/blog/_posts/how-durable-workflow-engines-work.mdx
@@ -94,7 +94,7 @@ async ({ event, step }) => {
 };
 ```
 
-This function uses workflow engine primitives to create reliable, retryable steps within a single block
+This function uses workflow engine primitives to create reliable, retriable steps within a single block
 of code.  Workflow engines should retry steps on error - whether that's a network error, worker crash, or some other
 failure.  Each step's data should be recorded in "memory", available for use later within the function.
 

--- a/pages/blog/_posts/launch-week-recap.mdx
+++ b/pages/blog/_posts/launch-week-recap.mdx
@@ -26,7 +26,7 @@ Let’s look at each of the major milestones we achieved this week.
 
 Inngest Replay is the easiest way to recover from incidents with just a couple of clicks. Within our team, we also call it the death of the dead-letter queue ☠️
 
-With Replay, you can easily query for all jobs between two timestamps and filter only jobs that failed (or were canceled). It is as simple as selecting a function, the time range, and filter by the result of the job and clicking a button – no scripts needed!
+With Replay, you can easily query for all jobs between two timestamps and filter only jobs that failed (or were cancelled). It is as simple as selecting a function, the time range, and filter by the result of the job and clicking a button – no scripts needed!
 
 ➡️ Read ["Inngest Replay"](/blog/announcing-replay-the-death-of-the-dead-letter-queue) blog post.
 

--- a/pages/blog/_posts/migrating-from-vite-to-nextjs.mdx
+++ b/pages/blog/_posts/migrating-from-vite-to-nextjs.mdx
@@ -166,7 +166,7 @@ export default function RootLayout({
 }
 ```
 
-1. Any [metadata files](https://nextjs.org/docs/app/building-your-application/optimizing/metadata#file-based-metadata) such as `favicon.ico`, `icon.png`, `robots.txt` are automatically added to the app `<head>` tag as long as you have them to to the top level of the `app` directory. After moving [all supported files](https://nextjs.org/docs/app/building-your-application/optimizing/metadata#file-based-metadata) into the `app` directory you can safely delete their `<link>` tags.
+1. Any [metadata files](https://nextjs.org/docs/app/building-your-application/optimizing/metadata#file-based-metadata) such as `favicon.ico`, `icon.png`, `robots.txt` are automatically added to the app `<head>` tag as long as you have them to the top level of the `app` directory. After moving [all supported files](https://nextjs.org/docs/app/building-your-application/optimizing/metadata#file-based-metadata) into the `app` directory you can safely delete their `<link>` tags.
 
 ```tsx
 export default function RootLayout({

--- a/pages/blog/_posts/open-source-event-driven-queue.md
+++ b/pages/blog/_posts/open-source-event-driven-queue.md
@@ -9,7 +9,7 @@ In recent years, products have grown more and more complex — which requires m
 
 We’re bullish on our ideas on how to address the annoyances of building these systems using standard, simple interfaces and a developer-focused approach.
 
-Today, we’re taking the the first step to open sourcing the core of Inngest so more developers can benefit from and influence it’s development. Our first release is to extract core components from Inngest’s platform and embed them in our cli as [the brand new Inngest DevServer](/blog/introducing-inngest-dev-server), which brings this better UX to your own machine. We use the same executor code internally and plan to open source additional components, like our own state store.
+Today, we’re taking the first step to open sourcing the core of Inngest so more developers can benefit from and influence it’s development. Our first release is to extract core components from Inngest’s platform and embed them in our cli as [the brand new Inngest DevServer](/blog/introducing-inngest-dev-server), which brings this better UX to your own machine. We use the same executor code internally and plan to open source additional components, like our own state store.
 
 Let’s share some context of what those problems are that we’re taking on first, how we’re looking to improve them, and our open source plans.
 

--- a/pages/blog/_posts/run-nextjs-functions-in-the-background.mdx
+++ b/pages/blog/_posts/run-nextjs-functions-in-the-background.mdx
@@ -96,7 +96,7 @@ export default serve("My App", [
 ```
 {/* TODO - update this with new SDK */}
 
-Great! You've done all the hard work already. You can always add or remove functions as your app grows. The best part is your code stays in your existing repo right alongside everything else. Go ahead and merge your code and let your platform automatically deploy your code.
+Great! You've done all the hard work already. You can always add or remove functions as your app grows. The best part is your code stays in your existing repository right alongside everything else. Go ahead and merge your code and let your platform automatically deploy your code.
 
 ### Syncing with Inngest
 

--- a/pages/blog/_posts/simple-testable-step-functions.mdx
+++ b/pages/blog/_posts/simple-testable-step-functions.mdx
@@ -7,7 +7,7 @@ date: 2022-08-18
 
 Serverless functions are fantastic for reducing your operational burden. For a long time, though, they’ve been limited to more basic API handlers, or small scripts that don’t live within your core infrastructure.  Anything more complex requires orchestration or heading into the complexity of AWS’ step functions.
 
-**With our latest release we’re excited to launch language-agnostic, locally testable step functions**.  You can now compose complex sequences of logic as [DAGs](https://en.wikipedia.org/wiki/Directed_acyclic_graph) — using any language, without any infrastructure, queues, state, or config.
+**With our latest release we’re excited to launch language-agnostic, locally testable step functions**.  You can now compose complex sequences of logic as [DAGs](https://en.wikipedia.org/wiki/Directed_acyclic_graph) — using any language, without any infrastructure, queues, state, or configuration.
 
 Let’s show you an example, then talk about their uses, benefits and how they work — plus our future plans for things like integrating webassembly and a local step-over debugger.
 

--- a/pages/blog/_posts/vercel-cloudflare-wait-until.mdx
+++ b/pages/blog/_posts/vercel-cloudflare-wait-until.mdx
@@ -16,7 +16,7 @@ To understand what `waitUntil` does and why it exists, let's talk about how serv
 
 Serverless functions are designed to be [stateless](https://www.redhat.com/en/topics/cloud-native-apps/stateful-vs-stateless) and short-lived. Unlike traditional servers, serverless functions are not kept alive between requests. Instead, they are spun up on-demand to handle incoming requests and then shut down once the response is sent.
 
-With JavaScript serverless functions, you have to `await` all asynchronous operations to ensure that the function doesn't return before the asynchronous operation is complete. If you don't `await` an asynchronous operation, the serverless function might be shut down before the operation is complete. If this happens, the operation might be canceled or fail which results in unpredictable behavior. This is why it's important to `await` all asynchronous operations in serverless functions.
+With JavaScript serverless functions, you have to `await` all asynchronous operations to ensure that the function doesn't return before the asynchronous operation is complete. If you don't `await` an asynchronous operation, the serverless function might be shut down before the operation is complete. If this happens, the operation might be cancelled or fail which results in unpredictable behavior. This is why it's important to `await` all asynchronous operations in serverless functions.
 
 ```js
 // ❌ BAD: If sendMetrics is an async function (a Promise), there is no guarantee it will succeed
@@ -63,7 +63,7 @@ In other words, `waitUntil` is not the tool for the job if the asynchronous oper
 
 Short answer: No.
 
-Long answer: `waitUntil` is not designed for running background jobs. There are no retries or tools for handling failures. Also, `waitUntil` will only run for as long as your function's timeout is set for, meaning if something takes longer than your timeout, it will be canceled. For running background jobs, you should use a system that handles queueing, retries, and logs failures.
+Long answer: `waitUntil` is not designed for running background jobs. There are no retries or tools for handling failures. Also, `waitUntil` will only run for as long as your function's timeout is set for, meaning if something takes longer than your timeout, it will be cancelled. For running background jobs, you should use a system that handles queueing, retries, and logs failures.
 
 Inngest is designed to handle background jobs reliably. It automatically handles retries, logs, and failures. If you need to run background jobs, you should consider using Inngest instead of `waitUntil`.
 

--- a/pages/customers/ocoya.mdx
+++ b/pages/customers/ocoya.mdx
@@ -52,7 +52,7 @@ allowed them to:
 * Rely on the same CI/CD process via Vercel
 
 Additionally, using Inngest allows for easier debugging: any failed
-functions are easily retryable, and the triggering event can be
+functions are easily retriable, and the triggering event can be
 copied and ran locally to instantly replay functions in development.
 
 With just a few weeks of development, an entire new product category

--- a/pages/docs/events/_event-format-and-structure.mdx
+++ b/pages/docs/events/_event-format-and-structure.mdx
@@ -30,7 +30,7 @@ The `user` object is a special field in Inngest Cloud. Sending data in this obje
 Inngest creates and stores a unified identity (aka profile) for each unique user that you send events for. You can think of it as performing an “upsert” for any data passed in the `user` object. There are two key ways to use this feature:
 
 - **Identifiers** - `id`, `email`, `phone`, or any field ending in `_id` will be used to match and group events together into a single identity. (Examples: `stripe_customer_id`, `zendesk_id`)
-- **Attributes** - Any non-identifier field will be stored as an an attribute for your own reference. Potential uses for attributes: `billing_plan` , `signup_source`, or `last_login_at`.
+- **Attributes** - Any non-identifier field will be stored as an attribute for your own reference. Potential uses for attributes: `billing_plan` , `signup_source`, or `last_login_at`.
 
 <aside>
   <p>🔐 <strong>Security</strong> - Each user's attributes is stored fully encrypted in our database using row-level encryption.  Each user gets its own encryption key which is permanently deleted when you delete the user from our system, which helps comply with GDPR and CCPA.</p>

--- a/pages/docs/functions/multi-step.mdx
+++ b/pages/docs/functions/multi-step.mdx
@@ -8,11 +8,11 @@ Critically, multi-step functions are written in code, not config, meaning you cr
 
 Writing multi-step functions provide you with some easy-to-use tools to create intuitive flows for your system.
 
-- Run retryable blocks of code to maximum reliability
+- Run retriable blocks of code to maximum reliability
 - Pause execution and Wait for an event matching rules before continuing
 - Pause for an amount of time or until a specified time
 
-This makes building reliable, distributed code simple. By wrapping asynchronous actions such as API calls in retryable blocks, we can ensure reliability when coordinating across many services.
+This makes building reliable, distributed code simple. By wrapping asynchronous actions such as API calls in retriable blocks, we can ensure reliability when coordinating across many services.
 
 ## Writing
 
@@ -186,7 +186,7 @@ Most importantly, we had to write no config to do this. We can use all the power
 
 For an in-depth reference of each step tool that you can use read [our create function reference](/docs/reference/functions/create#step) or jump directly to a step reference guide:
 
-- [`step.run()`](/docs/reference/functions/step-run) - Run synchronous or asynchronous code as a retryable step in your function
+- [`step.run()`](/docs/reference/functions/step-run) - Run synchronous or asynchronous code as a retriable step in your function
 - [`step.sleep()`](/docs/reference/functions/step-sleep) - Sleep for a given amount of time
 - [`step.sleepUntil()`](/docs/reference/functions/step-sleep-until) - Sleep until a given time
 - [`step.invoke()`](/docs/reference/functions/step-invoke) - Invoke another Inngest function as a step, receiving the result of the invoked function
@@ -211,7 +211,7 @@ await step.run("do-something", async () => {
 });
 ```
 
-Each call to `step.run()` is a single retryable step - a lightweight transaction.  Therefore, each step should have a single side effect.  For example, the below code is problematic:
+Each call to `step.run()` is a single retriable step - a lightweight transaction.  Therefore, each step should have a single side effect.  For example, the below code is problematic:
 
 ```ts
 await step.run("create-alert", async () => {

--- a/pages/docs/guides/background-jobs.mdx
+++ b/pages/docs/guides/background-jobs.mdx
@@ -3,7 +3,7 @@ This guide will walk you through creating background jobs with retries in a few 
 
 - You don't need to create queues, workers, or subscriptions
 - You can run background jobs on serverless functions without setting up infrastructure
-- You can enqueue jobs to run in the future, similar to a task queue, without any config.
+- You can enqueue jobs to run in the future, similar to a task queue, without any configuration.
 
 ## How to create background jobs
 

--- a/pages/docs/guides/error-handling.mdx
+++ b/pages/docs/guides/error-handling.mdx
@@ -19,7 +19,7 @@ A function that defines no steps is treated as a function with a single step, wh
 
 An **error** causes a step to retry. Exhausting all retry attempts will cause that step to **fail**, which means the step will never be attempted again this run.
 
-A **failed** step can be handled with native language features such as `try`/`catch`, but unhandled errors will cause the function to **fail**, meaning the run is marked as "Failed" in the Inngest UI and all future executions are canceled.
+A **failed** step can be handled with native language features such as `try`/`catch`, but unhandled errors will cause the function to **fail**, meaning the run is marked as "Failed" in the Inngest UI and all future executions are cancelled.
 
 Let's look at how to use and configure these retries.
 

--- a/pages/docs/guides/instrumenting-graphql.mdx
+++ b/pages/docs/guides/instrumenting-graphql.mdx
@@ -7,7 +7,7 @@ When building with GraphQL, you can give your event-driven application a kick-st
 {/* Describe that we can use a plugin for this, and how it's compatible */}
 {/* Mention Redwood */}
 
-We can do this using an an [Envelop](https://envelop.dev/) plugin, `useInngest`, for [GraphQL Yoga](https://the-guild.dev/graphql/yoga-server) and servers or frameworks powered by Yoga, such as [RedwoodJS](https://www.redwoodjs.com/).
+We can do this using an [Envelop](https://envelop.dev/) plugin, `useInngest`, for [GraphQL Yoga](https://the-guild.dev/graphql/yoga-server) and servers or frameworks powered by Yoga, such as [RedwoodJS](https://www.redwoodjs.com/).
 
 {/* Discuss the benefits of this */}
 

--- a/pages/docs/guides/logging.mdx
+++ b/pages/docs/guides/logging.mdx
@@ -2,28 +2,27 @@ import { Tag } from "src/shared/Docs/Tag";
 
 # Logging in Inngest <VersionBadge version="v2.0.0+" />
 
-Log handling could have some caveats when working with serverless runtimes.
+Log handling can have some caveats when working with serverless runtimes.
 
-One of the main problems is due to how serverless providers terminates after a function exits.
+One of the main problems is due to how serverless providers terminate after a function exits.
 There might not be enough time for a logger to finish flushing, which results in logs being lost.
 
-Another (opposite) problem is due to how Inngest handles memorization and code execution via HTTP calls to the SDK.
+Another (opposite) problem is due to how Inngest handles memoization and code execution via HTTP calls to the SDK.
 A log statement outside of `step` function could end up running multiple times, resulting in duplicated deliveries.
 
 ```ts {{ title: "example-fn.ts" }}
 async ({ event, step }) => {
-  logger.info("something") // this can be ran three times
+  logger.info("something") // this can be run three times
 
   await step.run("fn", () => {
-    logger.info("something else") // this will always be ran once
+    logger.info("something else") // this will always be run once
   })
 
   await step.run(...)
 }
 ```
 
-We provide a thin wrapper over existing logging tools, and export it to Inngest functions in order to mitigate these
-problems, so you as the user don't need to deal with it and things should work as you expect.
+We provide a thin wrapper over existing logging tools, and export it to Inngest functions in order to mitigate these problems, so you, as the user, don't need to deal with them and things should work as you expect.
 
 ## Usage
 
@@ -46,7 +45,7 @@ inngest.createFunction(
 );
 ```
 
-The exported logger provides the following interfaces.
+The exported logger provides the following interface methods:
 
 ```ts
 export interface Logger {
@@ -137,7 +136,7 @@ with.
 ### child logger
 
 If the logger library supports a child logger `.child()` implementation, the built-in middleware will utilize it to add
-function runtime metadata for you.
+function runtime metadata for you:
 
 - function name
 - event name
@@ -145,7 +144,7 @@ function runtime metadata for you.
 
 ## Loggers supported
 
-The following is a list of loggers we're aware of that works, but is not an exhaustive list.
+The following is a list of loggers we're aware of that work, but is not an exhaustive list:
 
 - [Winston][winston] <Tag>child logger support</Tag>
 - [Pino](https://github.com/pinojs/pino) <Tag>child logger support</Tag>
@@ -153,7 +152,7 @@ The following is a list of loggers we're aware of that works, but is not an exha
 - [Roarr](https://github.com/gajus/roarr) <Tag>child logger support</Tag>
 - [LogLevel](https://github.com/pimterry/loglevel)
 - [Log4js](https://github.com/log4js-node/log4js-node)
-- [npmlog](https://github.com/npm/npmlog) (don't have `.debug()` but has a way to add custom levels)
+- [npmlog](https://github.com/npm/npmlog) (doesn't have `.debug()` but has a way to add custom levels)
 - [Tracer](https://github.com/baryon/tracer)
 - [Signale](https://github.com/klaudiosinani/signale)
 

--- a/pages/docs/platform/webhooks.mdx
+++ b/pages/docs/platform/webhooks.mdx
@@ -97,7 +97,9 @@ function transform(evt, headers = {}, queryParams = {}) {
   return {
     name: `clerk/${evt.type}`,
     data: evt.data,
-    // You can optionally set "ts" using an
+    // You can optionally set ts using data from the raw json payload 
+    // to explicitly set the timestamp of the incoming event.
+    // If ts is not set, it will be automatically set to the time the request is received.
   }
 }
 ```

--- a/pages/docs/reference/functions/create.mdx
+++ b/pages/docs/reference/functions/create.mdx
@@ -237,7 +237,7 @@ If batching is not configured, the array contains a single event payload matchin
 
 The `step` object has methods that enable you to define
 
-- [`step.run()`](/docs/reference/functions/step-run) - Run synchronous or asynchronous code as a retryable step in your function
+- [`step.run()`](/docs/reference/functions/step-run) - Run synchronous or asynchronous code as a retriable step in your function
 - [`step.sleep()`](/docs/reference/functions/step-sleep) - Sleep for a given amount of time
 - [`step.sleepUntil()`](/docs/reference/functions/step-sleep-until) - Sleep until a given time
 - [`step.invoke()`](/docs/reference/functions/step-invoke) - Invoke another Inngest function as a step, receiving the result of the invoked function

--- a/pages/docs/reference/functions/step-run.mdx
+++ b/pages/docs/reference/functions/step-run.mdx
@@ -2,7 +2,7 @@ export const description = `Define steps to execute with step.run()`
 
 # Run
 
-Use `step.run()` to run synchronous or asynchronous code as a retryable step in your function. `step.run()` returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves with the return value of your handler function.
+Use `step.run()` to run synchronous or asynchronous code as a retriable step in your function. `step.run()` returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves with the return value of your handler function.
 
 ```ts
 export default inngest.createFunction(

--- a/pages/docs/reference/serve/index.mdx
+++ b/pages/docs/reference/serve/index.mdx
@@ -85,7 +85,7 @@ The API works by exposing a single endpoint at `/api/inngest` which handles diff
 
 If the framework that your application uses is not included in our list of [first-party supported frameworks](/docs/sdk/serve), you can create a custom `serve` handler.
 
-To create your own handler, check out the [example handler](https://github.com/inngest/inngest-js/blob/main/packages/inngest/src/test/functions/handler.ts) in our SDK's open source repo to understand how it works. Here's an example of a custom handler being created and used:
+To create your own handler, check out the [example handler](https://github.com/inngest/inngest-js/blob/main/packages/inngest/src/test/functions/handler.ts) in our SDK's open source repository to understand how it works. Here's an example of a custom handler being created and used:
 
 ```ts
 import { Inngest, InngestCommHandler, type ServeHandlerOptions } from "inngest";

--- a/pages/docs/reference/typescript/functions/cancel-on.mdx
+++ b/pages/docs/reference/typescript/functions/cancel-on.mdx
@@ -49,7 +49,7 @@ inngest.createFunction(
 );
 ```
 
-For the given function, this is an example of of an event that would trigger the function:
+For the given function, this is an example of an event that would trigger the function:
 
 
 ```json

--- a/pages/docs/typescript.mdx
+++ b/pages/docs/typescript.mdx
@@ -105,7 +105,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
 ### Using with `waitForEvent`
 
-When writing step functions, you can use `waitForEvent` to to, pause the current function until another event is received or the timeout expires - whichever happens first. When you declare your types using the `Inngest` constructor, `waitForEvent` leverages any types that you have:
+When writing step functions, you can use `waitForEvent` to pause the current function until another event is received or the timeout expires - whichever happens first. When you declare your types using the `Inngest` constructor, `waitForEvent` leverages any types that you have:
 
 <CodeGroup forceTabs filename="inngest/client.ts">
 ```ts {{ title: "v3" }}

--- a/pages/docs/usage-limits/providers.mdx
+++ b/pages/docs/usage-limits/providers.mdx
@@ -3,7 +3,7 @@
 As your functions' code runs on the hosting provider of your choice, you will be subject to provider or billing plan
 limits separate from [Inngest's own limits](/docs/usage-limits/inngest).
 
-Here are the the known usage limits for each provider we support based on their documentation.
+Here are the known usage limits for each provider we support based on their documentation.
 
 |                                         | Payload size  | Concurrency         | Timeout                    |
 |-----------------------------------------|:--------------|---------------------|----------------------------|

--- a/pages/patterns/_patterns/running-functions-in-parallel.mdx
+++ b/pages/patterns/_patterns/running-functions-in-parallel.mdx
@@ -1,6 +1,6 @@
 Event-driven systems allow you to have multiple subscribers for a single event stream.  This lets you [fan-out](https://en.wikipedia.org/wiki/Fan-out_(software)#Message-oriented_middleware) an event to multiple functions in parallel.  Running in parallel is useful for saparating logic into independent functions, and ensuring that each function retries independently on failure.
 
-This is different to how most queueing systems work.  In most queueing systems like SQS or Celery, a specific job in a queue runs a single function.  This may cause developers to bundle unrelated logic into a a single background job which isn't ideal as a failure in one part of your job may cause unrelated code to also fail.
+This is different to how most queueing systems work.  In most queueing systems like SQS or Celery, a specific job in a queue runs a single function.  This may cause developers to bundle unrelated logic into a single background job which isn't ideal as a failure in one part of your job may cause unrelated code to also fail.
 
 If you want to run 5 background jobs after a user signs up, using an event-driven system like Inngest you'll only have to send a single event.  In typical queueing systems you'll have to enqueue each 5 different messages individually.
 


### PR DESCRIPTION
A bunch of typo edits like:
- "canceled" -> "cancelled"
- "retryable" -> "retriable"
- "to to" -> "to"
- "an an" -> "an"
- "memorization" -> "memoization"
and a comment in a code snippet.