### PR TITLE
Changes the color of the "Previous" / "Next" buttons

### DIFF
--- a/shared/Button.tsx
+++ b/shared/Button.tsx
@@ -27,8 +27,11 @@ export function Button({
   };
 
   const variants = {
-    primary: "text-white bg-indigo-500 hover:bg-indigo-400",
-    secondary: "bg-slate-800/80 hover:bg-slate-700/80 text-white",
+    primary: "text-white bg-indigo-500 hover:bg-indigo-400 hover:text-white",
+    secondary: `
+      bg-slate-300/80 hover:bg-slate-300/100 text-slate-900 hover:text-slate-900,
+      dark:bg-slate-600/80 dark:hover:bg-slate-500/100 dark:text-white dark:hover:text-white
+    `,
     tertiary:
       "bg-slate-100 hover:bg-slate-300 text-slate-800 dark:bg-slate-800  dark:hover:bg-slate-700 dark:text-slate-100",
   };

--- a/shared/Docs/Footer.tsx
+++ b/shared/Docs/Footer.tsx
@@ -123,7 +123,7 @@ function PageLink({ label, page, previous = false }) {
       <Button
         href={page.href}
         aria-label={`${label}: ${page.title}`}
-        variant="primary"
+        variant="secondary"
         arrow={previous ? "left" : "right"}
         size="sm"
         className="not-prose"

--- a/shared/Docs/Footer.tsx
+++ b/shared/Docs/Footer.tsx
@@ -123,9 +123,10 @@ function PageLink({ label, page, previous = false }) {
       <Button
         href={page.href}
         aria-label={`${label}: ${page.title}`}
-        variant="secondary"
+        variant="primary"
         arrow={previous ? "left" : "right"}
         size="sm"
+        className="not-prose"
       >
         {label}
       </Button>

--- a/shared/Icons/ArrowRight.tsx
+++ b/shared/Icons/ArrowRight.tsx
@@ -7,8 +7,8 @@ export default function ArrowRight({
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
-      fill="currentColor"
       className={`${width}  ${height} ${className}`}
+      fill="currentColor"
     >
       <path
         fillRule="evenodd"


### PR DESCRIPTION
The previous color combo doesn't look great, and is not very accessbile

### BEFORE
<img width="1269" alt="Screenshot 2024-05-17 at 2 06 43 PM" src="https://github.com/inngest/website/assets/45401242/897d163d-5bc2-47b8-9b0d-eb11649fcac3">


### AFTER
<img width="1269" alt="Screenshot 2024-05-17 at 2 19 01 PM" src="https://github.com/inngest/website/assets/45401242/4826ca88-25da-48e0-acd2-1c861934bd5f">
