### PR TITLE
Add mdx to tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,10 +4,10 @@ const colors = require("tailwindcss/colors");
 module.exports = {
   darkMode: "class",
   content: [
-    "./app/**/*.{js,ts,jsx,tsx}",
-    "./pages/**/*.{js,ts,jsx,tsx}",
-    "./components/**/*.{js,ts,jsx,tsx}",
-    "./shared/**/*.{js,ts,jsx,tsx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./shared/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
     typography: require("./typography"),


### PR DESCRIPTION
Previously, only the Tailwind classes used elsewhere were recognized in the docs and blog, now any Tailwind classes can be used in `.mdx` files.