### PR TITLE
Example: Track failures in Datadog

### DIFF
--- a/pages/docs/examples/index.mdx
+++ b/pages/docs/examples/index.mdx
@@ -1,6 +1,6 @@
 import { ResourceGrid, Resource } from 'src/shared/Docs/Resources'
 import { EnvelopeIcon } from "@heroicons/react/24/outline";
-import { RiBracesFill, RiCalendarScheduleFill } from "@remixicon/react";
+import { RiBracesFill, RiCalendarScheduleFill, RiErrorWarningFill } from "@remixicon/react";
 
 export const hidePageSidebar = true;
 
@@ -8,7 +8,7 @@ export const hidePageSidebar = true;
 
 Explore the features built with Inngest:
 
-<ResourceGrid cols={3}>
+<ResourceGrid cols={2}>
 
 <Resource resource={{
   href: "/docs/examples/email-sequence",
@@ -32,6 +32,14 @@ Explore the features built with Inngest:
   icon: RiBracesFill,
   description: "Get the result of a run using an Event ID.",
   pattern: 3,
+}}/>
+
+<Resource resource={{
+  href: "/docs/examples/track-failures-in-datadog",
+  name: "Track all function failures in Datadog",
+  icon: RiErrorWarningFill,
+  description: "Send all function failures to Datadog (or similar) for monitoring.",
+  pattern: 1,
 }}/>
 
 </ResourceGrid>

--- a/pages/docs/examples/track-failures-in-datadog.mdx
+++ b/pages/docs/examples/track-failures-in-datadog.mdx
@@ -1,0 +1,102 @@
+import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
+import { Example } from 'src/shared/Docs/Examples';
+
+import { RiErrorWarningFill } from "@remixicon/react";
+
+
+export const description = "Create a function that handles all function failures in an Inngest environment and forwards them to Datadog.";
+
+# Track all function failures in Datadog
+
+Your functions may fail from time to time. Inngest provides a way to handle all failed functions in a single place. This can enable you to send metrics, alerts, or events to external systems like Datadog or Sentry for all of your Inngest functions.
+
+This page provides an example of tracking all function failures using [Datadog's Events API](https://docs.datadoghq.com/api/latest/events/) to send all failures the Datadog event stream. You could replace Datadog with whatever system you use for monitoring and alerting.
+
+## Quick Snippet
+
+Here is a basic function that uses the internal `"inngest/function.failed"` event. This event is triggered whenever any single function fails in your Inngest [environment](/docs/platform/environments).
+
+```ts
+import { client, v1 } from "@datadog/datadog-api-client";
+import { inngest } from "./client";
+
+const configuration = client.createConfiguration();
+const apiInstance = new v1.EventsApi(configuration);
+
+export default inngest.createFunction(
+  {
+    name: "Send failures to Datadog",
+    id: "send-failed-function-events-to-datadog"
+  },
+  { event: "inngest/function.failed" },
+  async ({ event, step }) => {
+    // This is a normal Inngest function, so we can use steps as we normally do:
+    await step.run("send-event-to-datadog", async () => {
+      const error = event.data.error;
+
+      // Create the Datadog event body using information about the failed function:
+      const params: v1.EventsApiCreateEventRequest = {
+        body: {
+          title: "Inngest Function Failed",
+          alert_type: "error",
+          text: `The ${event.data.function_id} function failed with the error: ${error.message}`,
+          tags: [
+            // Add a tag with the Inngest function id:
+            `inngest_function_id:${event.data.function_id}`,
+          ],
+        },
+      };
+
+      // Send to Datadog:
+      const data = await apiInstance.createEvent(params);
+
+      // Return the data to Inngest for viewing in function logs:
+      return { message: "Event sent successfully", data };
+    });
+  }
+);
+```
+
+An example failure event payload:
+
+```json
+{
+  "name": "inngest/function.failed",
+  "data": {
+    "error": {
+      "__serialized": true,
+      "error": "invalid status code: 500",
+      "message": "taylor@ok.com is already a list member. Use PUT to insert or update list members.",
+      "name": "Error",
+      "stack": "Error: taylor@ok.com is already a list member. Use PUT to insert or update list members.\n    at /var/task/.next/server/pages/api/inngest.js:2430:23\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async InngestFunction.runFn (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/components/InngestFunction.js:378:32)\n    at async InngestCommHandler.runStep (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/components/InngestCommHandler.js:459:25)\n    at async InngestCommHandler.handleAction (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/components/InngestCommHandler.js:359:33)\n    at async ServerTiming.wrap (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/helpers/ServerTiming.js:69:21)\n    at async ServerTiming.wrap (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/helpers/ServerTiming.js:69:21)"
+    },
+    "event": {
+      "data": { "billingPlan": "pro" },
+      "id": "01H0TPSHZTVFF6SFVTR6E25MTC",
+      "name": "user.signup",
+      "ts": 1684523501562,
+      "user": { "external_id": "6463da8211cdbbcb191dd7da" }
+    },
+    "function_id": "my-gcp-cloud-functions-app-hello-inngest",
+    "run_id": "01H0TPSJ576QY54R6JJ8MEX6JH"
+  },
+  "id": "01H0TPW7KB4KCR739TG2J3FTHT",
+  "ts": 1684523589227
+}
+```
+
+## More context
+
+Check the resources below to learn more about building email sequences with Inngest.
+
+<ResourceGrid cols={2}>
+
+<Resource resource={{
+  href: "/docs/reference/functions/handling-failures",
+  name: "Reference: TypeScript SDK failure handlers",
+  icon: RiErrorWarningFill,
+  description: "Learn how to use the onFailure handler to handle failures for a specific function.",
+  pattern: 1,
+}}/>
+
+</ResourceGrid>

--- a/pages/docs/reference/functions/handling-failures.mdx
+++ b/pages/docs/reference/functions/handling-failures.mdx
@@ -1,3 +1,6 @@
+import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
+import { RiErrorWarningFill } from "@remixicon/react";
+
 # Handling Failures
 
 Define any failure handlers for your function with the [`onFailure`](/docs/reference/functions/create#configuration) option. This function will be automatically called when your function fails after it's maximum number of retries. Alternatively, you can use the [`"inngest/function.failed"`](#the-inngest-function-failed-event) system event to handle failures across all functions.
@@ -185,51 +188,6 @@ export default inngest.createFunction(
 );
 ```
 
-### Track all function failures in Datadog
-
-You can use the `"inngest/function.failed"` event to handle all failed functions in a single place. This can enable you to send metrics, alerts, or events to external systems like Datadog or Sentry for all of your Inngest functions. Here's an example using [Datadog's Events API](https://docs.datadoghq.com/api/latest/events/) to send all failures the Datadog event stream.
-
-```ts
-import { client, v1 } from "@datadog/datadog-api-client";
-import { inngest } from "./client";
-
-const configuration = client.createConfiguration();
-const apiInstance = new v1.EventsApi(configuration);
-
-export default inngest.createFunction(
-  {
-    name: "Send failures to Datadog",
-    id: "send-failed-function-events-to-datadog"
-  },
-  { event: "inngest/function.failed" },
-  async ({ event, step }) => {
-    // This is a normal Inngest function, so we can use steps as we normally do:
-    await step.run("send-event-to-datadog", async () => {
-      const error = event.data.error;
-
-      // Create the Datadog event body using information about the failed function:
-      const params: v1.EventsApiCreateEventRequest = {
-        body: {
-          title: "Inngest Function Failed",
-          alert_type: "error",
-          text: `The ${event.data.function_id} function failed with the error: ${error.message}`,
-          tags: [
-            // Add a tag with the Inngest function id:
-            `inngest_function_id:${event.data.function_id}`,
-          ],
-        },
-      };
-
-      // Send to Datadog:
-      const data = await apiInstance.createEvent(params);
-
-      // Return the data to Inngest for viewing in function logs:
-      return { message: "Event sent successfully", data };
-    });
-  }
-);
-```
-
 ### Capture all failure errors with Sentry
 
 Similar to the above example, you can capture and all failed functions' errors and send them to a singular place. Here's an example using [Sentry's node.js library](https://docs.datadoghq.com/api/latest/events/) to capture and send all failure errors to Sentry.
@@ -273,3 +231,17 @@ export default inngest.createFunction(
   }
 );
 ```
+
+### Additional examples
+
+<ResourceGrid cols={2}>
+
+<Resource resource={{
+  href: "/docs/examples/track-failures-in-datadog",
+  name: "Track all function failures in Datadog",
+  icon: RiErrorWarningFill,
+  description: "Send all function failures to Datadog (or similar) for monitoring.",
+  pattern: 1,
+}}/>
+
+</ResourceGrid>

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -626,6 +626,10 @@ const sectionExamples: NavGroup[] = [
         title: "Fetch run status and output",
         href: `/docs/examples/fetch-run-status-and-output`,
       },
+      {
+        title: "Track all function failures in Datadog",
+        href: `/docs/examples/track-failures-in-datadog`,
+      },
     ],
   },
 ];


### PR DESCRIPTION
This better surfaces a popular question that we have in examples.

## Questions for reviewers:

* Should this be more generic, like "Tracking function failures in external tools"?
* Should we adjust the nav sidebar to handle longer page names?

<img width="374" alt="Screen Shot 2024-05-21 at 12 55 51 PM" src="https://github.com/inngest/website/assets/1509457/610f94b4-42cd-48de-a6be-507a4ca0b0c6">
