### PR TITLE
Create system events reference section

### DIFF
--- a/pages/docs/examples/track-failures-in-datadog.mdx
+++ b/pages/docs/examples/track-failures-in-datadog.mdx
@@ -1,7 +1,7 @@
 import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 import { Example } from 'src/shared/Docs/Examples';
 
-import { RiErrorWarningFill } from "@remixicon/react";
+import { RiBracesFill, RiErrorWarningFill } from "@remixicon/react";
 
 
 export const description = "Create a function that handles all function failures in an Inngest environment and forwards them to Datadog.";
@@ -14,7 +14,7 @@ This page provides an example of tracking all function failures using [Datadog's
 
 ## Quick Snippet
 
-Here is a basic function that uses the internal `"inngest/function.failed"` event. This event is triggered whenever any single function fails in your Inngest [environment](/docs/platform/environments).
+Here is a basic function that uses the internal [`"inngest/function.failed"`](/docs/reference/system-events/inngest-function-failed) event. This event is triggered whenever any single function fails in your Inngest [environment](/docs/platform/environments).
 
 ```ts
 import { client, v1 } from "@datadog/datadog-api-client";
@@ -92,11 +92,19 @@ Check the resources below to learn more about building email sequences with Inng
 <ResourceGrid cols={2}>
 
 <Resource resource={{
+  href: "/docs/reference/system-events/inngest-function-failed",
+  name: "Reference: inngest/function.failed system event",
+  icon: RiBracesFill,
+  description: "Learn more about the system event.",
+  pattern: 1,
+}}/>
+
+<Resource resource={{
   href: "/docs/reference/functions/handling-failures",
   name: "Reference: TypeScript SDK failure handlers",
   icon: RiErrorWarningFill,
   description: "Learn how to use the onFailure handler to handle failures for a specific function.",
-  pattern: 1,
+  pattern: 2,
 }}/>
 
 </ResourceGrid>

--- a/pages/docs/reference/functions/handling-failures.mdx
+++ b/pages/docs/reference/functions/handling-failures.mdx
@@ -54,7 +54,7 @@ The Inngest SDK attempts to serialize and deserialize the `Error` object to the 
 
 ### `event`
 
-The [`"inngest/function.failed"`](#the-inngest-function-failed-event) system event payload object. This object is similar to any event payload, but it contains data specific to the failed function's final retry attempt. [See the complete reference for this event payload below](#the-inngest-function-failed-event).
+The [`"inngest/function.failed"`](/docs/reference/system-events/inngest-function-failed) system event payload object. This object is similar to any event payload, but it contains data specific to the failed function's final retry attempt. [See the complete reference for this event payload here](/docs/reference/system-events/inngest-function-failed).
 
 ### `step`
 
@@ -63,79 +63,6 @@ The [`"inngest/function.failed"`](#the-inngest-function-failed-event) system eve
 ### `runId`
 
 This will be the function run ID for the error handling function, _not the function that failed_. To get the failed function's run ID, use `event.data.run_id`. [Learn more about `runId` here](/docs/reference/functions/create#run-id).
-
-
-## The `"inngest/function.failed"` event
-
-Inngest sends an `"inngest/function.failed"` event to your [environment](/docs/platform/environments) whenever any function fails after exhausting all of it's retry attempts. You can use this event as an `event` trigger within your own function or use the `onFailure` helper option as documented above.
-
-<Properties>
-  <Property name="name" type={`string: "inngest/function.failed"`} attribute>
-    The `inngest/` event prefix is reserved for system events in each environment.
-  </Property>
-  <Property name="data" type="object" attribute>
-    The event payload data.
-    <Properties nested>
-      <Property name="error" type="object" attribute>
-        Data about the error payload as returned from the failed function.
-        <Properties nested collapse>
-          <Property name="message" type="string" attribute>
-            The error message when an error is caught
-          </Property>
-          <Property name="name" type="string" attribute>
-            The name of the error, defaulting to "Error" if unspecified
-          </Property>
-          <Property name="stack" type="string">
-            The stack trace of the error, if supported by the language SDK
-          </Property>
-        </Properties>
-      </Property>
-      <Property name="event" type="string" attribute>
-        The failed function's original event payload.
-      </Property>
-      <Property name="function_id" type="string" attribute>
-        The failed function's [`id`](/docs/reference/functions/create#configuration)
-      </Property>
-      <Property name="run_id" type="string" attribute>
-        The failed function's function run ID.
-      </Property>
-    </Properties>
-  </Property>
-  <Property name="ts" type="number" attribute>
-    The timestamp integer in milliseconds at which the failure occurred.
-  </Property>
-</Properties>
-
-
-<details>
-  <summary><strong>Example "inngest/function.failed" event payload</strong></summary>
-
-  ```json
-  {
-    "name": "inngest/function.failed",
-    "data": {
-      "error": {
-        "__serialized": true,
-        "error": "invalid status code: 500",
-        "message": "taylor@ok.com is already a list member. Use PUT to insert or update list members.",
-        "name": "Error",
-        "stack": "Error: taylor@ok.com is already a list member. Use PUT to insert or update list members.\n    at /var/task/.next/server/pages/api/inngest.js:2430:23\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async InngestFunction.runFn (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/components/InngestFunction.js:378:32)\n    at async InngestCommHandler.runStep (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/components/InngestCommHandler.js:459:25)\n    at async InngestCommHandler.handleAction (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/components/InngestCommHandler.js:359:33)\n    at async ServerTiming.wrap (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/helpers/ServerTiming.js:69:21)\n    at async ServerTiming.wrap (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/helpers/ServerTiming.js:69:21)"
-      },
-      "event": {
-        "data": { "billingPlan": "pro" },
-        "id": "01H0TPSHZTVFF6SFVTR6E25MTC",
-        "name": "user.signup",
-        "ts": 1684523501562,
-        "user": { "external_id": "6463da8211cdbbcb191dd7da" }
-      },
-      "function_id": "my-gcp-cloud-functions-app-hello-inngest",
-      "run_id": "01H0TPSJ576QY54R6JJ8MEX6JH"
-    },
-    "id": "01H0TPW7KB4KCR739TG2J3FTHT",
-    "ts": 1684523589227
-  }
-  ```
-</details>
 
 ## Examples
 

--- a/pages/docs/reference/system-events/inngest-function-failed.mdx
+++ b/pages/docs/reference/system-events/inngest-function-failed.mdx
@@ -1,0 +1,87 @@
+# `inngest/function.failed` {{ className: "not-prose" }}
+
+The `inngest/function.failed` event is triggered whenever any single function fails in your Inngest [environment]((/docs/platform/environments)).
+
+This event can be used to track all function failures in a single place, enabling you to send metrics, alerts, or events to external systems like Datadog or Sentry for all of your Inngest functions.
+
+The TypeScript SDK offers a short hand `onFailure` handler that can be used to handle this event for a specific function.
+
+## The event payload
+
+<Row>
+<Col>
+
+<Properties>
+  <Property name="name" type={`string: "inngest/function.failed"`} attribute>
+    The `inngest/` event prefix is reserved for system events in each environment.
+  </Property>
+  <Property name="data" type="object" attribute>
+    The event payload data.
+    <Properties nested>
+      <Property name="error" type="object" attribute>
+        Data about the error payload as returned from the failed function.
+        <Properties nested>
+          <Property name="message" type="string" attribute>
+            The error message when an error is caught
+          </Property>
+          <Property name="name" type="string" attribute>
+            The name of the error, defaulting to "Error" if unspecified
+          </Property>
+          <Property name="stack" type="string">
+            The stack trace of the error, if supported by the language SDK
+          </Property>
+        </Properties>
+      </Property>
+      <Property name="event" type="string" attribute>
+        The failed function's original event payload.
+      </Property>
+      <Property name="function_id" type="string" attribute>
+        The failed function's [`id`](/docs/reference/functions/create#configuration)
+      </Property>
+      <Property name="run_id" type="string" attribute>
+        The failed function's function run ID.
+      </Property>
+    </Properties>
+  </Property>
+  <Property name="ts" type="number" attribute>
+    The timestamp integer in milliseconds at which the failure occurred.
+  </Property>
+</Properties>
+
+</Col>
+<Col>
+
+```json {{ title: "Example payload" }}
+  {
+    "name": "inngest/function.failed",
+    "data": {
+      "error": {
+        "__serialized": true,
+        "error": "invalid status code: 500",
+        "message": "taylor@ok.com is already a list member. Use PUT to insert or update list members.",
+        "name": "Error",
+        "stack": "Error: taylor@ok.com is already a list member. Use PUT to insert or update list members.\n    at /var/task/.next/server/pages/api/inngest.js:2430:23\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async InngestFunction.runFn (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/components/InngestFunction.js:378:32)\n    at async InngestCommHandler.runStep (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/components/InngestCommHandler.js:459:25)\n    at async InngestCommHandler.handleAction (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/components/InngestCommHandler.js:359:33)\n    at async ServerTiming.wrap (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/helpers/ServerTiming.js:69:21)\n    at async ServerTiming.wrap (/var/task/node_modules/.pnpm/inngest@2.6.0_typescript@5.1.6/node_modules/inngest/helpers/ServerTiming.js:69:21)"
+      },
+      "event": {
+        "data": { "billingPlan": "pro" },
+        "id": "01H0TPSHZTVFF6SFVTR6E25MTC",
+        "name": "user.signup",
+        "ts": 1684523501562,
+        "user": { "external_id": "6463da8211cdbbcb191dd7da" }
+      },
+      "function_id": "my-gcp-cloud-functions-app-hello-inngest",
+      "run_id": "01H0TPSJ576QY54R6JJ8MEX6JH"
+    },
+    "id": "01H0TPW7KB4KCR739TG2J3FTHT",
+    "ts": 1684523589227
+  }
+  ```
+
+
+</Col>
+</Row>
+
+## Related resources
+
+* [TypeScript SDK: onFailure](/docs/reference/functions/handling-failures)
+* [Example: Track all function failures in Datadog](/docs/examples/track-failures-in-datadog)

--- a/pages/docs/reference/system-events/inngest-function-failed.mdx
+++ b/pages/docs/reference/system-events/inngest-function-failed.mdx
@@ -1,10 +1,10 @@
 # `inngest/function.failed` {{ className: "not-prose" }}
 
-The `inngest/function.failed` event is triggered whenever any single function fails in your Inngest [environment]((/docs/platform/environments)).
+The `inngest/function.failed` event is sent whenever any single function fails in your Inngest [environment]((/docs/platform/environments)).
 
-This event can be used to track all function failures in a single place, enabling you to send metrics, alerts, or events to external systems like Datadog or Sentry for all of your Inngest functions.
+This event can be used to track all function failures in a single place, enabling you to send metrics, alerts, or events to [external systems like Datadog or Sentry](/docs/examples/track-failures-in-datadog) for all of your Inngest functions.
 
-The TypeScript SDK offers a short hand `onFailure` handler that can be used to handle this event for a specific function.
+The TypeScript SDK offers a shorthand `onFailure` handler that can be used to handle this event for a specific function.
 
 ## The event payload
 
@@ -22,13 +22,13 @@ The TypeScript SDK offers a short hand `onFailure` handler that can be used to h
         Data about the error payload as returned from the failed function.
         <Properties nested>
           <Property name="message" type="string" attribute>
-            The error message when an error is caught
+            The error message when an error is caught.
           </Property>
           <Property name="name" type="string" attribute>
-            The name of the error, defaulting to "Error" if unspecified
+            The name of the error, defaulting to "Error" if unspecified.
           </Property>
           <Property name="stack" type="string">
-            The stack trace of the error, if supported by the language SDK
+            The stack trace of the error, if supported by the language SDK.
           </Property>
         </Properties>
       </Property>
@@ -36,10 +36,10 @@ The TypeScript SDK offers a short hand `onFailure` handler that can be used to h
         The failed function's original event payload.
       </Property>
       <Property name="function_id" type="string" attribute>
-        The failed function's [`id`](/docs/reference/functions/create#configuration)
+        The failed function's [`id`](/docs/reference/functions/create#configuration).
       </Property>
       <Property name="run_id" type="string" attribute>
-        The failed function's function run ID.
+        The failed function's [run ID](/docs/reference/functions/create#run-id).
       </Property>
     </Properties>
   </Property>

--- a/pages/docs/reference/system-events/inngest-function-failed.mdx
+++ b/pages/docs/reference/system-events/inngest-function-failed.mdx
@@ -4,7 +4,7 @@ The `inngest/function.failed` event is sent whenever any single function fails i
 
 This event can be used to track all function failures in a single place, enabling you to send metrics, alerts, or events to [external systems like Datadog or Sentry](/docs/examples/track-failures-in-datadog) for all of your Inngest functions.
 
-The TypeScript SDK offers a shorthand `onFailure` handler that can be used to handle this event for a specific function.
+Our SDKs offer shorthand ["on failure"](#related-resources) handler options that can be used to handle this event for a specific function.
 
 ## The event payload
 
@@ -83,5 +83,6 @@ The TypeScript SDK offers a shorthand `onFailure` handler that can be used to ha
 
 ## Related resources
 
-* [TypeScript SDK: onFailure](/docs/reference/functions/handling-failures)
+* [TypeScript SDK: onFailure handler](/docs/reference/functions/handling-failures)
+* [Python SDK: on_failure handler](/docs/reference/python/functions/create#on_failure)
 * [Example: Track all function failures in Datadog](/docs/examples/track-failures-in-datadog)

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -883,6 +883,16 @@ const sectionReference: NavGroup[] = [
       },
     ],
   },
+  {
+    title: "System events",
+    links: [
+      {
+        title: "inngest/function.failed",
+        href: "/docs/reference/system-events/inngest-function-failed",
+        className: "font-mono",
+      },
+    ],
+  },
 ];
 
 function linkSearch(groups: NavGroup[], pathname) {


### PR DESCRIPTION
Following #786, the reference for the event payload for this system/internal event should not be stuck within the TS SDK docs.

I called this "system events" as "internal events" feel like they are internal and should not be exposed, whereas "system" makes it feel like these are useful events that come from within the Inngest system itself.

Other events that we can document:
* `inngest/function.finished` - This could be useful to logging successes for a certain function, or just useful as a reference to understand what this is and how it's used for `invoke()`
* `inngest/function.invoked` - Just for reference to understand that this is used for `invoke()`