### PR TITLE
Wrap sidebar items

### DIFF
--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -115,7 +115,7 @@ function NavLink({
         <span className="absolute inset-y-0 left-0 w-px bg-slate-900/10 dark:bg-white/15" />
       )}
 
-      <span className={truncate ? "truncate" : ""}>{children}</span>
+      <span>{children}</span>
       {tag && <Tag color="indigo">{tag}</Tag>}
     </LinkOrHref>
   );


### PR DESCRIPTION
This PR no longer truncates the sidebar items.

### BEFORE

<img width="312" alt="image" src="https://github.com/inngest/website/assets/45401242/e1fa604c-bd6a-4fa0-911a-0e75a769db50">

### AFTER

<img width="306" alt="image" src="https://github.com/inngest/website/assets/45401242/ca9c84de-0207-42ed-9172-5663b14580bc">
