### PR TITLE
Feature example apps in the Python Quick Start

### DIFF
--- a/pages/docs/getting-started/quick-start/python.mdx
+++ b/pages/docs/getting-started/quick-start/python.mdx
@@ -8,7 +8,7 @@ export const description =
 This guide will teach you how to add Inngest to a FastAPI app and run an Inngest function.
 
 <Callout variant="info">
-  💡 If you prefer to explore code instead, here are example apps in the frameworks currently supported by Inngest: [DigitalOcean Functions](https://github.com/inngest/inngest-py/tree/main/examples/digital_ocean), [Django](https://github.com/inngest/inngest-py/tree/main/examples/django), [FastAPI](https://github.com/inngest/inngest-py/tree/main/examples/fast_api), [Flask](https://github.com/inngest/inngest-py/tree/main/examples/flask), and [Tornado](https://github.com/inngest/inngest-py/tree/main/examples/tornado). 
+  💡 If you prefer to explore code instead, here are example apps in the frameworks currently supported by Inngest:  [FastAPI](https://github.com/inngest/inngest-py/tree/main/examples/fast_api), [Django](https://github.com/inngest/inngest-py/tree/main/examples/django),  [Flask](https://github.com/inngest/inngest-py/tree/main/examples/flask), [DigitalOcean Functions](https://github.com/inngest/inngest-py/tree/main/examples/digital_ocean), and [Tornado](https://github.com/inngest/inngest-py/tree/main/examples/tornado). 
   
   Is your favorite framework missing here? Please open an issue on [GitHub](https://github.com/inngest/inngest-py)!
 </Callout>

--- a/pages/docs/getting-started/quick-start/python.mdx
+++ b/pages/docs/getting-started/quick-start/python.mdx
@@ -8,7 +8,9 @@ export const description =
 This guide will teach you how to add Inngest to a FastAPI app and run an Inngest function.
 
 <Callout variant="info">
-  💡 Inngest currently supports DigitalOcean Functions, Django, FastAPI, Flask, and Tornado. If you'd like support for your favorite framework please open an issue on [GitHub](https://github.com/inngest/inngest-py)!
+  💡 If you prefer to explore code instead, here are example apps in the frameworks currently supported by Inngest: [DigitalOcean Functions](https://github.com/inngest/inngest-py/tree/main/examples/digital_ocean), [Django](https://github.com/inngest/inngest-py/tree/main/examples/django), [FastAPI](https://github.com/inngest/inngest-py/tree/main/examples/fast_api), [Flask](https://github.com/inngest/inngest-py/tree/main/examples/flask), and [Tornado](https://github.com/inngest/inngest-py/tree/main/examples/tornado). 
+  
+  Is your favorite framework missing here? Please open an issue on [GitHub](https://github.com/inngest/inngest-py)!
 </Callout>
 
 ---


### PR DESCRIPTION
This PR gives visibility to the example apps at the top of the Python Quick Start:

<img width="705" alt="Screenshot 2024-05-24 at 2 03 52 PM" src="https://github.com/inngest/website/assets/45401242/d2598f19-7f7e-4edd-9f3c-8f7c679b82de">
