### PR TITLE
Document stack traces in TS SDK

### DIFF
--- a/pages/docs/reference/typescript/functions/errors.mdx
+++ b/pages/docs/reference/typescript/functions/errors.mdx
@@ -222,7 +222,7 @@ inngest.createFunction(
 
 ## Stack traces
 
-When calling out to other functions returning Promises, it can be helpful to await the Promise to ensure that the stack trace is preserved. This applies to functions executing in different cycles of the event loop, for example, when calling out to a database or an external API. This is especially useful when debugging errors in production.
+When calling functions that return Promises, await the Promise to ensure that the stack trace is preserved. This applies to functions executing in different cycles of the event loop, for example, when calling a database or an external API. This is especially useful when debugging errors in production.
 
 <CodeGroup>
   ```ts {{ title: "Returning Promise" }}

--- a/pages/docs/reference/typescript/functions/errors.mdx
+++ b/pages/docs/reference/typescript/functions/errors.mdx
@@ -252,7 +252,7 @@ When calling functions that return Promises, await the Promise to ensure that th
   ```
 </CodeGroup>
 
-Immediately returning the Promise will not include a pointer to the calling function in the stack trace. Awaiting the Promise will ensure that the stack trace includes the calling function.
+Please note that immediately returning the Promise will not include a pointer to the calling function in the stack trace. Awaiting the Promise will ensure that the stack trace includes the calling function.
 
 ## Learn more
 

--- a/pages/docs/reference/typescript/functions/errors.mdx
+++ b/pages/docs/reference/typescript/functions/errors.mdx
@@ -220,6 +220,40 @@ inngest.createFunction(
 );
 ```
 
+## Stack traces
+
+When calling out to other functions returning Promises, it can be helpful to await the Promise to ensure that the stack trace is preserved. This applies to functions executing in different cycles of the event loop, for example, when calling out to a database or an external API. This is especially useful when debugging errors in production.
+
+<CodeGroup>
+  ```ts {{ title: "Returning Promise" }}
+  inngest.createFunction(
+    { id: "update-recent-usage" },
+    { event: "app/update-recent-usage" },
+    async ({ event, step }) => {
+      // ...
+      await step.run("update in db", () => doSomeWork(event.data));
+      // ...
+    }
+  );
+  ```
+  ```ts {{ title: "Awaiting Promise" }}
+  inngest.createFunction(
+    { id: "update-recent-usage" },
+    { event: "app/update-recent-usage" },
+    async ({ event, step }) => {
+      // ...
+      await step.run("update in db", async () => {
+        return await doSomeWork(event.data);
+      });
+      // ...
+    }
+  );
+
+  ```
+</CodeGroup>
+
+Immediately returning the Promise will not include a pointer to the calling function in the stack trace. Awaiting the Promise will ensure that the stack trace includes the calling function.
+
 ## Learn more
 
 * Guide: [Error handling](/docs/guides/error-handling)


### PR DESCRIPTION
This adds a section on preserving stack traces for the TypeScript SDK, thank you @jpwilliams for suggesting this! Related thread: https://inngest.slack.com/archives/C05PV209Y66/p1716478919426769