### PR TITLE
change the examples icon

### DIFF
--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -5,6 +5,7 @@ import {
   LifebuoyIcon,
   PlayIcon,
   QuestionMarkCircleIcon,
+  LightBulbIcon,
 } from "@heroicons/react/24/outline";
 import GoIcon from "src/shared/Icons/Go";
 import GuideIcon from "src/shared/Icons/Guide";
@@ -980,7 +981,7 @@ export const menuTabs = [
   },
   {
     title: "Examples",
-    icon: CogIcon,
+    icon: LightBulbIcon,
     href: "/docs/examples",
     matcher: matchers.examples,
   },
@@ -1014,7 +1015,7 @@ export const topLevelNav = [
   },
   {
     title: "Examples",
-    icon: CogIcon,
+    icon: LightBulbIcon,
     href: "/docs/examples",
     matcher: matchers.examples,
     sectionLinks: sectionExamples,


### PR DESCRIPTION
This PR replaces the icon for Examples to be a lightbulb:
<img width="502" alt="Screenshot 2024-06-10 at 11 35 53 AM" src="https://github.com/inngest/website/assets/45401242/adbb71bb-3f07-44ac-b608-a41f32a3cf51">
