### PR TITLE
DEV-84: Add information about steps being separate HTTP calls

### DIFF
--- a/pages/docs/guides/multi-step-functions.mdx
+++ b/pages/docs/guides/multi-step-functions.mdx
@@ -142,7 +142,7 @@ You can read more about [Inngest steps](/docs/learn/inngest-steps) or jump direc
 - [`step.sendEvent()`](/docs/reference/functions/step-send-event): Send event(s) reliability within your function. Use this instead of `inngest.send()` to ensure reliable event delivery from within functions.
 
 <Callout>
-Please note that each step is executed as **a separate HTTP request**. To ensure efficient execution, place any non-deterministic logic (such as DB calls or API calls) within a `step.run()` call. Learn more about [working with loops in Inngest](/docs/guides/working-with-loops).
+Please note that each step is executed as **a separate HTTP request**. To ensure efficient execution, place any non-deterministic logic (such as DB calls or API calls) within a `step.run()` call. [Learn more](/docs/guides/working-with-loops).
 
 </Callout>
 

--- a/pages/docs/guides/multi-step-functions.mdx
+++ b/pages/docs/guides/multi-step-functions.mdx
@@ -141,6 +141,11 @@ You can read more about [Inngest steps](/docs/learn/inngest-steps) or jump direc
 - [`step.waitForEvent()`](/docs/reference/functions/step-wait-for-event): Pause a function's execution until another event is received.
 - [`step.sendEvent()`](/docs/reference/functions/step-send-event): Send event(s) reliability within your function. Use this instead of `inngest.send()` to ensure reliable event delivery from within functions.
 
+<Callout>
+Please note that each step is executed as **a separate HTTP request**. To ensure efficient execution, place any non-deterministic logic (such as DB calls or API calls) within a `step.run()` call. Learn more about [working with loops in Inngest](/docs/guides/working-with-loops).
+
+</Callout>
+
 ## Gotchas
 
 ### My function is running twice
@@ -232,10 +237,17 @@ const userBirthday = await step.run("get-user-birthday", async () => {
 await sleepUntil("wait-for-user-birthday", userBirthday);
 ```
 
+### Unexpected loop behavior
+
+Users often find that loops in their functions do not behave as expected, leading to repeated or inconsistent operations. This issue arises because each step in Inngest is executed as a separate HTTP request. The function re-enters from the beginning for each step execution, causing loops to restart unless properly managed. To correctly implement loops, treat each iteration as an independent step using `step.run()` and `step.sleep()`, and encapsulate non-deterministic logic within steps.
+
+Learn more about [working with loops in Inngest](/docs/guides/working-with-loops).
+
 
 ## Further reading
 
 More information on multi-step functions:
+- Docs guide: [working with loops in Inngest](/docs/guides/working-with-loops)
 - Blog post: ["Building an Event Driven Video Processing Workflow with Next.js, tRPC, and Inngest
 "](/blog/nextjs-trpc-inngest)
 - Blog post: ["Running chained LLMs with TypeScript in production"](/blog/running-chained-llms-typescript-in-production)

--- a/pages/docs/guides/multi-step-functions.mdx
+++ b/pages/docs/guides/multi-step-functions.mdx
@@ -239,7 +239,11 @@ await sleepUntil("wait-for-user-birthday", userBirthday);
 
 ### Unexpected loop behavior
 
-Users often find that loops in their functions do not behave as expected, leading to repeated or inconsistent operations. This issue arises because each step in Inngest is executed as a separate HTTP request. The function re-enters from the beginning for each step execution, causing loops to restart unless properly managed. To correctly implement loops, treat each iteration as an independent step using `step.run()` and `step.sleep()`, and encapsulate non-deterministic logic within steps.
+When using loops within functions, it is recommended to treat each iteration as it's own step or steps. 
+
+When [functions are run](/docs/learn/how-functions-are-executed), the function handler is re-executed from the start for each new step and previously completed steps are memoized. This means that iterations of loops will be run every re-execution, but code encapsulated within `step.run()` will not re-run. 
+
+If code within a loop is not encapsulated within a step, it will re-run multiple times, which can lead to confusing behavior, debugging, or [logging](/docs/guides/logging). This is why it is recommended to encapsulate non-deterministic code within a `step.run()` when working with loops.
 
 Learn more about [working with loops in Inngest](/docs/guides/working-with-loops).
 

--- a/pages/docs/guides/multi-step-functions.mdx
+++ b/pages/docs/guides/multi-step-functions.mdx
@@ -247,7 +247,7 @@ Learn more about [working with loops in Inngest](/docs/guides/working-with-loops
 ## Further reading
 
 More information on multi-step functions:
-- Docs guide: [working with loops in Inngest](/docs/guides/working-with-loops)
+- Docs guide: [working with loops in Inngest](/docs/guides/working-with-loops).
 - Blog post: ["Building an Event Driven Video Processing Workflow with Next.js, tRPC, and Inngest
 "](/blog/nextjs-trpc-inngest)
 - Blog post: ["Running chained LLMs with TypeScript in production"](/blog/running-chained-llms-typescript-in-production)

--- a/pages/docs/guides/working-with-loops.mdx
+++ b/pages/docs/guides/working-with-loops.mdx
@@ -145,6 +145,6 @@ When using `step.sleep` inside a loop, ensure it is combined with structuring th
 
 ## Next steps
 
-- Learn more about [Inngest execution model](/docs/learn/how-functions-are-executed).
-- Explore [multi-step functions](/docs/guides/multi-step-functions).
+- Docs explanation: [Inngest execution model](/docs/learn/how-functions-are-executed).
+- Docs guide: [multi-step functions](/docs/guides/multi-step-functions).
 - Blog post: ["How to import 1000s of items from any E-commerce API in seconds with serverless functions"](/blog/import-ecommerce-api-data-in-seconds).

--- a/pages/docs/guides/working-with-loops.mdx
+++ b/pages/docs/guides/working-with-loops.mdx
@@ -86,7 +86,48 @@ inngest.createFunction(
 
 Now, "hello" is printed only once, as expected.
 
-## Implementing Loops in Inngest
+## Loop example
+
+Here's [an example](/blog/import-ecommerce-api-data-in-seconds) of an Inngest function that imports all products from a Shopify store into a local system. This function iterates over all pages combining all products into a single array.
+
+```typescript
+export default inngest.createFunction(
+  { id: "shopify-product-import"},
+  { event: "shopify/import.requested" },
+  async ({ event, step }) => {
+    const allProducts = []
+    let cursor = null
+    let hasMore = true
+
+    // Use the event's "data" to pass key info like IDs
+    const session = await database.getShopifySession(event.data.storeId)
+
+    while (hasMore) {
+      const page = await step.run(`fetch-products-${pageNumber}`, async () => {
+        return await shopify.rest.Product.all({
+          session,
+          since_id: cursor,
+        })
+      })
+      // Combine all of the data into a single list
+      allProducts.push(...page.products)
+      if (page.products.length === 50) {
+        cursor = page.products[49].id
+      } else {
+        hasMore = false
+      }
+    }
+
+    // Now we have the entire list of products within allProducts!
+  }
+)
+```
+
+In the example above, each iteration of the loop is managed using `step.run()`, ensuring that **all non-deterministic logic (like fetching products from Shopify) is encapsulated within a step**. This approach guarantees that if the request fails, it will be retried automatically. This structure aligns with Inngest's execution model, where each step is a separate HTTP request, ensuring robust and consistent loop behavior.
+
+Read more about this use case in the [blog post](/blog/import-ecommerce-api-data-in-seconds).
+
+## Best practices: implementing loops in Inngest
 
 To ensure your loops run correctly within [Inngest's execution model](/docs/learn/how-functions-are-executed):
 
@@ -102,89 +143,8 @@ Place non-deterministic logic (like API calls, database queries, or random numbe
 
 When using `step.sleep` inside a loop, ensure it is combined with structuring the loop to handle each iteration as a separate step. This prevents the function from appearing to restart and allows for controlled timing between iterations.
 
-Consider this function:
-
-```typescript
-inngest.createFunction(
-  { id: "loop-sleep" },
-  { event: "test/loop.sleep" },
-  async ({ step }) => {
-    for (let i = 0; i < 3; i++) {
-      console.log("Loop iteration", i);
-      await step.sleep("sleep", "1s");
-      await step.run("log", () => {
-        console.log("Slept for 1 second");
-      });
-    }
-  },
-);
-```
-
-In the example, every step method is run in a separate HTTP request, which means Inngest needs to start the function from the beginning each time. The SDK receives a request, runs the next unmemoized step, and then exits early to report the results. So as Inngest runs each step, it gets further into the loop iterations.
-
-
-With this in mind, the above code will be executed in Inngest as follows:
-
-<CodeGroup forceTabs>
-```bash {{ title: "✅ How Inngest executes the code" }}
-
-# This is how Inngest executes the code above:
-
-<run start>
-
-Loop iteration 0
-
-Loop iteration 0
-<sleep>
-Slept for 1 second
-
-Loop iteration 0
-Loop iteration 1
-
-Loop iteration 0
-Loop iteration 1
-<sleep>
-Slept for 1 second
-
-Loop iteration 0
-Loop iteration 1
-Loop iteration 2
-
-Loop iteration 0
-Loop iteration 1
-Loop iteration 2
-<sleep>
-Slept for 1 second
-
-<run complete>
-```
-```bash {{ title: "❌ Common incorrect misconception" }}
-
-# This is a common assumption of how Inngest executes the code above.
-# It is not correct.
-
-<run start>
-
-Loop iteration 0
-<sleep>
-Slept for 1 second
-
-Loop iteration 1
-<sleep>
-Slept for 1 second
-
-Loop iteration 2
-<sleep>
-Slept for 1 second
-
-<run complete>
-```
-</CodeGroup>
-
-When writing an Inngest function, assume all code outside of `step.run` is executed multiple times. All code within `step.run` is executed once (if it ran successfully and does not need a retry).
-
-
 ## Next steps
 
 - Learn more about [Inngest execution model](/docs/learn/how-functions-are-executed).
 - Explore [multi-step functions](/docs/guides/multi-step-functions).
+- Blog post: ["How to import 1000s of items from any E-commerce API in seconds with serverless functions"](/blog/import-ecommerce-api-data-in-seconds).

--- a/pages/docs/guides/working-with-loops.mdx
+++ b/pages/docs/guides/working-with-loops.mdx
@@ -1,0 +1,190 @@
+export const description = 'Each step is executed as a separate HTTP request.';
+
+# Working with Loops in Inngest
+
+In Inngest each step in your function is executed as a separate HTTP request.  This means that for every step in your function, the function is re-entered, starting from the beginning, up to the point where the next step is executed. This [execution model](/docs/learn/how-functions-are-executed) helps in managing retries, timeouts, and ensures robustness in distributed systems.
+
+This page covers how to implement loops in your Inngest functions and avoid common pitfalls.
+
+## Simple function example
+
+Let's start with a simple example to illustrate the concept:
+
+```javascript
+inngest.createFunction(
+  { id: "simple-function" },
+  { event: "test/simple.function" },
+  async ({ step }) => {
+    console.log("hello");
+
+    await step.run("a", async () => { console.log("a") });
+    await step.run("b", async () => { console.log("b") });
+    await step.run("c", async () => { console.log("c") });
+  }
+);
+```
+
+In the above example, you will see "hello" printed four times, once for the initial function entry and once for each step execution (`a`, `b`, and `c`).
+
+
+<CodeGroup forceTabs>
+```bash {{ title: "✅ How Inngest executes the code" }}
+
+# This is how Inngest executes the code above:
+
+<run start>
+"hello"
+
+"hello"
+"a"
+
+"hello"
+"b"
+
+"hello"
+"c"
+<run complete>
+```
+```bash {{ title: "❌ Common incorrect misconception" }}
+
+# This is a common assumption of how Inngest executes the code above.
+# It is not correct.
+
+<run start>
+
+"hello"
+"a"
+"b"
+"c"
+
+<run complete>
+```
+</CodeGroup>
+
+Any non-deterministic logic (like database calls or API calls) must be placed inside a `step.run` call to ensure it is executed correctly within each step.
+
+With this in mind, here is how the previous example can be fixed:
+
+```ts
+inngest.createFunction(
+  { id: "simple-function" },
+  { event: "test/simple.function" },
+  async ({ step }) => {
+    await step.run("hello", () => { console.log("hello") });
+
+    await step.run("a", async () => { console.log("a") });
+    await step.run("b", async () => { console.log("b") });
+    await step.run("c", async () => { console.log("c") });
+  }
+);
+
+// hello
+// a
+// b
+// c
+```
+
+Now, "hello" is printed only once, as expected.
+
+## Implementing Loops in Inngest
+
+To ensure your loops run correctly within [Inngest's execution model](/docs/learn/how-functions-are-executed):
+
+### 1. Treat each loop iterations as a single step
+
+In a typical programming environment, loops maintain their state across iterations. In Inngest, each step re-executes the function from the beginning to ensure that only the failed steps will be re-tried. To handle this, treat each loop iteration as a separate step. This way, the loop progresses correctly, and each iteration builds on the previous one.
+
+### 2. Place non-deterministic logic inside steps
+
+Place non-deterministic logic (like API calls, database queries, or random number generation) inside `step.run` calls. This ensures that such operations are executed correctly and consistently within each step, preventing repeated execution with each function re-entry.
+
+### 3. Use sleep effectively
+
+When using `step.sleep` inside a loop, ensure it is combined with structuring the loop to handle each iteration as a separate step. This prevents the function from appearing to restart and allows for controlled timing between iterations.
+
+Consider this function:
+
+```typescript
+inngest.createFunction(
+  { id: "loop-sleep" },
+  { event: "test/loop.sleep" },
+  async ({ step }) => {
+    for (let i = 0; i < 3; i++) {
+      console.log("Loop iteration", i);
+      await step.sleep("sleep", "1s");
+      await step.run("log", () => {
+        console.log("Slept for 1 second");
+      });
+    }
+  },
+);
+```
+
+In the example, every step method is run in a separate HTTP request, which means Inngest needs to start the function from the beginning each time. The SDK receives a request, runs the next unmemoized step, and then exits early to report the results. So as Inngest runs each step, it gets further into the loop iterations.
+
+
+With this in mind, the above code will be executed in Inngest as follows:
+
+<CodeGroup forceTabs>
+```bash {{ title: "✅ How Inngest executes the code" }}
+
+# This is how Inngest executes the code above:
+
+<run start>
+
+Loop iteration 0
+
+Loop iteration 0
+<sleep>
+Slept for 1 second
+
+Loop iteration 0
+Loop iteration 1
+
+Loop iteration 0
+Loop iteration 1
+<sleep>
+Slept for 1 second
+
+Loop iteration 0
+Loop iteration 1
+Loop iteration 2
+
+Loop iteration 0
+Loop iteration 1
+Loop iteration 2
+<sleep>
+Slept for 1 second
+
+<run complete>
+```
+```bash {{ title: "❌ Common incorrect misconception" }}
+
+# This is a common assumption of how Inngest executes the code above.
+# It is not correct.
+
+<run start>
+
+Loop iteration 0
+<sleep>
+Slept for 1 second
+
+Loop iteration 1
+<sleep>
+Slept for 1 second
+
+Loop iteration 2
+<sleep>
+Slept for 1 second
+
+<run complete>
+```
+</CodeGroup>
+
+When writing an Inngest function, assume all code outside of `step.run` is executed multiple times. All code within `step.run` is executed once (if it ran successfully and does not need a retry).
+
+
+## Next steps
+
+- Learn more about [Inngest execution model](/docs/learn/how-functions-are-executed).
+- Explore [multi-step functions](/docs/guides/multi-step-functions).

--- a/pages/docs/learn/how-functions-are-executed.mdx
+++ b/pages/docs/learn/how-functions-are-executed.mdx
@@ -41,7 +41,7 @@ Inngest functions are defined with a series of steps that define the execution f
 Inngest functions execute incrementally, _step by step_. As a function is executed, the results of each step are returned to Inngest and persisted in a managed function state store. The steps that successfully executed are [_memoized_](https://en.wikipedia.org/wiki/Memoization). The function then resumes, skipping any steps that have already been completed and the SDK injects the data returned by the previous step into the function.
 
 <Callout variant="info">
-Each step in your function is executed as **a separate HTTP request**. Any non-deterministic logic (such as DB calls or API calls) must be placed within a `step.run` call to ensure it executes correctly in the context of the execution model.
+Each step in your function is executed as **a separate HTTP request**. Any non-deterministic logic (such as DB calls or API calls) must be placed within a `step.run()` call to ensure it executes correctly in the context of the execution model.
 </Callout>
 
 Let's look at an example of a function and walk through how it is executed:

--- a/pages/docs/learn/how-functions-are-executed.mdx
+++ b/pages/docs/learn/how-functions-are-executed.mdx
@@ -40,6 +40,10 @@ Inngest functions are defined with a series of steps that define the execution f
 
 Inngest functions execute incrementally, _step by step_. As a function is executed, the results of each step are returned to Inngest and persisted in a managed function state store. The steps that successfully executed are [_memoized_](https://en.wikipedia.org/wiki/Memoization). The function then resumes, skipping any steps that have already been completed and the SDK injects the data returned by the previous step into the function.
 
+<Callout variant="info">
+Each step in your function is executed as **a separate HTTP request**. Any non-deterministic logic (such as DB calls or API calls) must be placed within a `step.run` call to ensure it executes correctly in the context of the execution model.
+</Callout>
+
 Let's look at an example of a function and walk through how it is executed:
 
 ```typescript

--- a/pages/docs/learn/inngest-steps.mdx
+++ b/pages/docs/learn/inngest-steps.mdx
@@ -42,6 +42,10 @@ export default inngest.createFunction(
  
 The ID is also used to identify the function in the Inngest system.
 
+<Callout>
+Please note that each step is executed as **a separate HTTP request**. To ensure efficient execution, place any non-deterministic logic (such as DB calls or API calls) within a `step.run()` call.
+</Callout>
+
 ## Available Step Methods
 
 ### <a href="/docs/reference/functions/step-run" className="flex items-center gap-4"><IconConcurrency size="2rem"/><pre>step.run()</pre></a> {{anchor: false}}

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -146,6 +146,10 @@ const sectionGuides: NavGroup[] = [
         title: "Invoking functions directly",
         href: `/docs/guides/invoking-functions-directly`,
       },
+      {
+        title: "Working with loops",
+        href: `/docs/guides/working-with-loops`,
+      },
     ],
   },
   {


### PR DESCRIPTION
This PR aims to better inform our users about Inngest execution model, specifically when working with loops.

## New page

I've added a new page explaining the behavior.

➡️ [See preview](https://website-git-docs-http-callout-inngest.vercel.app/docs/guides/working-with-loops)

## New gotcha

I've added an additional gotcha on `/docs/guides/multi-step-functions`:

➡️ [See preview](https://website-git-docs-http-callout-inngest.vercel.app/docs/guides/multi-step-functions#unexpected-loop-behavior)

<details>
<summary> Screenshot </summary>
<img width="891" alt="Screenshot 2024-06-12 at 3 07 40 PM" src="https://github.com/inngest/website/assets/45401242/0bbe1522-881b-4225-96e4-4f0afa99b1bd">
</details>

## New callouts

I've added the following callouts:

### `/docs/learn/how-functions-are-executed`
➡️ [See preview](https://website-git-docs-http-callout-inngest.vercel.app/docs/learn/how-functions-are-executed#how-steps-are-executed)

<details>
<summary> Screenshot </summary>
<img width="891" alt="Screenshot 2024-06-12 at 3 08 19 PM" src="https://github.com/inngest/website/assets/45401242/d7615b0f-e1f4-438b-a7d7-dd595fadc984">
</details>

### `/docs/guides/multi-step-functions`
➡️ [See preview](https://website-git-docs-http-callout-inngest.vercel.app/docs/guides/multi-step-functions#step-reference)

<details>
<summary> Screenshot </summary>
<img width="891" alt="Screenshot 2024-06-12 at 3 07 25 PM" src="https://github.com/inngest/website/assets/45401242/a308dae7-5931-462b-8cfa-2c8cc9557199">
</details>

### `/docs/learn/inngest-steps`
➡️ [See preview](https://website-git-docs-http-callout-inngest.vercel.app/docs/learn/inngest-steps#anatomy-of-an-inngest-step)

<details>
<summary> Screenshot </summary>
<img width="891" alt="Screenshot 2024-06-12 at 3 08 08 PM" src="https://github.com/inngest/website/assets/45401242/6c0bc981-d2bb-4acc-930e-6e424d254498">
</details>


