### PR TITLE
Add separate serve instructions for CF Workers and CF Pages Functions

### DIFF
--- a/pages/docs/sdk/serve.mdx
+++ b/pages/docs/sdk/serve.mdx
@@ -174,6 +174,23 @@ export default {
 ```
 </CodeGroup>
 
+When developing locally with Wrangler and the `--remote` flag, your code is
+deployed and run remotely. To use this with a local Inngest Dev Server, you must
+use a tool such as [ngrok](https://ngrok.com/) or
+[localtunnel](https://theboroer.github.io/localtunnel-www/) to allow access to
+the Dev Server from the internet.
+
+```sh
+ngrok http 8288
+```
+
+```toml
+# wrangler.toml
+[vars]
+INNGEST_DEV = "https://YOUR_TUNNEL_URL.ngrok.app"
+INNGEST_SERVE_HOST = "http://localhost:3000" # force the Dev Server to access the app at this local URL
+```
+
 ## Framework: DigitalOcean Functions
 
 The DigitalOcean serve function allows you to deploy Inngest to DigitalOcean serverless functions.

--- a/pages/docs/sdk/serve.mdx
+++ b/pages/docs/sdk/serve.mdx
@@ -35,7 +35,8 @@ We provide framework-specific bindings to make this easy for common platforms:
 - [Astro](#framework-astro)
 - [AWS Lambda](#framework-aws-lambda)
 - [Bun.serve()](#bun-serve)
-- [Cloudflare](#framework-cloudflare)
+- [Cloudflare Pages Functions](#framework-cloudflare-pages-functions)
+- [Cloudflare Workers](#framework-cloudflare-workers)
 - [DigitalOcean functions](#framework-digital-ocean-functions)
 - [Express](#framework-express)
 - [Fastify](#framework-fastify)
@@ -127,9 +128,9 @@ Bun.serve({
 });
 ```
 
-## Framework: Cloudflare
+## Framework: Cloudflare Pages Functions
 
-You can import the Inngest API server when using <a href="https://developers.cloudflare.com/pages/platform/functions/" target="_blank" rel="nofollow">Cloudflare pages functions</a> or workers within `/functions/api/inngest.js`:
+You can import the Inngest API server when using <a href="https://developers.cloudflare.com/pages/platform/functions/" target="_blank" rel="nofollow">Cloudflare pages functions</a>  within `/functions/api/inngest.js`:
 
 <CodeGroup>
 ```ts {{ title: "v3" }}
@@ -147,7 +148,42 @@ import { serve } from "inngest/cloudflare";
 import { inngest } from "../../inngest/client";
 import fnA from "../../inngest/fnA"; // Your own function
 
-export const onRequest = serve(inngest, [fnA]);
+export const onRequest = serve({
+  client: inngest,
+  functions: [fnA],
+});
+```
+</CodeGroup>
+
+## Framework: Cloudflare Workers <VersionBadge version="v3.19.15+" />
+
+You can export `"inngest/cloudflare"`'s `serve()` as your Cloudflare Worker:
+
+<CodeGroup>
+```ts {{ title: "v3" }}
+import { serve } from "inngest/cloudflare";
+import { inngest } from "./client";
+import fnA from "./fnA";
+
+export default serve({
+  client: inngest,
+  functions: [fnA],
+});
+```
+</CodeGroup>
+
+The `serve()` call can also be spread to allow you to export more handlers
+within the same worker if needed:
+
+<CodeGroup>
+```ts {{ title: "v3" }}
+export default {
+  ...serve({
+    client: inngest,
+    functions: [fnA],
+  }),
+  // ...
+};
 ```
 </CodeGroup>
 

--- a/pages/docs/sdk/serve.mdx
+++ b/pages/docs/sdk/serve.mdx
@@ -166,7 +166,7 @@ import { inngest } from "./client";
 import fnA from "./fnA";
 
 export default {
-  serve({
+  fetch: serve({
     client: inngest,
     functions: [fnA],
   }),

--- a/pages/docs/sdk/serve.mdx
+++ b/pages/docs/sdk/serve.mdx
@@ -160,7 +160,7 @@ export const onRequest = serve({
 You can export `"inngest/cloudflare"`'s `serve()` as your Cloudflare Worker:
 
 <CodeGroup>
-```ts {{ title: "v3" }}
+```ts
 import { serve } from "inngest/cloudflare";
 import { inngest } from "./client";
 import fnA from "./fnA";
@@ -176,7 +176,7 @@ The `serve()` call can also be spread to allow you to export more handlers
 within the same worker if needed:
 
 <CodeGroup>
-```ts {{ title: "v3" }}
+```ts
 export default {
   ...serve({
     client: inngest,

--- a/pages/docs/sdk/serve.mdx
+++ b/pages/docs/sdk/serve.mdx
@@ -165,24 +165,11 @@ import { serve } from "inngest/cloudflare";
 import { inngest } from "./client";
 import fnA from "./fnA";
 
-export default serve({
-  client: inngest,
-  functions: [fnA],
-});
-```
-</CodeGroup>
-
-The `serve()` call can also be spread to allow you to export more handlers
-within the same worker if needed:
-
-<CodeGroup>
-```ts
 export default {
-  ...serve({
+  serve({
     client: inngest,
     functions: [fnA],
   }),
-  // ...
 };
 ```
 </CodeGroup>


### PR DESCRIPTION
## Summary

Adds separate sections for both Cloudflare Workers and Cloudflare Pages Functions within instructions for using `serve()` with Cloudflare.

Is the docs PR for inngest/inngest-js#619.

## Related

- inngest/inngest-js#619