### PR TITLE
 DEV-87 Docs: add information on sleep limits

### DIFF
--- a/pages/docs/guides/delayed-functions.mdx
+++ b/pages/docs/guides/delayed-functions.mdx
@@ -2,7 +2,7 @@ import { CodeGroup } from "src/shared/Docs/mdx";
 
 # Enqueueing future jobs
 
-You can easily enqueue jobs in the future with Inngest. Inngest offers two ways to run jobs in the future: delaying jobs for a specific amount of time (eg. run in 1 day), or running code at a specific date and time. There are some benefits to enqueuing jobs using Inngest:
+You can easily enqueue jobs in the future with Inngest. Inngest offers two ways to run jobs in the future: delaying jobs for a specific amount of time (up to a year, and for free plan up to seven days), or running code at a specific date and time. There are some benefits to enqueuing jobs using Inngest:
 
 - It works across any provider or platform
 - Delaying jobs is durable, and works across server restarts, serverless functions, and redeploys
@@ -38,7 +38,7 @@ export const fn = inngest.createFunction(
 ```
 </CodeGroup>
 
-For more information on `step.sleep()` read [the reference guide](/docs/reference/functions/step-sleep)
+For more information on `step.sleep()` read [the reference](/docs/reference/functions/step-sleep).
 
 
 ## Running at specific times
@@ -69,7 +69,7 @@ export const fn = inngest.createFunction(
 ```
 </CodeGroup>
 
-For more information on `step.sleepUntil()` [read the reference guide](/docs/reference/functions/step-sleep-until).
+For more information on `step.sleepUntil()` [read the reference](/docs/reference/functions/step-sleep-until).
 
 ## How it works
 

--- a/pages/docs/guides/multi-step-functions.mdx
+++ b/pages/docs/guides/multi-step-functions.mdx
@@ -3,7 +3,7 @@ export const description = `Build reliable workflows with event coordination and
 
 # Multi-Step Functions
 
-Use Inngest's multi-step functions to safely coordinate events, delay execution for hours, days, or months, retry [individual steps](/docs/learn/inngest-steps), and conditionally run code based on the result of previous steps and incoming events.
+Use Inngest's multi-step functions to safely coordinate events, delay execution for hours (or up to a year), retry [individual steps](/docs/learn/inngest-steps), and conditionally run code based on the result of previous steps and incoming events.
 
 Critically, multi-step functions are written in code, not config, meaning you create readable, obvious functionality that's easy to maintain.
 

--- a/pages/docs/guides/multi-step-functions.mdx
+++ b/pages/docs/guides/multi-step-functions.mdx
@@ -3,7 +3,7 @@ export const description = `Build reliable workflows with event coordination and
 
 # Multi-Step Functions
 
-Use Inngest's multi-step functions to safely coordinate events, delay execution for hours or _days_, retry [individual steps](/docs/learn/inngest-steps), and conditionally run code based on the result of previous steps and incoming events.
+Use Inngest's multi-step functions to safely coordinate events, delay execution for hours, days, or months, retry [individual steps](/docs/learn/inngest-steps), and conditionally run code based on the result of previous steps and incoming events.
 
 Critically, multi-step functions are written in code, not config, meaning you create readable, obvious functionality that's easy to maintain.
 

--- a/pages/docs/learn/inngest-steps.mdx
+++ b/pages/docs/learn/inngest-steps.mdx
@@ -67,7 +67,7 @@ export default inngest.createFunction(
 
 ### <a href="/docs/reference/functions/step-sleep" className="flex items-center gap-4"><IconConcurrency size="2rem"/><pre>step.sleep()</pre></a> {{anchor: false}}
 
-This method pauses execution for a specified duration. Even though it seems like a `setInterval`, your function does not run for that time (you don't use any compute). Inngest handles the scheduling for you. Use it to add delays or to wait for a specific amount of time before proceeding. At maximum, functions can sleep for a year (seven days for the free tier accounts).
+This method pauses execution for a specified duration. Even though it seems like a `setInterval`, your function does not run for that time (you don't use any compute). Inngest handles the scheduling for you. Use it to add delays or to wait for a specific amount of time before proceeding. At maximum, functions can sleep for a year (seven days for the [free tier plans](/pricing)).
 
 ```typescript
 export default inngest.createFunction(
@@ -82,7 +82,7 @@ export default inngest.createFunction(
 
 ### <a href="/docs/reference/functions/step-sleep-until" className="flex items-center gap-4"><IconConcurrency size="2rem"/><pre>step.sleepUntil()</pre></a> {{anchor: false}}
 
-This method pauses execution until a specific date time. Any date time string in the format accepted by the Date object, for example `YYYY-MM-DD` or `YYYY-MM-DDHH:mm:ss`. At maximum, functions can sleep for a year (seven days for the free tier accounts).
+This method pauses execution until a specific date time. Any date time string in the format accepted by the Date object, for example `YYYY-MM-DD` or `YYYY-MM-DDHH:mm:ss`. At maximum, functions can sleep for a year (seven days for the [free tier plans](/pricing)).
 
 ```typescript
 export default inngest.createFunction(

--- a/pages/docs/learn/inngest-steps.mdx
+++ b/pages/docs/learn/inngest-steps.mdx
@@ -67,7 +67,7 @@ export default inngest.createFunction(
 
 ### <a href="/docs/reference/functions/step-sleep" className="flex items-center gap-4"><IconConcurrency size="2rem"/><pre>step.sleep()</pre></a> {{anchor: false}}
 
-This method pauses execution for a specified duration. Even though it seems like a `setInterval`, your function does not run for that time. Inngest handles the scheduling for you. Use it to add delays or to wait for a specific amount of time before proceeding.
+This method pauses execution for a specified duration. Even though it seems like a `setInterval`, your function does not run for that time (you don't use any compute). Inngest handles the scheduling for you. Use it to add delays or to wait for a specific amount of time before proceeding. At maximum, functions can sleep for a year (seven days for the free tier accounts).
 
 ```typescript
 export default inngest.createFunction(
@@ -82,7 +82,7 @@ export default inngest.createFunction(
 
 ### <a href="/docs/reference/functions/step-sleep-until" className="flex items-center gap-4"><IconConcurrency size="2rem"/><pre>step.sleepUntil()</pre></a> {{anchor: false}}
 
-This method pauses execution until a specific date time. Any date time string in the format accepted by the Date object, for example `YYYY-MM-DD` or `YYYY-MM-DDHH:mm:ss`.
+This method pauses execution until a specific date time. Any date time string in the format accepted by the Date object, for example `YYYY-MM-DD` or `YYYY-MM-DDHH:mm:ss`. At maximum, functions can sleep for a year (seven days for the free tier accounts).
 
 ```typescript
 export default inngest.createFunction(

--- a/pages/docs/reference/functions/step-sleep-until.mdx
+++ b/pages/docs/reference/functions/step-sleep-until.mdx
@@ -6,7 +6,7 @@ export const description = `Sleep until a specific date time with step.sleepUnti
 
 Use `step.sleepUntil()` to pause the execution of your function until a specific date time.
 
-Please note that at maximum, functions can sleep for a year (seven days for the free tier accounts).
+Please note that at maximum, functions can sleep for a year (seven days for the [free tier plans](/pricing)).
 
 <CodeGroup>
 ```ts {{ title: "v3" }}

--- a/pages/docs/reference/functions/step-sleep-until.mdx
+++ b/pages/docs/reference/functions/step-sleep-until.mdx
@@ -6,6 +6,8 @@ export const description = `Sleep until a specific date time with step.sleepUnti
 
 Use `step.sleepUntil()` to pause the execution of your function until a specific date time.
 
+Please note that at maximum, functions can sleep for a year (seven days for the free tier accounts).
+
 <CodeGroup>
 ```ts {{ title: "v3" }}
 export default inngest.createFunction(

--- a/pages/docs/reference/functions/step-sleep.mdx
+++ b/pages/docs/reference/functions/step-sleep.mdx
@@ -2,7 +2,7 @@ import { Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from
 
 # Sleep `step.sleep()`
 
-Use `step.sleep()` to pause the execution of your function for a specific amount of time.
+Use `step.sleep()` to pause the execution of your function for a specific amount of time. At maximum, functions can sleep for a year (seven days for the free tier accounts).
 
 Functions that are sleeping do not count towards [concurrency](/docs/functions/concurrency) limits.
 

--- a/pages/docs/reference/functions/step-sleep.mdx
+++ b/pages/docs/reference/functions/step-sleep.mdx
@@ -2,7 +2,7 @@ import { Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from
 
 # Sleep `step.sleep()`
 
-Use `step.sleep()` to pause the execution of your function for a specific amount of time. At maximum, functions can sleep for a year (seven days for the free tier accounts).
+Use `step.sleep()` to pause the execution of your function for a specific amount of time. At maximum, functions can sleep for a year (seven days for the [free tier plans](/pricing)).
 
 Functions that are sleeping do not count towards [concurrency](/docs/functions/concurrency) limits.
 

--- a/pages/docs/usage-limits/inngest.mdx
+++ b/pages/docs/usage-limits/inngest.mdx
@@ -11,20 +11,23 @@ Some of these limits are customizable, so if you need more than what the current
 
 The following applies to `step` usage.
 
-**Timeout**
+### Sleep duration
 
-Each step has a timeout depending on the hosting provider of your choice ([see more info][provider-docs]),
-but Inngest supports up to `2 hours` at the maximum.
+Sleep (with `step.sleep()` and `step.sleepUntil()`) up to a year, and for free plan up to seven days. Check the [pricing page](/pricing) for more information.
 
-**Concurrency** <Tag>Customizable</Tag>
+### Timeout
+
+Each step has a timeout depending on the hosting provider of your choice ([see more info][provider-docs]), but Inngest supports up to `2 hours` at the maximum.
+
+### Concurrency <Tag>Customizable</Tag>
 
 Our free plan has a concurrency limit of `25`, and paid plans have concurrency limits of `100` (team), `500` (startup), and up to `20,000` (enterprise).
 
-**Payload Size**
+### Payload Size
 
 The limit for data returned by a step is `4MB`.
 
-**# of Steps per Function**
+### Number of Steps per Function
 
 The maximum number of steps allowed per function is `1000`.
 
@@ -38,15 +41,15 @@ The maximum number of steps allowed per function is `1000`.
 
 ## Events
 
-**Name length**
+### Name length
 
 The maximum length allowed for an event name is `256` characters.
 
-**Request Body Size** <Tag>Customizable</Tag>
+### Request Body Size <Tag>Customizable</Tag>
 
 The limit for each event request is `512KB`, though this can be increased up to `3MB` on request.
 
-**# of Events per request** <Tag>Customizable</Tag>
+### Number of events per request <Tag>Customizable</Tag>
 
 Maximum number of events you can send in one request is `5000`.
 If you're doing fan out, you'll need to be aware of this limitation when you run `step.sendEvent(events)`.


### PR DESCRIPTION
There's a recurring question about sleep maximum time on Discord.

This PR is adding information on the sleep limits on both the steps guide, and two reference pages (step.sleep, step.sleepUnti).