### PR TITLE
fix(docs): remove initial flash when loading the docs

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -26,28 +26,7 @@ export default class MyDocument extends Document {
             }}
           />
         </Head>
-        <body className="light-theme">
-          <script
-            type="text/javascript"
-            dangerouslySetInnerHTML={{
-              __html: `
-               (function(){
-                // Any page with a base path matching this will enable light mode
-                const THEME_SUPPORT = [
-                  "/docs",
-                  "/blog"
-                ];
-                 const hasThemeSupport = !!THEME_SUPPORT.find(function(p) {
-                  return document.location.pathname.indexOf(p) === 0;
-                 });
-                 const theme = window.localStorage.getItem("theme");
-                 if (hasThemeSupport && theme) {
-                  document.body.classList.add(theme + "-theme");
-                 }
-               })();
-              `,
-            }}
-          />
+        <body>
           <Main />
           <NextScript />
         </body>

--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -133,6 +133,9 @@ export function Layout({
 }
 
 const modeScript = `
+
+  document.documentElement.classList.add('docs');
+
   // change to "let = darkModeMediaQuery" if/when this moves to the _document
   window.darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
 


### PR DESCRIPTION
Fixes an issue related to light mode being applied on client side when loading the docs.

### TODO
- [x] run a full QA on the preview env, make sure the main website is not impacted ⚠️ 