### PR TITLE
Remove slugify call for app IDs

### DIFF
--- a/pages/docs/sdk/migration.mdx
+++ b/pages/docs/sdk/migration.mdx
@@ -165,7 +165,7 @@ When instantiating a client using `new Inngest()` or creating a function via `in
      <Col>
           <CodeGroup filename="✅ v3">
           ```ts
-          import { Inngest, slugify } from "inngest";
+          import { Inngest } from "inngest";
 
           export const inngest = new Inngest({
             id: "My App",

--- a/pages/docs/sdk/migration.mdx
+++ b/pages/docs/sdk/migration.mdx
@@ -65,7 +65,7 @@ This is only needed to ensure function runs started on v2 will transition to v3;
           import { serve } from "inngest/next";
 
           const inngest = new Inngest({
-            id: slugify("My App"),
+            id: "My App",
           });
 
           const fn = inngest.createFunction(
@@ -168,7 +168,7 @@ When instantiating a client using `new Inngest()` or creating a function via `in
           import { Inngest, slugify } from "inngest";
 
           export const inngest = new Inngest({
-            id: slugify("My App"),
+            id: "My App",
           });
           ```
           </CodeGroup>


### PR DESCRIPTION
We don't want users calling `slugify` on app IDs since it could change the app ID, which will make us think it's a new app