### PR TITLE
Remove duplicated glossary

### DIFF
--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -64,11 +64,6 @@ const sectionGettingStarted: NavGroup[] = [
         href: `/docs/learn/glossary`,
         tag: "New",
       },
-      {
-        title: "Glossary",
-        href: `/docs/learn/glossary`,
-        tag: "New",
-      },
       { title: "Installing the SDK", href: `/docs/sdk/overview` },
       { title: "Serving the API & Frameworks", href: `/docs/sdk/serve` },
       { title: "Sending Events", href: `/docs/events` },


### PR DESCRIPTION
I didn't notice the duplicated menu item after merging main into the "New labels" PR.

<img width="318" alt="Screenshot 2024-07-09 at 4 53 06 PM" src="https://github.com/inngest/website/assets/45401242/0ee3430e-5ed0-409c-8407-7cfba62a81f6">
