### PR TITLE
DEV-82: remove vertical line on the sidebar

### DIFF
--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -104,16 +104,14 @@ function NavLink({
       target={target}
       className={clsx(
         "flex justify-between items-center gap-2 py-1 pr-3 text-sm transition group", // group for nested hovers
-        isTopLevel || isAnchorLink ? "pl-0" : "pl-4",
+        isTopLevel || isAnchorLink ? "pl-0" : "pl-1",
         active
-          ? "font-semibold text-black dark:text-white"
+          ? "font-semibold text-black dark:text-white bg-slate-700/10 dark:bg-white/10"
           : "font-medium text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white",
         className
       )}
     >
-      {!isAnchorLink && (
-        <span className="absolute inset-y-0 left-0 w-px bg-slate-900/10 dark:bg-white/15" />
-      )}
+      {!isAnchorLink && <span className="absolute inset-y-0 left-0 w-px" />}
 
       <span>{children}</span>
       {tag && <Tag color="indigo">{tag}</Tag>}

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -103,8 +103,7 @@ function NavLink({
       aria-current={active ? "page" : undefined}
       target={target}
       className={clsx(
-        "flex justify-between items-center gap-2 py-1 pr-3 text-sm transition group", // group for nested hovers
-        isTopLevel || isAnchorLink ? "pl-0" : "pl-1",
+        "flex justify-between items-center gap-2 py-1 pr-3 text-sm transition group pl-0", // group for nested hovers
         active
           ? "font-semibold text-black dark:text-white bg-slate-700/10 dark:bg-white/10"
           : "font-medium text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white",
@@ -286,7 +285,7 @@ function NavigationGroup({
           <div
             className={clsx(
               "relative overflow-hidden",
-              isNestedGroup ? "mt-2" : "pl-2 mt-3"
+              isNestedGroup ? "mt-2" : "pl-0 mt-3"
             )}
           >
             <motion.ul role="list" className="border-l border-transparent">

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -303,7 +303,9 @@ function NavigationGroup({
                   <motion.li
                     key={link.href}
                     layout="position"
-                    className={clsx("relative", { "ml-3": isNestedGroup })}
+                    className={clsx("relative", {
+                      "ml-3": isNestedGroup,
+                    })}
                   >
                     <NavLink
                       href={link.href}
@@ -311,7 +313,7 @@ function NavigationGroup({
                       className={link.className}
                       tag={link.tag}
                     >
-                      {link.title}
+                      <span className="ml-1">{link.title}</span>
                     </NavLink>
                   </motion.li>
                 )


### PR DESCRIPTION
This PR addresses @sanjanaladdha's advice on [removing the vertical line from the sidebar](https://linear.app/inngest/issue/DEV-82/docs-side-menu-remove-the-vertical-line).

It also includes a visual distinction on the currently selected page. I chose a background instead of a font color change because it seems more visible.

Lastly, I also moved the menu items to be aligned with the title, following Sanjana's feedback on this PR.

➡️ [See it yourself!](https://website-git-docs-remove-vertical-line-inngest.vercel.app/docs?ref=nav) ⬅️

---

### BEFORE
<img width="705" alt="Screenshot 2024-07-09 at 8 11 10 PM" src="https://github.com/inngest/website/assets/45401242/b876b2e6-2e90-4412-9463-7498f57298e5">

### AFTER
<img width="705" alt="Screenshot 2024-07-09 at 8 11 03 PM" src="https://github.com/inngest/website/assets/45401242/3cb7cc0a-097f-4c31-abb1-5296ce98a130">

---

<details>
<summary>Previous iteration -- before Sanjana's comment on the PR</summary>
### BEFORE
<img width="318" alt="Screenshot 2024-07-09 at 4 55 27 PM" src="https://github.com/inngest/website/assets/45401242/67ad2e9f-e47f-4a43-bb3c-7fb9737ef2c7">

### AFTER
<img width="318" alt="Screenshot 2024-07-09 at 4 55 51 PM" src="https://github.com/inngest/website/assets/45401242/358a6d5f-79cc-4803-b7ab-c5aeddfcbb4b">
</details>
