### PR TITLE
Nit: unify resource type icons in the example pages

### DIFF
--- a/pages/docs/examples/email-sequence.mdx
+++ b/pages/docs/examples/email-sequence.mdx
@@ -1,7 +1,7 @@
 import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 import { Example } from 'src/shared/Docs/Examples';
 
-import { EnvelopeIcon } from "@heroicons/react/24/outline";
+import { BookOpenIcon, VideoCameraIcon, PencilSquareIcon } from "@heroicons/react/24/outline";
 
 
 export const description = "See how to implement an email sequence with Inngest"
@@ -109,7 +109,7 @@ Check the resources below to learn more about building email sequences with Inng
 <Resource resource={{
   href: "/docs/guides/resend-webhook-events",
   name: "Guide: Integrate email events with Resend webhooks",
-  icon: EnvelopeIcon,
+  icon: PencilSquareIcon,
   description: "Resend webhooks can be used to build functionality into your application based on changes in the email status. In this guide, you will learn how to build a dynamic drip marketing campaign which responds to a user's behavior.",
   pattern: 1,
 }}/>
@@ -117,7 +117,7 @@ Check the resources below to learn more about building email sequences with Inng
 <Resource resource={{
   href: "https://www.youtube.com/watch?v=44WEb7SCgAw",
   name: 'Talk: "Background jobs 101: building reliable apps with Inngest"',
-  icon: EnvelopeIcon,
+  icon: VideoCameraIcon,
   description: "In this talk Sylwia Vargas explains why the DIY approaches to user onboarding email campaigns tend to be slow and unreliable, and how we can leverage background jobs to deliver a great UX.",
   pattern: 1,
 }}/>
@@ -125,7 +125,7 @@ Check the resources below to learn more about building email sequences with Inng
 <Resource resource={{
   href: "https://www.youtube.com/watch?v=EoFI_Bmzb4g",
   name: 'Talk: "Automate All of Your Customer Emails with AI in Next.js"',
-  icon: EnvelopeIcon,
+  icon: VideoCameraIcon,
   description: "In this talk Joel Hooks dives into managing long-running processes like generative AI to enhance our processes and handle the human interaction required at each step of the workflow process.",
   pattern: 1,
 }}/>
@@ -133,7 +133,7 @@ Check the resources below to learn more about building email sequences with Inng
 <Resource resource={{
   href: "/blog/lifecycle-emails-with-resend",
   name: 'Blog post: "Sending customer lifecycle emails with Resend and Inngest"',
-  icon: EnvelopeIcon,
+  icon: BookOpenIcon,
   description: "In this blog post Joel Hooks implements customer lifecycle emails using Inngest, Next.js, Prisma, and Resend, building a highly personalized and automated email workflows.",
   pattern: 1,
 }}/>

--- a/pages/docs/examples/scheduling-one-off-function.mdx
+++ b/pages/docs/examples/scheduling-one-off-function.mdx
@@ -1,5 +1,5 @@
 import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
-import { RiSendPlaneFill } from "@remixicon/react";
+import { PencilSquareIcon } from "@heroicons/react/24/outline";
 
 export const description = "Schedule a function to run at a specific time in the future."
 
@@ -63,7 +63,7 @@ Check the resources below to learn more about scheduling functions with Inngest.
 <Resource resource={{
   href: "/docs/events",
   name: "Guide: Sending events",
-  icon: RiSendPlaneFill,
+  icon: PencilSquareIcon,
   description: "Learn how to send events to trigger functions in Inngest.",
   pattern: 1,
 }}/>


### PR DESCRIPTION
This is a small nit fix: unifies the resource icons in the Example pages.

### BEFORE
<img width="879" alt="Screenshot 2024-07-09 at 8 25 25 PM" src="https://github.com/inngest/website/assets/45401242/69d1b792-c6ee-4274-b0d3-dbe221680f51">

### AFTER
<img width="879" alt="Screenshot 2024-07-09 at 8 25 07 PM" src="https://github.com/inngest/website/assets/45401242/0451b22f-4d46-4dbd-868a-d15f588dcaa7">
