### PR TITLE
Fixes "On this Page" sidebar overflow

### DIFF
--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -97,7 +97,7 @@ export function Layout({
             {hidePageSidebar ? null : (
               <motion.nav
                 layoutScroll
-                className="fixed inset-y-0 mt-14 pt-16 pb-12 right-0 z-40 hidden w-60 border-l border-slate-900/10 px-6 2xl:px-10 dark:border-white/10 xl:block 2xl:w-96"
+                className="fixed overflow-y-auto inset-y-0 mt-14 pt-16 pb-12 right-0 z-40 hidden w-60 border-l border-slate-900/10 px-6 2xl:px-10 dark:border-white/10 xl:block 2xl:w-96"
               >
                 <div className="pt-2">
                   <PageSidebar />

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -189,7 +189,7 @@ export function PageSidebar() {
   return (
     <div>
       <h4 className="text-base font-medium pb-2">On this page</h4>
-      <div className="relative max-h-[600px] overflow-y-auto">
+      <div className="relative">
         <AnimatePresence initial={!isInsideMobileNavigation}>
           {pageSectionListItems && (
             <VisibleSectionHighlight listItems={pageSectionListItems} />

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -189,10 +189,7 @@ export function PageSidebar() {
   return (
     <div>
       <h4 className="text-base font-medium pb-2">On this page</h4>
-      <div
-        className="relative"
-        style={{ maxHeight: "600px", overflowY: "auto" }}
-      >
+      <div className="relative max-h-[600px] overflow-y-auto">
         <AnimatePresence initial={!isInsideMobileNavigation}>
           {pageSectionListItems && (
             <VisibleSectionHighlight listItems={pageSectionListItems} />

--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -161,7 +161,6 @@ function VisibleSectionHighlight({ listItems }) {
     />
   );
 }
-
 export function PageSidebar() {
   let isInsideMobileNavigation = useIsInsideMobileNavigation();
   let router = useRouter();
@@ -190,7 +189,10 @@ export function PageSidebar() {
   return (
     <div>
       <h4 className="text-base font-medium pb-2">On this page</h4>
-      <div className="relative">
+      <div
+        className="relative"
+        style={{ maxHeight: "600px", overflowY: "auto" }}
+      >
         <AnimatePresence initial={!isInsideMobileNavigation}>
           {pageSectionListItems && (
             <VisibleSectionHighlight listItems={pageSectionListItems} />
@@ -233,6 +235,7 @@ export function PageSidebar() {
     </div>
   );
 }
+
 // A nested navigation group of links that expand and follow
 function NavigationGroup({
   group,


### PR DESCRIPTION
This PR introduces a scroll to "On this Page" sidebar. 

### BEFORE
Currently, when a page has numerous menu items, the sidebar cannot feature them all. It is not a common situation.
➡️ [See in the docs](https://www.inngest.com/docs/sdk/serve)
<br/>

https://github.com/inngest/website/assets/45401242/8540b173-dc0f-4aad-93d1-4f095e3bb8aa

### AFTER
Now the siedebar is scrollable.
➡️ [See in the preview](https://website-git-docs-sidebar-overflow-fix-inngest.vercel.app/docs/sdk/serve)
<br/>

https://github.com/inngest/website/assets/45401242/57ae3ae6-28ca-4b0f-abcd-29f64b9df955

## Next steps
Ideally, when there's an overflow, the sidebar would scroll to the correct menu item as we scroll the page. Because the situation is not common for us to have long sidebar lists, I am leaving it as "nice to have" ([Linear ticket](https://linear.app/inngest/issue/DEV-93/make-on-this-page-sidebar-scroll-automatically-as-you-scroll-the-page)).