### PR TITLE
Add reference docs for `onFunctionRun.finished` hook in TS middleware

### DIFF
--- a/pages/docs/reference/middleware/lifecycle.mdx
+++ b/pages/docs/reference/middleware/lifecycle.mdx
@@ -183,13 +183,13 @@ The `init()` function can return functions for two separate lifecycles to hook i
                     </Properties>
                </Property>
                <Property name="finished" type="function" version="v3.21.0+">
-                    Called when the function has finished executing and has returned a final response that will end the run which could be either a successful or erroring response.
+                    Called when execution is complete and a final response is returned (success or an error), which will end the run.
 
-                    This is not guaranteed to be called on every execution, and may be called multiple times if many parallel executions reach the end of the function or during retries.
+                    This function is not guaranteed to be called on every execution. It may be called multiple times if there are many parallel executions or during retries.
 
                     <Properties name="Arguments" nested collapse>
                           <Property name="result" type="object" required>
-                              An object containing either the successful `data` that is ending the run or the `error` that has been thrown. Both outputs will have already been affected by `transformOutput`.
+                              An object that contains either the successful `data` ending the run or the `error` that has been thrown. Both outputs have already been affected by `transformOutput`.
                           </Property>
                     </Properties>
                </Property>

--- a/pages/docs/reference/middleware/lifecycle.mdx
+++ b/pages/docs/reference/middleware/lifecycle.mdx
@@ -182,6 +182,17 @@ The `init()` function can return functions for two separate lifecycles to hook i
                          </Property>
                     </Properties>
                </Property>
+               <Property name="finished" type="function" version="v3.21.0+">
+                    Called when the function has finished executing and has returned a final response that will end the run which could be either a successful or erroring response.
+
+                    This is not guaranteed to be called on every execution, and may be called multiple times if many parallel executions reach the end of the function or during retries.
+
+                    <Properties name="Arguments" nested collapse>
+                          <Property name="result" type="object" required>
+                              An object containing either the successful `data` that is ending the run or the `error` that has been thrown. Both outputs will have already been affected by `transformOutput`.
+                          </Property>
+                    </Properties>
+               </Property>
                <Property name="beforeResponse" type="function">
                     Called after the output has been set and before the response has been sent back to Inngest. Use this to perform any final actions before the request closes.
                </Property>
@@ -224,6 +235,9 @@ The `init()` function can return functions for two separate lifecycles to hook i
                           data: transformData(result.data)
                         }
                       }
+                    },
+                    finished({ result }) {
+                      // ...
                     },
                     beforeResponse() {
                       // ...


### PR DESCRIPTION
## Summary

Adds reference docs for inngest/inngest-js#651, which adds an `onFunctionRun.finished` hook to middleware.

## Related

- inngest/inngest-js#651