### PR TITLE
Add reference docs for sending events to a particular environment

### DIFF
--- a/pages/docs/reference/events/send.mdx
+++ b/pages/docs/reference/events/send.mdx
@@ -27,7 +27,7 @@ To send events from within of the context of a function, use [`step.sendEvent()`
 ---
 
 
-## `inngest.send(eventPayload | eventPayload[]): Promise<{ ids: string[] }>`
+## `inngest.send(eventPayload | eventPayload[], options): Promise<{ ids: string[] }>`
 
 <Row>
   <Col>
@@ -62,6 +62,13 @@ To send events from within of the context of a function, use [`step.sendEvent()`
           </Property>
           <Property name="v" type="string">
             A version identifier for a particular event payload. e.g. `"2023-04-14.1"`
+          </Property>
+        </Properties>
+      </Property>
+      <Property name="options" type="object" version="v3.21.0+">
+        <Properties nested={true}>
+          <Property name="env" type="string">
+            The [environment](/docs/platform/environments) to send the events to.
           </Property>
         </Properties>
       </Property>


### PR DESCRIPTION
## Summary

Add reference docs inngest/inngest-js#650, which adds the ability to sending events for a particular `inngest.send()` call to another environment.

## Related

- inngest/inngest-js#650