### PR TITLE
fix(docs): ensure Python SDK deeply nested menu items stay visible when active

### DIFF
--- a/shared/Docs/Navigation.tsx
+++ b/shared/Docs/Navigation.tsx
@@ -334,6 +334,14 @@ function hasPath(links: { href?: string }[], pathname: string) {
   return findPathIndex(links, pathname) !== -1;
 }
 
+function hasNavGroupPath(links: NavGroup[], pathname: string) {
+  return links.some((link) =>
+    link.links
+      ? hasPath(link.links, pathname)
+      : link.href && link.href === pathname
+  );
+}
+
 // Flatten the nested nav and get all nav sections w/ sectionLinks
 function getAllSections(nav) {
   return nav.reduce((acc, item) => {
@@ -384,7 +392,7 @@ export function Navigation(props) {
   const activeGroup = useMemo(
     () =>
       nestedNavigation?.sectionLinks.find((group) =>
-        hasPath(group.links, router.pathname)
+        hasNavGroupPath(group.links, router.pathname)
       ),
     [router.pathname, nestedNavigation]
   );


### PR DESCRIPTION
## Before

_The Python SDK section closes when navigating to the nested Steps items_

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/53ba416e-9457-48c1-bd61-702fe937b963">



## After

_The Python SDK section remains open when navigating to the nested Steps items_

<img width="1268" alt="image" src="https://github.com/user-attachments/assets/edbd3abf-e380-4e30-99fc-93616b1696c2">

