### PR TITLE
Update the RetryAfterError documentation

### DIFF
--- a/pages/docs/reference/typescript/functions/errors.mdx
+++ b/pages/docs/reference/typescript/functions/errors.mdx
@@ -119,7 +119,7 @@ new RetryAfterError(
   <Property name="retryAfter" type="number | string | date" required>
     The specified time to delay the next retry attempt. The following formats are accepted:
 
-    * `number` - The number of **seconds** to delay the next retry attempt.
+    * `number` - The number of **milliseconds** to delay the next retry attempt.
     * `string` - A time string, parsed by the [ms](https://npm.im/ms) package, such as `"30m"`, `"3 hours"`, or `"2.5d"`.
     * `date` - A `Date` object.
   </Property>


### PR DESCRIPTION
While testing the RetryAfterError, I discovered that the actual behaviour wasn't matching the docs.
Based on the implementation: https://github.com/inngest/inngest-js/blob/main/packages/inngest/src/components/RetryAfterError.ts

If the `retryAfter` value is a number, it should be in milliseconds.