### PR TITLE
Update Cloudflare AI usage example; lib now deprecated

### DIFF
--- a/pages/docs/reference/middleware/examples.mdx
+++ b/pages/docs/reference/middleware/examples.mdx
@@ -22,13 +22,12 @@ To use the `@cloudflare/ai` package, you need access to the `env` object passed 
 Use this along with [mutating function input](/docs/reference/middleware/typescript#mutating-input) to set a new `ai` property that you can use within functions, like in the following example:
 
 ```ts
-import { Ai } from "@cloudflare/ai";
 import { InngestMiddleware } from "inngest";
 
 interface Env {
   // If you set another name in wrangler.toml as the value for 'binding',
   // replace "AI" with the variable name you defined.
-  AI: any;
+  AI: Ai;
 }
 
 export const cloudflareMiddleware = new InngestMiddleware({
@@ -36,8 +35,8 @@ export const cloudflareMiddleware = new InngestMiddleware({
   init: () => {
     return {
       onFunctionRun: ({ reqArgs }) => {
-        const [, env] = reqArgs as [Request, Env];
-        const ai = new Ai(env.AI);
+        const [ctx] = reqArgs as [Request, Env];
+        const ai = ctx.env.AI
 
         return {
           transformInput: () => {


### PR DESCRIPTION
## Summary

Following a discussion in inngest/inngest#664, [@cloudflare/ai](https://www.npmjs.com/package/@cloudflare/ai) is now deprecated; the example for using Cloudflare AI in middleware needs updating.

## Related

- Discussed in inngest/inngest#664