### PR TITLE
Add note for runtime environment variables if needed in a framework

### DIFF
--- a/pages/docs/sdk/environment-variables.mdx
+++ b/pages/docs/sdk/environment-variables.mdx
@@ -14,6 +14,26 @@ We'll look at all available environment variables here, what to set them to, and
 - [INNGEST_SIGNING_KEY](#inngest-signing-key)
 - [INNGEST_STREAMING](#inngest-streaming)
 
+Within some frameworks and platforms such as Cloudflare Workers, environment
+variables are not available in the global scope and are instead passed as
+runtime arguments to your handler. In this case, you can use
+`inngest.setEnvVars()` to ensure your client has the correct configuration
+before communicating with Inngest.
+
+```ts
+// For example, in Hono on Cloudflare Workers
+app.on("POST", "/my-api/send-some-event", async (c) => {
+  inngest.setEnvVars(c.env);
+
+  await inngest.send({ name: "test/event" });
+
+  return c.json({ message: "Done!" });
+});
+
+// You can also chain the call to be succinct
+await inngest.setEnvVars(c.env).send({ name: "test/event" });
+```
+
 ---
 
 ## INNGEST_BASE_URL


### PR DESCRIPTION
## Summary

Documents a change in inngest/inngest-js#665, where environment variables may not be available within the global scope.

Preview: [Environment Variables - Inngest Documentation](https://website-git-docs-client-runtime-env-vars-inngest.vercel.app/docs/sdk/environment-variables)

## Related

- Documents inngest/inngest-js#665