### PR TITLE
Update invoke.mdx to fix missing 'await' when invoking another step

### DIFF
--- a/pages/docs/reference/python/steps/invoke.mdx
+++ b/pages/docs/reference/python/steps/invoke.mdx
@@ -42,7 +42,7 @@ async def fn_2(
     ctx: inngest.Context,
     step: inngest.Step,
 ) -> None:
-    output = step.invoke(
+    output = await step.invoke(
         "invoke",
         function=fn_1,
     )


### PR DESCRIPTION
Python SDK