### PR TITLE
Docs: Include snippets within search results

### DIFF
--- a/shared/Docs/Search.tsx
+++ b/shared/Docs/Search.tsx
@@ -254,27 +254,38 @@ function SearchResult({ result, resultIndex, autocomplete, collection }) {
         </span>
       )}
 
-      {hierarchyHtml.length > 0 && (
+      {result?._snippetResult?.content?.matchLevel === "full" ? (
         <div
-          id={`${id}-hierarchy`}
+          id={`${id}-snippet`}
           aria-hidden="true"
           className="mt-1 truncate whitespace-nowrap text-2xs text-carbon-500"
-        >
-          {hierarchyHtml.map((item, itemIndex, items) => (
-            <Fragment key={itemIndex}>
-              <span dangerouslySetInnerHTML={{ __html: item }} />
-              <span
-                className={
-                  itemIndex === items.length - 1
-                    ? "sr-only"
-                    : "mx-2 text-breeze-600 dark:text-breeze-300"
-                }
-              >
-                /
-              </span>
-            </Fragment>
-          ))}
-        </div>
+          dangerouslySetInnerHTML={{
+            __html: result?._snippetResult?.content?.value,
+          }}
+        />
+      ) : (
+        hierarchyHtml.length > 0 && (
+          <div
+            id={`${id}-hierarchy`}
+            aria-hidden="true"
+            className="mt-1 truncate whitespace-nowrap text-2xs text-carbon-500"
+          >
+            {hierarchyHtml.map((item, itemIndex, items) => (
+              <Fragment key={itemIndex}>
+                <span dangerouslySetInnerHTML={{ __html: item }} />
+                <span
+                  className={
+                    itemIndex === items.length - 1
+                      ? "sr-only"
+                      : "mx-2 text-breeze-600 dark:text-breeze-300"
+                  }
+                >
+                  /
+                </span>
+              </Fragment>
+            ))}
+          </div>
+        )
       )}
     </li>
   );


### PR DESCRIPTION
### After
<img width="751" alt="Screen Shot 2024-09-13 at 12 11 07 PM" src="https://github.com/user-attachments/assets/8767565b-5445-4855-bbaa-bdb43fe2c140">


### Before

<img width="752" alt="Screen Shot 2024-09-13 at 12 11 35 PM" src="https://github.com/user-attachments/assets/20e10c4a-5f8e-42d7-9ec3-9ae40d8ca7e6">
