### PR TITLE
feat(homepage): add banner for PH launch day

### DIFF
--- a/components/LaunchWeekBanner.tsx
+++ b/components/LaunchWeekBanner.tsx
@@ -1,7 +1,27 @@
+"use client";
 import AnnouncementBanner from "src/components/AnnouncementBanner";
+import ProductHuntAnnouncementBanner from "src/components/ProductHuntAnnouncementBanner";
+
+function useIsItDay3InSFNow() {
+  const d = new Date();
+  const localTime = d.getTime();
+  const localOffset = d.getTimezoneOffset() * 60000;
+  const utc = localTime + localOffset;
+  const offset = -8; // UTC of PST is -05.00
+  const sfDate = new Date(utc + 3600000 * offset);
+
+  return (
+    sfDate.getDate() == 24 &&
+    sfDate.getMonth() == 8 &&
+    sfDate.getFullYear() === 2024
+  );
+}
 
 export default function LaunchWeekBanner() {
-  return (
+  const day3 = useIsItDay3InSFNow();
+  return day3 ? (
+    <ProductHuntAnnouncementBanner />
+  ) : (
     <AnnouncementBanner href="/launch-week" className="mb-4">
       Inngest Launch Week kicks off September 23rd. Follow along with all of our
       updates!

--- a/components/LaunchWeekBanner.tsx
+++ b/components/LaunchWeekBanner.tsx
@@ -11,7 +11,7 @@ function useIsItDay3InSFNow() {
   const sfDate = new Date(utc + 3600000 * offset);
 
   return (
-    sfDate.getDate() == 24 &&
+    sfDate.getDate() == 25 &&
     sfDate.getMonth() == 8 &&
     sfDate.getFullYear() === 2024
   );

--- a/components/ProductHuntAnnouncementBanner.tsx
+++ b/components/ProductHuntAnnouncementBanner.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const ProductHuntAnnouncementBanner = () => (
-  <div className="py-4 px-4 flex flex-col md:flex-row items-center justify-center border-b border-[#B0B0B0] gap-8">
+  <div className="py-4 px-4 flex flex-col md:flex-row items-center justify-center border-b border-[#B0B0B0] gap-8 relative">
     <div className="text-sm text-basis max-w-[826px]">
       <span className="hidden md:inline">
         As part of launch week, we launched our new open source{" "}

--- a/components/ProductHuntAnnouncementBanner.tsx
+++ b/components/ProductHuntAnnouncementBanner.tsx
@@ -38,7 +38,7 @@ const ProductHuntAnnouncementBanner = () => (
         target="_blank"
       >
         <img
-          className="border border-white"
+          className="border border-white rounded-lg"
           src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=490802&theme=dark"
           alt="Workflow&#0032;Kit&#0032;by&#0032;Inngest - Open&#0032;source&#0032;SDK&#0032;to&#0032;add&#0032;Zapier&#0045;like&#0032;workflows&#0032;to&#0032;your&#0032;product | Product Hunt"
           style={{ width: "169px", height: "38px" }}

--- a/components/ProductHuntAnnouncementBanner.tsx
+++ b/components/ProductHuntAnnouncementBanner.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+const ProductHuntAnnouncementBanner = () => (
+  <div className="py-4 px-4 flex flex-col md:flex-row items-center justify-center border-b border-[#B0B0B0] gap-8">
+    <div className="text-sm text-basis max-w-[826px]">
+      <span className="hidden md:inline">
+        As part of launch week, we launched our new open source{" "}
+        <strong>Workflow Kit</strong> today on <strong>Product Hunt</strong>.
+        Check it out and give us an upvote!{" "}
+      </span>
+      <span className="md:hidden inline">
+        We are launching <strong>Workflow Kit</strong> today on{" "}
+        <a
+          href="https://www.producthunt.com/posts/workflow-kit-by-inngest"
+          className="underline"
+        >
+          Product Hunt
+        </a>
+        !
+      </span>
+      <br />
+      <span className="hidden md:inline">
+        Want to see more of Inngest's launch week?{" "}
+        <a href="/launch-week" className="underline">
+          Follow along with all of our updates
+        </a>
+      </span>
+      <span className="md:hidden inline">
+        Follow along with all with{" "}
+        <a href="/launch-week" className="underline">
+          Inngest's launch week updates.
+        </a>
+      </span>
+    </div>
+    <div className="hidden md:inline">
+      <a
+        href="https://www.producthunt.com/posts/workflow-kit-by-inngest?embed=true&utm_source=badge-featured&utm_medium=badge&utm_souce=badge-workflow&#0045;kit&#0045;by&#0045;inngest"
+        target="_blank"
+      >
+        <img
+          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=490802&theme=neutral"
+          alt="Workflow&#0032;Kit&#0032;by&#0032;Inngest - Open&#0032;source&#0032;SDK&#0032;to&#0032;add&#0032;Zapier&#0045;like&#0032;workflows&#0032;to&#0032;your&#0032;product | Product Hunt"
+          style={{ width: "169px", height: "38px" }}
+          width="169"
+          height="38"
+        />
+      </a>
+    </div>
+  </div>
+);
+
+export default ProductHuntAnnouncementBanner;

--- a/components/ProductHuntAnnouncementBanner.tsx
+++ b/components/ProductHuntAnnouncementBanner.tsx
@@ -38,7 +38,8 @@ const ProductHuntAnnouncementBanner = () => (
         target="_blank"
       >
         <img
-          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=490802&theme=neutral"
+          className="border border-white"
+          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=490802&theme=dark"
           alt="Workflow&#0032;Kit&#0032;by&#0032;Inngest - Open&#0032;source&#0032;SDK&#0032;to&#0032;add&#0032;Zapier&#0045;like&#0032;workflows&#0032;to&#0032;your&#0032;product | Product Hunt"
           style={{ width: "169px", height: "38px" }}
           width="169"


### PR DESCRIPTION
This banner replaces the current one only on Day 3 (PST time).

@whatupjohnb, we cannot customize the colors of the Product Hunt button; let me know what you think about the current one; I can also replace it with the following dark-themed version: 
<img width="543" alt="image" src="https://github.com/user-attachments/assets/645b991c-a360-4279-aa43-6eb35ba1ad5e">

## Desktop
![Screenshot 2024-09-24 at 12 10 03](https://github.com/user-attachments/assets/917d5eef-7624-4c23-87eb-60a2d65b1268)


## Mobile
![Screenshot 2024-09-24 at 12 15 49](https://github.com/user-attachments/assets/2736ca97-c899-430c-966e-af15aa039032)

