### PR TITLE
Add Nitro framework to serve docs

### DIFF
--- a/pages/docs/learn/serving-inngest-functions.mdx
+++ b/pages/docs/learn/serving-inngest-functions.mdx
@@ -661,6 +661,27 @@ export default serve(inngest, [...fns], {
 
 For more information, check out the [Streaming](/docs/streaming) page.
 
+### Framework: Nitro <VersionBadge version="v3.24.0" />
+
+Add the following to `./server/routes/api/inngest.ts`:
+
+<CodeGroup>
+```ts
+import { serve } from "inngest/nitro";
+import { inngest } from "~~/inngest/client";
+import fnA from "~~/inngest/fnA"; // Your own function
+
+export default eventHandler(
+  serve({
+    client: inngest,
+    functions: [fnA],
+  })
+);
+```
+</CodeGroup>
+
+See the [Nitro example](https://github.com/inngest/inngest-js/tree/main/examples/framework-nitro) for more information.
+
 ### Framework: Nuxt <VersionBadge version="v0.9.2+" />
 
 Inngest has first class support for [Nuxt server routes](https://nuxt.com/docs/guide/directory-structure/server#server-routes), allowing you to easily create the Inngest API.


### PR DESCRIPTION
## Summary

Adds serve docs for the [Nitro](https://nitro.unjs.io/) framework following inngest/inngest-js#685.

In draft until the change is shipped.

![image](https://github.com/user-attachments/assets/149b82b2-89ab-4848-abc7-e23758b7879b)

## Related

- inngest/inngest-js#685