### PR TITLE
Use CodeHike filenames. Refresh CTA using new design styles.

### DIFF
--- a/pages/blog/_posts/nextjs-serverless-vs-durable-functions.mdx
+++ b/pages/blog/_posts/nextjs-serverless-vs-durable-functions.mdx
@@ -62,8 +62,7 @@ A pragmatic way of implementing such flow in Next.js would be to rely on a CRON 
 
 The Serverless Function would retrieve all the `"pending"` domains from the database, query the DNS servers, and send emails, all in a single loop while handling most failure cases:
 
-```tsx
-// src/api/domain-verification/route.tsx
+```tsx src/api/domain-verification/route.tsx
 import { intervalToDuration } from "date-fns";
 
 import prisma from "./prisma-client";
@@ -172,8 +171,7 @@ Beyond being hard to decipher, the above code also has many drawbacks:
 
 This is where Durable Functions get interesting; let's look at our refactored workflow:
 
-```tsx
-// src/inngest/domain-verification.tsx
+```tsx src/inngest/domain-verification.tsx
 import { intervalToDuration } from "date-fns";
 
 import inngest from "./inngest-client";
@@ -324,9 +322,7 @@ Durable Functions provide [Flow Control](https://www.inngest.com/docs/guides/flo
 
 Let's add the following line to our Durable Function to add some Throttling configuration:
 
-```tsx
-// src/inngest/domain-verification.tsx
-
+```tsx src/inngest/domain-verification.tsx
 // ...
 
 export default inngest.createFunction(

--- a/shared/CTACallout.tsx
+++ b/shared/CTACallout.tsx
@@ -18,14 +18,21 @@ export default function CTACallout({
     <aside
       className={`not-prose ${
         wide ? "max-w-[80ch]" : "max-w-[70ch]"
-      } m-auto bg-indigo-900/20 text-indigo-100 flex flex-col items-start gap-4 leading-relaxed rounded-lg py-5 px-6  my-12 border border-indigo-900/50`}
+      } m-auto my-12 p-px text-basis rounded-lg bg-gradient-to-br from-[rgba(var(--color-carbon-400)/0.4)] via-transparent to-transparent`}
     >
-      <p className="text-sm lg:text-base">{text}</p>
-      {!!cta && (
-        <Button href={cta.href} arrow="right">
-          {cta.text}
-        </Button>
-      )}
+      <div
+        className="flex flex-col items-start gap-5 py-5 px-6 leading-relaxed rounded-lg"
+        style={{
+          background: `linear-gradient(108deg, rgba(204, 204, 204, 0.12) 9.67%, rgba(0, 0, 0, 0.00) 49.19%), #050505`,
+        }}
+      >
+        <p className="text-sm lg:text-base">{text}</p>
+        {!!cta && (
+          <Button href={cta.href} arrow="right">
+            {cta.text}
+          </Button>
+        )}
+      </div>
     </aside>
   );
 }


### PR DESCRIPTION
Using codehike file names:
<img width="825" alt="Screen Shot 2024-10-30 at 4 07 01 PM" src="https://github.com/user-attachments/assets/904c72c3-6a64-409b-884e-dcafc649f0e7">

Refreshed CTA, using styles from recent landing page. The only CTA was using old brand colors.

![image](https://github.com/user-attachments/assets/a2e29ea8-7385-4d1f-b3a2-5ec8dc9b3343)
