### PR TITLE
fix(tracking): re-render issue altering data + cleaning

### DIFF
--- a/components/InngestClientSDK.tsx
+++ b/components/InngestClientSDK.tsx
@@ -40,17 +40,11 @@ export function PageViews() {
         window.Inngest.identify({ anonymous_id: anonymousID });
         // The hook should tell us if the anon id is an existing one, or it's just been set
         const firstTouch = !existing;
-        let ref: string | null = null;
-        try {
-          const urlParams = new URLSearchParams(window.location.search);
-          ref = urlParams.get("ref");
-        } catch (e) {}
         // See tracking for next/link based transitions in tracking.ts
         window.Inngest.event({
           name: "website/page.viewed",
           data: {
             first_touch: firstTouch,
-            ref: ref,
           },
           v: "2022-12-27.1",
         });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -187,17 +187,11 @@ function MyApp({ Component, pageProps }: AppProps<DefaultProps>) {
           window.Inngest.identify({ anonymous_id: anonymousID });
           // The hook should tell us if the anon id is an existing one, or it's just been set
           const firstTouch = !existing;
-          let ref: string | null = null;
-          try {
-            const urlParams = new URLSearchParams(window.location.search);
-            ref = urlParams.get("ref");
-          } catch (e) {}
           // See tracking for next/link based transitions in tracking.ts
           window.Inngest.event({
             name: "website/page.viewed",
             data: {
               first_touch: firstTouch,
-              ref: ref,
             },
             v: "2022-12-27.1",
           });

--- a/public/inngest-sdk.js
+++ b/public/inngest-sdk.js
@@ -154,6 +154,7 @@
     "utm_content",
     "utm_medium",
     "utm_term",
+    "ref",
   ];
 
   function context(eventData) {

--- a/public/inngest-sdk.js
+++ b/public/inngest-sdk.js
@@ -38,7 +38,7 @@
       return false;
     }
     event.data = event.data || {};
-    assign(event.data, context());
+    assign(event.data, context(event.data));
 
     // The event.user object should take precedence over the identify() attributes
     // called.  Copy the event user attributes into a new variable so that we can
@@ -73,7 +73,7 @@
   Inngest.track = function (eventName, data) {
     evt = {
       name: eventName,
-      data: assign(data || {}, context()),
+      data: assign(data || {}, context(data)),
       user: user,
     };
     Inngest.event(evt);
@@ -148,7 +148,28 @@
     return errors;
   }
 
-  function context() {
+  const utmKeys = [
+    "utm_source",
+    "utm_campaign",
+    "utm_content",
+    "utm_medium",
+    "utm_term",
+  ];
+
+  function context(eventData) {
+    const utmProps = {};
+    const isFirstTouch = eventData.first_touch;
+    try {
+      const urlParams = new URLSearchParams(window.location.search);
+      // we track both first touch UTMs props and all touchpoints UTMs
+      for (let utmKey of utmKeys) {
+        utmProps[utmKey] = urlParams.get(utmKey);
+        if (isFirstTouch) {
+          utmProps[`first_${utmKey}`] = urlParams.get(utmKey);
+        }
+      }
+    } catch (e) {}
+
     var data = {
       context: {
         path: window.location.pathname,
@@ -159,7 +180,7 @@
         user_agent: navigator && navigator.userAgent,
         library: "js",
         library_version: VERSION,
-        // TODO Store utm params
+        ...utmProps,
       },
     };
     if (window && window.location.search.length) {

--- a/public/inngest-sdk.js
+++ b/public/inngest-sdk.js
@@ -184,21 +184,6 @@
         ...utmProps,
       },
     };
-    if (window && window.location.search.length) {
-      try {
-        var params = new URLSearchParams(window.location.search);
-        ["source", "medium", "campaign", "content", "term"].forEach(function (
-          param
-        ) {
-          var key = "utm_" + param;
-          if (params.get(key)) {
-            data.context[key] = params.get(key);
-          }
-        });
-      } catch (err) {
-        /* No-op - URLSearchParams may not be supported in browser */
-      }
-    }
     return data;
   }
 

--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -1,10 +1,4 @@
 export const trackPageView = (url: string) => {
-  let ref = null;
-  try {
-    const urlParams = new URLSearchParams(window.location.search);
-    ref = urlParams.get("ref");
-  } catch (e) {}
-
   if (typeof window.Inngest === "undefined") {
     console.warn("Inngest is not initialized");
     return;
@@ -14,7 +8,6 @@ export const trackPageView = (url: string) => {
     name: "website/page.viewed",
     data: {
       first_touch: false,
-      ref,
     },
     v: "2022-12-27.1",
   });


### PR DESCRIPTION
## Before 
Race condition on the `useAnonymousID()` hook is due to multiple renders, leading to a `first_touch` always being `false`.

<img width="1512" alt="Screenshot 2024-11-11 at 15 58 42" src="https://github.com/user-attachments/assets/f750bce0-0a45-41d5-8b8c-e2979c818463">

_Page loaded without anonID cookie is flagged as existing user_

## After

No more re-renders issues + UTM tracking on both first touch and all page views

<img width="1512" alt="Screenshot 2024-11-11 at 16 27 27" src="https://github.com/user-attachments/assets/acdce8a7-e39c-4b80-96e7-414bc92bacfb">

_No anonID cookie: properly flagged as first touched with dedicated UTM props_

<img width="1511" alt="Screenshot 2024-11-11 at 16 29 00" src="https://github.com/user-attachments/assets/61fb5eb4-e59f-4a29-8367-6e2c677a7614">

_Second visit: properly flagged with dedicated UTM props_
