### PR TITLE
Fix Sentry middleware setup example for Python

### DIFF
--- a/pages/docs/features/middleware/sentry-middleware.mdx
+++ b/pages/docs/features/middleware/sentry-middleware.mdx
@@ -36,7 +36,7 @@ Using the Sentry middleware is useful to:
 
     inngest_client = inngest.Inngest(
         app_id="my-app",
-        middleware=[SentryMiddleware()],
+        middleware=[SentryMiddleware],
     )
     ```
 


### PR DESCRIPTION
Inngest expects a list of uninitialized middleware here, i.e. the actual SentryMiddleware class rather than an instance of it.

The class is initialized in MiddlewareManager.add when sending events.