### PR TITLE
Add missing class attribute type in pydantic.mdx

### DIFF
--- a/pages/docs/reference/python/guides/pydantic.mdx
+++ b/pages/docs/reference/python/guides/pydantic.mdx
@@ -38,7 +38,7 @@ class PostUpvotedEventData(pydantic.BaseModel):
 
 class PostUpvotedEvent(BaseEvent):
     data: PostUpvotedEventData
-    name: str = "forum/post.upvoted"
+    name: typing.ClassVar[str] = "forum/post.upvoted"
 ```
 
 Since Pydantic validates on instantiation, the following code will raise an error if the data is invalid.


### PR DESCRIPTION
The subclass attribute 'name' also needs to be of type 'ClassVar' otherwise you get and Attribute error for 'name' when doing ' trigger=inngest.TriggerEvent(event=PostUpvotedEvent.name)' (the class is not instantiated here)