### PR TITLE
Add sub heads for python examples in step-parallelism.mdx

### DIFF
--- a/pages/docs/guides/step-parallelism.mdx
+++ b/pages/docs/guides/step-parallelism.mdx
@@ -58,6 +58,7 @@ When each step is finished, Inngest will aggregate each step's state and re-invo
 
 Inngest supports parallel steps regardless of whether you're using asynchronous or synchronous code. For both approaches, you can use `step.parallel`:
 
+#### async - with `inngest.Step` and `await step.parallel()` 
 ```py
 @client.create_function(
   fn_id="my-fn",
@@ -77,6 +78,7 @@ async def fn(
   )
 ```
 
+#### sync - with `inngest.StepSync` and `step.parallel()` 
 ```py
 @client.create_function(
   fn_id="my-fn",


### PR DESCRIPTION
Added sub headlines for the python (a)sync examples because I thought these are the same code block twice and only saw after using a diff checker. 

Note: There is a randering issue on GH realted to the '<CodeGroup>' tag. I can not tell if that's just GH or also the website after merge!