### PR TITLE
docs: sidebar editor empty when following user guides

### DIFF
--- a/pages/docs/guides/user-defined-workflows.mdx
+++ b/pages/docs/guides/user-defined-workflows.mdx
@@ -215,9 +215,7 @@ export const AutomationEditor = ({ workflow }: { workflow: Workflow }) => {
       }}
     >
       <Editor>
-        <Sidebar position="right">
-          <></>
-        </Sidebar>
+        <Sidebar position="right"/>
       </Editor>
     </Provider>
   );


### PR DESCRIPTION
The sidebar component was blank because it was rendering the fragment provided to it, instead of the built-in functionality.