### PR TITLE
Add callout about 1st gen Cloud Run Functions

### DIFF
--- a/pages/docs/learn/serving-inngest-functions.mdx
+++ b/pages/docs/learn/serving-inngest-functions.mdx
@@ -356,9 +356,9 @@ export const handler = serve(inngest, [fnA]);
 ```
 </CodeGroup>
 
-### Framework: Google Cloud Functions
+### Framework: Google Cloud Run Functions
 
-Google's [Functions Framework](https://github.com/GoogleCloudPlatform/functions-framework-nodejs) has an Express-compatible API which enables you to use the Express serve handler to deploy your functions to Google's Cloud Functions or Cloud Run. This is an example of a function
+Google's [Functions Framework](https://github.com/GoogleCloudPlatform/functions-framework-nodejs) has an Express-compatible API which enables you to use the Express serve handler to deploy your Inngest functions to Google Cloud Run. This is an example of a function:
 
 <CodeGroup>
 ```ts {{ title: "v3" }}
@@ -372,6 +372,7 @@ ff.http(
   serve({
     client: inngest,
     functions: [fnA],
+    servePath: "/",
   })
 );
 ```
@@ -381,13 +382,24 @@ import { serve } from "inngest/express";
 import { inngest } from "./src/inngest/client";
 import fnA from "./src/inngest/fnA"; // Your own function
 
-ff.http('inngest', serve(inngest, [fnA]));
+ff.http(
+  'inngest',
+  serve(
+    inngest,
+    [fnA],
+    { servePath: "/" },
+  )
+);
 ```
 </CodeGroup>
 
 You can run this locally with `npx @google-cloud/functions-framework --target=inngest` which will serve your Inngest functions on port `8080`.
 
 See the [Google Cloud Functions example](https://github.com/inngest/inngest-js/tree/main/examples/framework-google-functions-framework) for more information.
+
+<Callout>
+1st generation Cloud Run Functions are not officially supported. Using one may result in a signature verification error.
+</Callout>
 
 ### Framework: Firebase Cloud Functions
 


### PR DESCRIPTION
Add a callout about how we don't officially support 1st gen Cloud Run Functions. There's an issue with signature verification errors, which may remain unsolved since Google is sunsetting 1st gen Cloud Run Functions.

Add `servePath: "/"` to the `serve` call, since 2nd gen Cloud Run Functions don't have a path.