### PR TITLE
Create Workers + Hono env middleware example

### DIFF
--- a/pages/docs/examples/index.mdx
+++ b/pages/docs/examples/index.mdx
@@ -51,3 +51,15 @@ Send all function failures to Datadog (or similar) for monitoring.
 </Card>
 
 </CardGroup>
+
+## Middleware
+
+<CardGroup>
+<Card
+  href={"/docs/examples/middleware/cloudflare-workers-environment-variables"}
+  title={'Cloudflare Workers & Hono environment variables'}
+>
+  Access environment variables and other Cloudflare bindings within Inngest functions when using Workers or Hono.
+</Card>
+
+</CardGroup>

--- a/pages/docs/examples/middleware/cloudflare-workers-environment-variables.mdx
+++ b/pages/docs/examples/middleware/cloudflare-workers-environment-variables.mdx
@@ -1,0 +1,110 @@
+import { CodeGroup } from "src/shared/Docs/mdx";
+
+# Cloudflare Workers environment variables and context
+
+Cloudflare Workers does not set environment variables a global object like Node.js does with `process.env`. Workers [binds environment variables](https://developers.cloudflare.com/workers/configuration/environment-variables/) to the worker's special `fetch` event handler thought a specific `env` argument.
+
+This means accessing environment variables within Inngest function handlers isn't possible without explicitly passing them through from the worker event handler to the Inngest function handler.
+
+We can accomplish this by use the [middleware](/docs/features/middleware) feature for Workers or when using [Hono](/docs/learn/serving-inngest-functions#framework-hono).
+
+## Creating middleware
+
+You can create middleware which extracts the `env` argument from the Workers `fetch` event handler arguments for either Workers or Hono:
+
+1. Use `onFunctionRun`'s `reqArgs` array to get the `env` object and, optionally, cast a type.
+2. Return the `env` object within the special `ctx` object of `transformInput` lifecycle method.
+
+<CodeGroup>
+
+```ts {{ title: "Workers" }}
+import { Inngest, InngestMiddleware } from 'inngest';
+
+const bindings = new InngestMiddleware({
+  name: 'Cloudflare Workers bindings',
+  init({ client, fn }) {
+    return {
+      onFunctionRun({ ctx, fn, steps, reqArgs }) {
+        return {
+          transformInput({ ctx, fn, steps }) {
+            // reqArgs is the array of arguments passed to the Worker's fetch event handler
+            // ex. fetch(request, env, ctx)
+            // We cast the argument to the global Env var that Wrangler generates:
+            const env = reqArgs[1] as Env;
+            return {
+              ctx: {
+                // Return the env object to the function handler's input args
+                env,
+              },
+            };
+          },
+        };
+      },
+    };
+  },
+});
+
+// Include the middleware when creating the Inngest client
+export const inngest = new Inngest({
+  id: 'my-workers-app',
+  middleware: [bindings],
+});
+```
+
+```ts {{ title: "Hono" }}
+import { Inngest, InngestMiddleware } from 'inngest';
+import { type Context } from 'hono';
+
+type Bindings = {
+  MY_VAR: string;
+  DB_URL: string;
+  MY_BUCKET: R2Bucket;
+};
+
+const bindings = new InngestMiddleware({
+  name: 'Hono bindings',
+  init({ client, fn }) {
+    return {
+      onFunctionRun({ ctx, fn, steps, reqArgs }) {
+        return {
+          transformInput({ ctx, fn, steps }) {
+            // reqArgs is the array of arguments passed to a Hono handler
+            // We cast the argument to the correct Hono Context type with our
+            // environment variable bindings
+            const [honoCtx] = reqArgs as [Context<{ Bindings: Bindings }>];
+            return {
+              ctx: {
+                // Return the context's env object to the function handler's input args
+                env: honoCtx.env,
+              },
+            };
+          },
+        };
+      },
+    };
+  },
+});
+
+// Include the middleware when creating the Inngest client
+export const inngest = new Inngest({
+  id: 'my-hono-app',
+  middleware: [bindings],
+});
+```
+
+</CodeGroup>
+
+Within your functions, you can now access the environment variables via the `env` object argument that you returned in `transformInput` above. Here's an example function:
+
+```ts
+const myFn = inngest.createFunction(
+  { id: 'my-fn' },
+  { event: 'demo/event.sent' },
+  // The "env" argument returned in transformInput is passed through:
+  async ({ event, step, env }) => {
+
+    // The env object will be typed as well:
+    console.log(env.MY_VAR);
+  }
+);
+```

--- a/pages/docs/features/inngest-functions/steps-workflows/step-ai-orchestration.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-ai-orchestration.mdx
@@ -26,7 +26,7 @@ Using [AgentKit](https://agentkit.inngest.com) and `step.ai` allows you to:
   **In TypeScript, we strongly recommend using AgentKit, our AI SDK which adds multiple AI capabilities to Inngest.**  AgentKit allows you to call single-shot inference APIs with a simple self-documenting class, and also allows you to create semi or fully autonomous agent workflows using a network of agents.
 
   - [AgentKit GitHub repo](https://github.com/inngest/agent-kit)
-  - [AgentKit docs](/https://agentkit.inngest.com)
+  - [AgentKit docs](https://agentkit.inngest.com)
 </Callout>
 
 ## AgentKit: AI and agent orchestration
@@ -162,7 +162,7 @@ The list of current providers supported for `step.ai.infer()` is:
 
 - Streaming responses from providers is coming soon, alongisde realtime support with Inngest functions.
 
-- When using `step.ai.wrap` with sdk clients that require client instance context to be preserved between 
+- When using `step.ai.wrap` with sdk clients that require client instance context to be preserved between
 invocations, currently it's necessary to bind the client call outside the `step.ai.wrap` call like so:
 
 <CodeGroup>
@@ -253,7 +253,7 @@ export const openAIWrapCompletionCreate = inngest.createFunction(
 ```
 </CodeGroup>
 
-- When using `step.ai.wrap`, you can edit prompts and rerun steps in the dev server. 
+- When using `step.ai.wrap`, you can edit prompts and rerun steps in the dev server.
 But, arguments must be JSON serializable.
 
 <CodeGroup>
@@ -298,10 +298,10 @@ export const vercelWrapGenerateText = inngest.createFunction(
 
 - `step.ai.wrap's` Typescript definition will for the most part infer allowable inputs based on the
 signature of the wrapped function. However in some cases where the wrapped function contains complex
-overloads, such as Vercel's `generateObject`, it may be necessary to type cast. 
+overloads, such as Vercel's `generateObject`, it may be necessary to type cast.
 
-*Note*: Future version of the Typescript SDK will correctly infer these complex types but for now we 
-require type casting to ensure backwards compatibility. 
+*Note*: Future version of the Typescript SDK will correctly infer these complex types but for now we
+require type casting to ensure backwards compatibility.
 
 <CodeGroup>
 ```ts {{ title: "Vercel AI SDK" }}

--- a/pages/docs/features/middleware/create.mdx
+++ b/pages/docs/features/middleware/create.mdx
@@ -5,9 +5,10 @@ import {
   RiMistFill,
   RiPlugLine,
   RiTerminalBoxLine,
+  RiKeyLine,
 } from "@remixicon/react";
 
-# Creating a middleware
+# Creating middleware
 
 Creating middleware means defining the lifecycles and subsequent hooks in those lifecycles to run code in. Lifecycles are actions such as a function run or sending events, and individual hooks within those are where we run code, usually with a _before_ and _after_ step.
 
@@ -39,7 +40,7 @@ Creating middleware means defining the lifecycles and subsequent hooks in those 
       middleware: [myMiddleware],
     });
     ```
-    
+
 </GuideSection>
 
 <GuideSection show="python">
@@ -340,7 +341,7 @@ It's common for middleware to require additional customization or options from d
 
 ## Next steps
 
-Check out our pre-build middleware and examples:
+Check out our pre-built middleware and examples:
 
 <CardGroup cols={2}>
   <Card title="Dependency Injection" icon={<RiPlugLine className="text-basis h-4 w-4" />} href={'/docs/features/middleware/dependency-injection'}>
@@ -354,6 +355,9 @@ Check out our pre-build middleware and examples:
   </Card>
   <Card title="Datadog middleware" icon={<RiTerminalBoxLine className="text-basis h-4 w-4"/>} href={'/docs/examples/track-failures-in-datadog'}>
     Add tracing with Datadog under a few minutes.
+  </Card>
+  <Card title="Cloudflare Workers & Hono middleware" icon={<RiKeyLine className="text-basis h-4 w-4"/>} href={'/docs/examples/middleware/cloudflare-workers-environment-variables'}>
+    Access environment variables within Inngest functions.
   </Card>
 </CardGroup>
 

--- a/pages/docs/learn/serving-inngest-functions.mdx
+++ b/pages/docs/learn/serving-inngest-functions.mdx
@@ -1,4 +1,4 @@
-import { Callout, CodeGroup, VersionBadge, GuideSelector, GuideSection } from "shared/Docs/mdx";
+import { Callout, Tip, CodeGroup, VersionBadge, GuideSelector, GuideSection, Col, Row } from "shared/Docs/mdx";
 
 export const description = `Serve the Inngest API as an HTTP endpoint in your application.`
 export const hidePageSidebar = true;
@@ -32,13 +32,41 @@ serve({
 });
 ```
 
-<Callout>
-  You will find the complete list of supported frameworks below.
-</Callout>
+## Supported frameworks and platforms
 
-## Supported Platforms
+<div className="grid md:grid-cols-3">
 
-Below you will find a list of framework-specific bindings, as well as instructions on adding bindings to [custom platforms](#custom-frameworks)!
+<Col>
+* [Astro](#framework-astro)
+* [AWS Lambda](#framework-aws-lambda)
+* [Bun](#bun-serve)
+* [Cloudflare Pages](#framework-cloudflare-pages-functions)
+* [Cloudflare Workers](#framework-cloudflare-workers)
+* [DigitalOcean Functions](#framework-digital-ocean-functions)
+* [Express](#framework-express)
+</Col>
+<Col>
+* [Fastify](#framework-fastify)
+* [Fresh (Deno)](#framework-fresh-deno)
+* [Google Cloud Run Functions](#framework-google-cloud-run-functions)
+* [Firebase Cloud functions](#framework-firebase-cloud-functions)
+* [H3](#framework-h3)
+* [Hono](#framework-hono)
+* [Koa](#framework-koa)
+</Col>
+<Col>
+* [NestJS](#framework-nest-js)
+* [Next.js](#framework-next-js)
+* [Nitro](#framework-nitro)
+* [Nuxt](#framework-nuxt)
+* [Redwood](#framework-redwood)
+* [Remix](#framework-remix)
+* [SvelteKit](#framework-svelte-kit)
+</Col>
+
+</div>
+
+You can also create a custom serve handler for any framework or platform not listed here - [read more here](#custom-frameworks).
 
 <Callout variant="info">
   Want us to add support for another framework? Open an issue on [GitHub](https://github.com/inngest/website) or tell us about it on our [Discord](/discord).
@@ -155,10 +183,16 @@ export default {
   fetch: serve({
     client: inngest,
     functions: [fnA],
+    // We suggest explicitly defining the path to serve Inngest functions
+    servePath: "/api/inngest",
   }),
 };
 ```
 </CodeGroup>
+
+<Tip>
+  To automatically pass environment variables defined with Wrangler to Inngest function handlers, use the [Cloudflare Workers bindings middleware](/docs/examples/middleware/cloudflare-workers-environment-variables).
+</Tip>
 
 When developing locally with Wrangler and the `--remote` flag, your code is
 deployed and run remotely. To use this with a local Inngest Dev Server, you must
@@ -488,7 +522,7 @@ See the [github.com/unjs/h3](https://github.com/unjs/h3) repository for more inf
 
 ### Framework: Hono
 
-Add the following to `./src/index.ts`:
+Inngest supports the [Hono](https://hono.dev/) framework which is popularly deployed to Cloudflare Workers. Add the following to `./src/index.ts`:
 
 <CodeGroup>
 ```ts
@@ -510,6 +544,10 @@ app.on(
 export default app;
 ```
 </CodeGroup>
+
+<Tip>
+  To automatically pass environment variables defined with Wrangler to Inngest function handlers, use the [Hono bindings middleware](/docs/examples/middleware/cloudflare-workers-environment-variables).
+</Tip>
 
 See the [Hono example](https://github.com/inngest/inngest-js/blob/main/examples/framework-hono) for more information.
 

--- a/pages/docs/reference/middleware/examples.mdx
+++ b/pages/docs/reference/middleware/examples.mdx
@@ -1,4 +1,5 @@
-import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
+import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge, Card, CardGroup } from "src/shared/Docs/mdx";
+import { RiKeyLine } from "@remixicon/react"
 
 # Example middleware <VersionBadge version="v2.0.0+" />
 
@@ -8,6 +9,7 @@ The following examples show how you might use middleware in some real-world scen
 - [Common actions for every function](#common-actions-for-every-function)
 - [Logging](#logging)
 - [Prisma in function context](#prisma-in-function-context)
+- [Cloudflare Workers & Hono environment variables](/docs/examples/middleware/cloudflare-workers-environment-variables)
 
 ---
 
@@ -283,3 +285,10 @@ const prismaMiddleware = new InngestMiddleware({
 
 Check out [Common actions for every function](/docs/reference/middleware/examples#common-actions-for-every-function) to see how this technique can be used to create steps for all of your unique logic.
 
+## Other examples
+
+<CardGroup cols={2}>
+  <Card title="Cloudflare Workers & Hono middleware" icon={<RiKeyLine className="text-basis h-4 w-4"/>} href={'/docs/examples/middleware/cloudflare-workers-environment-variables'}>
+    Access environment variables within Inngest functions.
+  </Card>
+</CardGroup>

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -652,7 +652,7 @@ const sectionHome: (NavGroup | NavLink)[] = [
             href: `/docs/features/middleware`,
           },
           {
-            title: "Creating a middleware",
+            title: "Creating middleware",
             href: `/docs/features/middleware/create`,
           },
           {
@@ -861,6 +861,16 @@ const sectionExamples: NavGroup[] = [
       {
         title: "Cleanup after function cancellation",
         href: `/docs/examples/cleanup-after-function-cancellation`,
+      },
+    ],
+  },
+  {
+    title: "Middleware",
+    defaultOpen: true,
+    links: [
+      {
+        title: "Cloudflare Workers & Hono environment variables",
+        href: `/docs/examples/middleware/cloudflare-workers-environment-variables`,
       },
     ],
   },


### PR DESCRIPTION
This question comes up a lot and it should be documented and easy to find.

This also adds a table of contents to the serve docs now that the sidebar is disabled. It's much better to be able to see all the frameworks to save having to search/scroll.

<img width="924" alt="Screen Shot 2025-01-10 at 1 25 04 PM" src="https://github.com/user-attachments/assets/ddbb0123-55a9-448f-927e-13aab0825b8e" />
