### PR TITLE
Pricing: event size is measured in base-2, not base-10

### DIFF
--- a/app/pricing/plans.ts
+++ b/app/pricing/plans.ts
@@ -400,9 +400,9 @@ export const FEATURES: Feature[] = [
     name: "Event size",
     description: "The maximum size for a single event",
     plans: {
-      [PLAN_NAMES.basicFree]: "256KB",
-      [PLAN_NAMES.basic]: "512KB",
-      [PLAN_NAMES.pro]: "3MB",
+      [PLAN_NAMES.basicFree]: "256KiB",
+      [PLAN_NAMES.basic]: "512KiB",
+      [PLAN_NAMES.pro]: "3MiB",
       [PLAN_NAMES.enterprise]: "Custom",
     },
     infoUrl: "/docs/usage-limits/inngest#payload-size?ref=pricing",


### PR DESCRIPTION
The backend calculates and enforces event sizes based on base-2 sizes. This PR tweaks the units on the pricing page to match.

Ref: https://physics.nist.gov/cuu/Units/binary.html