### PR TITLE
docs: Fix data type and description

### DIFF
--- a/pages/docs/reference/functions/create.mdx
+++ b/pages/docs/reference/functions/create.mdx
@@ -52,8 +52,8 @@ The `createFunction` method accepts a series of arguments to define your functio
       <Property name="limit" type="number" required>
         The total number of runs allowed to start within the given `period`.
       </Property>
-      <Property name="period" type="number" required>
-        The period within the `limit` will be applied.
+      <Property name="period" type="string" required>
+        The period within which the `limit` will be applied.
       </Property>
       <Property name="burst" type="number">
         The number of runs allowed to start in the given window in a single burst. This defaults to 1, which ensures that requests are smoothed amongst the given `period`.


### PR DESCRIPTION
Fix "period" data type and description.

Should this data type be more explicit than `string`?
I'm not sure what the data type actually is, but my understanding is that it can only handle specific "duration" strings e.g. 5s, 10m, 4h, 6d etc.