### PR TITLE
Recommend users use the named Fastify plugin for compat

### DIFF
--- a/pages/docs/getting-started/nodejs-quick-start.mdx
+++ b/pages/docs/getting-started/nodejs-quick-start.mdx
@@ -1,4 +1,4 @@
-import { GuideSelector, GuideSection, GuideTitle, Callout, CodeGroup } from "src/shared/Docs/mdx";
+import { Callout, CodeGroup, GuideSection, GuideSelector, GuideTitle } from "src/shared/Docs/mdx";
 
 export const description =
   `Get started with Inngest in this ten-minute JavaScript tutorial`
@@ -190,7 +190,7 @@ Using your existing Fastify server, we'll set up Inngest using the provided Fast
 
 ```ts {{ filename: "./index.ts" }}
 import Fastify from "fastify";
-import inngestFastify from "inngest/fastify";
+import { fastifyPlugin } from "inngest/fastify";
 import { inngest, functions } from "./src/inngest"
 
 const fastify = Fastify({
@@ -198,7 +198,7 @@ const fastify = Fastify({
 });
 
 // This automatically adds the "/api/inngest" routes to your server
-fastify.register(inngestFastify, {
+fastify.register(fastifyPlugin, {
   client: inngest,
   functions,
   options: {},
@@ -409,13 +409,13 @@ app.listen(3000, () => {
 <GuideSection show="fastify">
 ```ts {{ filename: "./index.ts" }}
 import Fastify from "fastify";
-import inngestFastify from "inngest/fastify";
+import { fastifyPlugin } from "inngest/fastify";
 import { inngest, functions } from "./src/inngest"
 
 const fastify = Fastify({
   logger: true,
 });
-fastify.register(inngestFastify, { client: inngest, functions, options: {} });
+fastify.register(fastifyPlugin, { client: inngest, functions, options: {} });
 
 // Create a new route:
 fastify.get("/api/hello", async function (request, reply) {

--- a/pages/docs/learn/serving-inngest-functions.mdx
+++ b/pages/docs/learn/serving-inngest-functions.mdx
@@ -1,4 +1,4 @@
-import { Callout, Tip, Info, CodeGroup, VersionBadge, GuideSelector, GuideSection, Col, Row, Card, CardGroup } from "shared/Docs/mdx";
+import { Callout, Card, CardGroup, CodeGroup, Col, GuideSection, GuideSelector, Info, Row, Tip, VersionBadge } from "shared/Docs/mdx";
 
 export const description = `Serve the Inngest API as an HTTP endpoint in your application.`
 export const hidePageSidebar = true;
@@ -336,12 +336,12 @@ We recommend using the exported `inngestFastify` plugin, though we also expose a
 <CodeGroup>
 ```ts {{ title: "Plugin" }}
 import Fastify from "fastify";
-import inngestFastify from "inngest/fastify";
+import { fastifyPlugin } from "inngest/fastify";
 import { inngest, fnA } from "./inngest";
 
 const fastify = Fastify();
 
-fastify.register(inngestFastify, {
+fastify.register(fastifyPlugin, {
   client: inngest,
   functions: [fnA],
   options: {},


### PR DESCRIPTION
## Summary

Following inngest/inngest-js#925, we recommend developers use the named export of our `inngest/fastify` plugin instead of the default, as that can lead to CJS<->ESM interop hell in certain configurations.

> [!NOTE]
> Fastify plugins are traditionally the default export from the package, but we'll go against the grain here to save our users some grief.

## Related

- Documentation tweak for inngest/inngest-js#925
- Follows recommendation made in inngest/inngest-js#736