### PR TITLE
fix: bun install global

### DIFF
--- a/pages/docs/getting-started/nodejs-quick-start.mdx
+++ b/pages/docs/getting-started/nodejs-quick-start.mdx
@@ -104,7 +104,7 @@ yarn dlx inngest-cli@latest dev -u http://localhost:3000/api/inngest
 pnpm dlx inngest-cli@latest dev -u http://localhost:3000/api/inngest
 ```
 ```shell {{ title: "bun" }}
-bun add global inngest-cli@latest
+bun install --global inngest-cli@latest
 inngest-cli dev -u http://localhost:3000/api/inngest
 ```
 </CodeGroup>


### PR DESCRIPTION
`bun add global` is wrong and it would attempt to install a package named 'global' alongside 'inngest-cli' rather than installing 'inngest-cli' globally."

It should be `bun install --global inngest-cli@latest`