### PR TITLE
chore: fixed overflow dark mode

### DIFF
--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -146,6 +146,19 @@ const modeScript = `
 
   document.documentElement.classList.add('docs');
 
+  const styleEl = document.createElement('style');
+  styleEl.id = 'dark-mode-styles';
+  styleEl.textContent = \`
+    html.dark {
+      background-color: rgb(var(--color-carbon-1000)) !important;
+      min-height: 100vh;
+    }
+    html.dark body {
+      background-color: rgb(var(--color-carbon-1000)) !important;
+    }
+  \`;
+  document.head.appendChild(styleEl);
+
   // change to "let = darkModeMediaQuery" if/when this moves to the _document
   window.darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
 

--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -146,19 +146,6 @@ const modeScript = `
 
   document.documentElement.classList.add('docs');
 
-  const styleEl = document.createElement('style');
-  styleEl.id = 'dark-mode-styles';
-  styleEl.textContent = \`
-    html.dark {
-      background-color: rgb(var(--color-carbon-1000)) !important;
-      min-height: 100vh;
-    }
-    html.dark body {
-      background-color: rgb(var(--color-carbon-1000)) !important;
-    }
-  \`;
-  document.head.appendChild(styleEl);
-
   // change to "let = darkModeMediaQuery" if/when this moves to the _document
   window.darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1119,6 +1119,11 @@ ul.check li {
   }
 }
 
+html.docs.dark {
+  min-height: 100vh !important;
+  background-color: rgb(var(--color-carbon-1000)) !important;
+}
+
 /* default colors */
 body {
   background-color: rgb(var(--color-background-canvas-base));


### PR DESCRIPTION
### Summary
Currently in the docs, if you scroll too far down, you can see the canvas underneath which is default light mode color

<img width="1306" alt="Screenshot 2025-05-09 at 1 10 12 PM" src="https://github.com/user-attachments/assets/36e9534d-f055-466a-8b70-33e5cd9b5023" />

This fixes the unintended behavior

<img width="1306" alt="Screenshot 2025-05-09 at 1 10 28 PM" src="https://github.com/user-attachments/assets/5dd2551c-5937-49ea-8544-1a624374104e" />

Add dark-mode rules to `styles/globals.css` to fix overflow
