### PR TITLE
Fix copy button overlapping with code tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ pnpm dev
 
 This will start a local server that will automatically rebuild the app and refresh the page when you
 make changes to the code. The app will be available at
-[http://localhost:3000](http://localhost:3000).
+[http://localhost:3001](http://localhost:3001).
 
 This is how you will run the app most of the time.
 

--- a/shared/Docs/Code.tsx
+++ b/shared/Docs/Code.tsx
@@ -140,9 +140,9 @@ function CodePanel({ tag, label, code, children }: CodePanelProps) {
         tag={child.props.tag ?? tag}
         label={child.props.label ?? label}
       />
-      {/* Uses absolute positioning for now with CodeGroup container */}
-      <CopyButton code={child.props.code ?? code} />
-      <div>
+      {/* Added wrapper to contain button within code area and prevent tab overlap */}
+      <div className="relative">
+        <CopyButton code={child.props.code ?? code} />
         <pre className="overflow-x-auto px-6 py-5 text-xs text-basis leading-relaxed">
           {children}
         </pre>


### PR DESCRIPTION
## Motivation

The copy button in code blocks was overlapping with version tabs (v3, v2, etc.) making it difficult to switch between tabs in some cases.

<img width="827" alt="image" src="https://github.com/user-attachments/assets/53e7c5aa-ea95-463c-87a3-3e8e8a7715b9" />

## Solution
Added a relative positioned wrapper around the code content area that contains the copy button. This changes the positioning context of the copy button so it remains within the code content area rather than being positioned relative to the entire code group container.

<img width="809" alt="image" src="https://github.com/user-attachments/assets/9a0d9f34-f2a6-4bc6-af1a-967af43a9c9c" />

The fix maintains the existing design and functionality while ensuring the copy button doesn't interfere with tab selection.
