### PR TITLE
Add recommendation for encryption middleware best practice

### DIFF
--- a/pages/docs/features/events-triggers/event-format.mdx
+++ b/pages/docs/features/events-triggers/event-format.mdx
@@ -11,10 +11,11 @@ The event payload is a JSON object that must contain a `name` and `data` propert
 
 ### Optional properties
 
-* `user` contains any relevant user-identifying data or attributes associated with the event. This data is encrypted at rest. For example, you might include the user's `id`, `email`, and `name` in the `user` property. The `user` property can contain any JSON object, including nested objects and arrays.
 * `id` is a unique identifier for the event used to prevent duplicate events. Learn more about [deduplication](#deduplication).
 * `ts` is the timestamp of the event in milliseconds since the Unix epoch. If not provided, the timestamp will be set to the time the event was received by Inngest.
 * `v` is the event payload version. This is useful to track changes in the event payload shape over time. For example, `"2024-01-14.1"`
+* `user` is object for ease of grouping user-identifying data or attributes associated with the event. This data is encrypted at rest.
+  * **NOTE** - We now recommend that developers use [encryption middleware](/docs/features/middleware/encryption-middleware) to store personally identifiable information (PII) within the `data` object. Encryption middleware also has added benefits as it supports full or partial encryption of data returned from steps as well as complete control over the encryption key.
 
 <CodeGroup>
 ```json {{ title: "Basic JSON event example" }}


### PR DESCRIPTION
Encryption middleware offers more functionality and control for the end developer and is what we currently recommend.