### PR TITLE
Add Express streaming to TS SDK docs

### DIFF
--- a/pages/docs/learn/serving-inngest-functions.mdx
+++ b/pages/docs/learn/serving-inngest-functions.mdx
@@ -324,7 +324,28 @@ app.use(
 You must ensure you're using the `express.json()` middleware otherwise your functions won't be
 executed. **Note** - You may need to set [`express.json()`'s `limit` option](https://expressjs.com/en/5x/api.html#express.json) to something higher than the default `100kb` to support larger event payloads and function state.
 
-See the [Express example](https://github.com/inngest/inngest-js/tree/main/examples/framework-express) for more information.
+See the [Express
+example](https://github.com/inngest/inngest-js/tree/main/examples/framework-express)
+for more information.
+
+#### Streaming <VersionBadge version="v3.39.2+" />
+
+Express can also stream responses back to Inngest, potentially allowing much
+longer timeouts.
+
+To enable this, set add the `streaming: "force"` option to your serve handler:
+
+<CodeGroup>
+```ts {{ title: "v3" }}
+const handler = serve({
+  client: inngest,
+  functions: [...fns],
+  streaming: "force",
+});
+```
+</CodeGroup>
+
+For more information, check out the [Streaming](/docs/streaming) page.
 
 
 ### Framework: Fastify <VersionBadge version="v2.6.0+" />

--- a/pages/docs/streaming.mdx
+++ b/pages/docs/streaming.mdx
@@ -6,9 +6,10 @@ In select environments, the SDK allows streaming responses back to Inngest, huge
 
 While we add wider support for streaming to other platforms, we currently support the following:
 
+- [Cloudflare Workers](/docs/learn/serving-inngest-functions#framework-cloudflare-workers)
+- [Express](/docs/learn/serving-inngest-functions#framework-express)
 - [Next.js on Vercel Edge Functions](/docs/learn/serving-inngest-functions#framework-next-js)
 - [Remix on Vercel Edge Functions](/docs/learn/serving-inngest-functions#framework-remix)
-- [Cloudflare Workers](/docs/learn/serving-inngest-functions#framework-cloudflare-workers)
 
 ## Enabling streaming
 


### PR DESCRIPTION
## Summary

Adds docs for Express streaming being added in inngest/inngest-js#1001.

## Related

- Docs for inngest/inngest-js#1001