### PR TITLE
Added Anthropic, Grok & Azure models to docs

### DIFF
--- a/pages/docs/features/inngest-functions/steps-workflows/step-ai-orchestration.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-ai-orchestration.mdx
@@ -172,6 +172,9 @@ The list of current providers supported for `step.ai.infer()` is:
 
 - `openai`, including any OpenAI compatible API such as Perplexity
 - `gemini`
+- `anthropic`
+- `grok`
+- `azure-openai`
 
 ### Limitations
 


### PR DESCRIPTION
We currently support Anthropic Claude and Grok.

Once we merge the PR below we will have support for Azure models.

Related:
https://github.com/inngest/inngest-js/pull/1015