### PR TITLE
Self hosting documentation update

### DIFF
--- a/pages/docs/self-hosting.mdx
+++ b/pages/docs/self-hosting.mdx
@@ -109,7 +109,7 @@ Flags:
       --signing-key string   Signing key used to sign and validate data between the server and apps.
 
 Persistence Flags:
-      --postgres-uri string   [Experimental] PostgreSQL database URI for configuration and history persistence. Defaults to SQLite database.
+      --postgres-uri string   PostgreSQL database URI for configuration and history persistence. Defaults to SQLite database.
       --redis-uri string      Redis server URI for external queue and run state. Defaults to self-contained, in-memory Redis server with periodic snapshot backups.
       --sqlite-dir string     Directory for where to write SQLite database.
 


### PR DESCRIPTION
Remove experimental status of PostgreSQL database URI in self-hosting documentation