### PR TITLE
Update self-hosting docs with signing key reqs

### DIFF
--- a/pages/docs/self-hosting.mdx
+++ b/pages/docs/self-hosting.mdx
@@ -58,7 +58,7 @@ Now that you have the CLI installed, you can start the Inngest server using the 
 
 <CodeGroup>
 ```plaintext {{ title: "shell" }}
-inngest start --event-key abc --signing-key xyz
+inngest start --event-key abcd --signing-key 1234
 ```
 ```plaintext {{ title: "Docker" }}
 docker run -p 8288:8288 -p 8289:8289 -e INNGEST_EVENT_KEY=abc -e INNGEST_SIGNING_KEY=xyz inngest/inngest inngest start
@@ -79,6 +79,13 @@ By default, the server will:
 * Disable app sync polling to check for new functions or updated configurations (see `--poll-interval` flag).
 
 To securely configure your server, create your event and signing keys using whatever format you choose and start the Inngest server using them. You can also pass them via environment variable (see below):
+
+<Callout>
+The signing key must be a hexadecimal string. You can generate a secure signing key using: 
+```plaintext
+openssl rand -hex 32
+```
+</Callout>
 
 ```plaintext
 inngest start --event-key <YOUR_EVENT_KEY> --signing-key <YOUR_SIGNING_KEY>

--- a/pages/docs/self-hosting.mdx
+++ b/pages/docs/self-hosting.mdx
@@ -61,7 +61,7 @@ Now that you have the CLI installed, you can start the Inngest server using the 
 inngest start --event-key abcd --signing-key 1234
 ```
 ```plaintext {{ title: "Docker" }}
-docker run -p 8288:8288 -p 8289:8289 -e INNGEST_EVENT_KEY=abc -e INNGEST_SIGNING_KEY=xyz inngest/inngest inngest start
+docker run -p 8288:8288 -p 8289:8289 -e INNGEST_EVENT_KEY=abcd -e INNGEST_SIGNING_KEY=1234 inngest/inngest inngest start
 ```
 </CodeGroup>
 


### PR DESCRIPTION
Updates self-hosting documentation to improve signing key guidance and examples.

Changes

- Updates example keys in shell and Docker commands to use valid placeholder values (abcd and 1234 instead of abc and xyz)
- Adds a callout box explaining that signing keys must be hexadecimal strings
- Includes a practical command (openssl rand -hex 32) to generate secure signing keys