### PR TITLE
Add Helm chart section for Kubernetes deployments in self-hosting guide

### DIFF
--- a/pages/docs/self-hosting.mdx
+++ b/pages/docs/self-hosting.mdx
@@ -1,4 +1,5 @@
 import { Callout, Warning, CodeGroup, DownloadLink } from "src/shared/Docs/mdx";
+import Github from "src/shared/Icons/Github.tsx";
 
 export const description = 'Learn how to self-host Inngest. Includes configuration options and instructions for using external services.'
 
@@ -268,6 +269,32 @@ networks:
 ```
 
 <DownloadLink url="/files/docker-compose.yml" children="Download docker-compose.yml" filename="docker-compose.yml" />
+
+## Helm chart
+
+Inngest provides a Helm chart for production-ready Kubernetes deployments. Key features include:
+
+**Quick Setup & Production Ready**
+- Supports Kubernetes 1.20+ and Helm 3.0+ with simple installation
+- Bundled PostgreSQL and Redis for easy setup, with support for external databases
+- Consistent resource naming across all environments regardless of Helm release name
+- Deployment examples for development, production, and hybrid scenarios
+
+**Autoscaling & Performance**
+- KEDA-based autoscaling using Inngest's Prometheus metrics
+- Configurable replica counts, resource limits, and queue worker settings
+- Horizontal pod autoscaling based on queue depth
+
+**Security & Access**
+- Security-first design with non-root execution and read-only filesystem
+- Database credentials stored securely in Kubernetes Secrets
+- Network policy support for additional cluster isolation
+- Built-in ingress support with SSL certificate provisioning via cert-manager
+- Let's Encrypt integration for production HTTPS endpoints
+
+You can find the chart, documentation, and configuration examples here:
+
+[<Github size="1.25em" className="inline-block mr-1"/> inngest/inngest-helm](https://github.com/inngest/inngest-helm)
 
 ## Roadmap & feature requests
 


### PR DESCRIPTION
_trying the copilot summary generator_ 😊

This pull request updates the self-hosting documentation for Inngest to include information about the Helm chart for Kubernetes deployments and adds a `Github` icon component for linking to the Helm chart repository.

### Documentation updates:

* [`pages/docs/self-hosting.mdx`](diffhunk://#diff-9726d7baf8dd64dcaff63a7266cfe55483d75a537d1fec05e382f50056ace910R273-R298): Added a new section detailing the features and benefits of the Helm chart for Kubernetes deployments, including setup instructions, autoscaling capabilities, and security features.

### UI enhancements:

* [`pages/docs/self-hosting.mdx`](diffhunk://#diff-9726d7baf8dd64dcaff63a7266cfe55483d75a537d1fec05e382f50056ace910R2): Imported the `Github` icon component and used it to enhance the link to the Helm chart repository, improving visual clarity and user experience.