### PR TITLE
Clarify signing key requirements in self-hosting guide

### DIFF
--- a/pages/docs/self-hosting.mdx
+++ b/pages/docs/self-hosting.mdx
@@ -82,7 +82,7 @@ By default, the server will:
 To securely configure your server, create your event and signing keys using whatever format you choose and start the Inngest server using them. You can also pass them via environment variable (see below):
 
 <Callout>
-The signing key must be a hexadecimal string. You can generate a secure signing key using: 
+The signing key must be a valid hexadecimal string with an even number of characters. You can generate a secure signing key using: 
 ```plaintext
 openssl rand -hex 32
 ```
@@ -208,8 +208,8 @@ services:
       - "8288:8288"
       - "8289:8289"
     environment:
-      - INNGEST_EVENT_KEY=your_event_key_here # Must be a hexadecimal string
-      - INNGEST_SIGNING_KEY=your_signing_key_here # Must be a hexadecimal string
+      - INNGEST_EVENT_KEY=your_event_key_here # Must be hex string with even number of chars
+      - INNGEST_SIGNING_KEY=your_signing_key_here # Must be hex string with even number of chars
       - INNGEST_POSTGRES_URI=postgres://inngest:password@postgres:5432/inngest
       - INNGEST_REDIS_URI=redis://redis:6379
     depends_on:

--- a/public/files/docker-compose.yml
+++ b/public/files/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       - "8288:8288"
       - "8289:8289"
     environment:
-      - INNGEST_EVENT_KEY=your_event_key_here # Must be a hexadecimal string
-      - INNGEST_SIGNING_KEY=your_signing_key_here # Must be a hexadecimal string
+      - INNGEST_EVENT_KEY=your_event_key_here # Must be hex string with even number of chars
+      - INNGEST_SIGNING_KEY=your_signing_key_here # Must be hex string with even number of chars
       - INNGEST_POSTGRES_URI=postgres://inngest:password@postgres:5432/inngest
       - INNGEST_REDIS_URI=redis://redis:6379
     depends_on:


### PR DESCRIPTION
This pull request updates documentation and configuration files to clarify requirements for hexadecimal strings used as keys. The changes ensure users understand that the keys must have an even number of characters.

### Documentation updates:
* [`pages/docs/self-hosting.mdx`](diffhunk://#diff-9726d7baf8dd64dcaff63a7266cfe55483d75a537d1fec05e382f50056ace910L85-R85): Updated the description of signing key requirements to specify that the hexadecimal string must have an even number of characters.

### Configuration updates:
* [`pages/docs/self-hosting.mdx`](diffhunk://#diff-9726d7baf8dd64dcaff63a7266cfe55483d75a537d1fec05e382f50056ace910L211-R212): Modified environment variable comments to reflect the requirement for hexadecimal strings with an even number of characters.
* [`public/files/docker-compose.yml`](diffhunk://#diff-97554f662796e6a04a617631b2b45c6bfe4eec66dd7ea07c40c17ca356c20d56L9-R10): Updated environment variable comments to specify that keys must be hexadecimal strings with an even number of characters.