### PR TITLE
docs: fix missing app arg in Express example

### DIFF
--- a/pages/docs/features/realtime.mdx
+++ b/pages/docs/features/realtime.mdx
@@ -185,13 +185,14 @@ Subscribing can be done using an Inngest client that either has a valid signing 
     ```
 
     ```ts {{ title: "Express" }}
+    import { getInngestApp } from "@/inngest";
     import { getSubscriptionToken } from "@inngest/realtime";
     import { getAuth } from "src/auth"; // this could be any auth provider
 
     app.post("/get-subscribe-token", async (req, res) => {
       const { userId } = getAuth(req)
 
-      const token = await getSubscriptionToken({
+      const token = await getSubscriptionToken(getInngestApp(), {
         channel: `user:${userId}`,
         topics: ["ai"],
       })


### PR DESCRIPTION
Updated getSubscriptionToken call to include getInngestApp() as an argument.

This is copied from the Next example, so not sure if you want to keep the `getInngestApp()` or do something else.