### PR TITLE
Update go snippets with latest APIs.

### DIFF
--- a/pages/docs/dev-server.mdx
+++ b/pages/docs/dev-server.mdx
@@ -83,7 +83,7 @@ When using the Inngest SDK locally, it tries to detect if the dev server is runn
 ```ts {{ title: "Node.js" }}
 import { Inngest } from "inngest";
 
-const inngest = new Inngest({ id: "my-app" });
+const inngest = new Inngest({ id: "my_app" });
 await inngest.send({
   name: "user.avatar.uploaded",
   data: { url: "https://a-bucket.s3.us-west-2.amazonaws.com/..." },
@@ -103,10 +103,14 @@ await inngest_client.send(
 ```go {{ title: "Go" }}
 package main
 
-import "github.com/inngest/inngest-go"
+import "github.com/inngest/inngestgo"
 
 func main() {
-  inngestgo.Send(context.Background(), inngestgo.Event{
+  client, err := inngestgo.NewClient(inngestgo.ClientOpts{
+		AppID: "my_app",
+	})
+  
+  client.Send(context.Background(), inngestgo.Event{
     Name: "user.avatar.uploaded",
     Data: map[string]any{"url": "https://a-bucket.s3.us-west-2.amazonaws.com/..."},
   })

--- a/pages/docs/events/index.mdx
+++ b/pages/docs/events/index.mdx
@@ -93,16 +93,31 @@ await inngest_client.send(
 
 <GuideSection show="go">
 
-You can send a single event, or [multiple events at once](#sending-multiple-events-at-once).
+```go {{ title: "Go" }}
+  import "github.com/inngest/inngestgo"
 
+  func main() {
+    client, err := inngestgo.NewClient(inngestgo.ClientOpts{
+		  AppID: "acme-storefront-app",
+    })
+    if err != nil {
+      panic(err)
+    }
+  }
+```
+
+Now with this client, you can send events from anywhere in your app. You can send a single event, or [multiple events at once](#sending-multiple-events-at-once).
 
 ```go {{ title: "Go" }}
 package main
 
-import "github.com/inngest/inngest-go"
+import "github.com/inngest/inngestgo"
 
 func main() {
-  inngestgo.Send(context.Background(), inngestgo.Event{
+  // ...
+  // ...
+  
+  client.Send(context.Background(), inngestgo.Event{
     Name: "storefront/cart.checkout.completed",
     Data: map[string]any{
       "cartId": "ed12c8bde",
@@ -306,7 +321,7 @@ ids = await inngest_client.send(
 <GuideSection show="go">
 
 ```go
-_, err := inngestgo.SendMany(ctx, []inngestgo.Event{
+_, err := client.SendMany(ctx, []inngestgo.Event{
   {
     Name: "storefront/cart.checkout.completed",
     Data: data,
@@ -324,10 +339,10 @@ _, err := inngestgo.SendMany(ctx, []inngestgo.Event{
 
 ## Using Event IDs
 
-Each event sent to Inngest is assigned a unique Event ID. These `ids` are returned from `inngestgo.SendMany()` . Event IDs can be used to look up the event in the Inngest dashboard or via [the REST API](https://api-docs.inngest.com/docs/inngest-api/pswkqb7u3obet-get-an-event). You can choose to log or save these Event IDs if you want to look them up later.
+Each event sent to Inngest is assigned a unique Event ID. These `ids` are returned from `client.SendMany()` . Event IDs can be used to look up the event in the Inngest dashboard or via [the REST API](https://api-docs.inngest.com/docs/inngest-api/pswkqb7u3obet-get-an-event). You can choose to log or save these Event IDs if you want to look them up later.
 
 ```go
-ids, err := inngestgo.SendMany(ctx, []inngestgo.Event{
+ids, err := client.SendMany(ctx, []inngestgo.Event{
   {
     Name: "storefront/cart.checkout.completed",
     Data: data,
@@ -458,10 +473,17 @@ await inngest_client.send(
 ```go {{ title: "Go" }}
 package main
 
-import "github.com/inngest/inngest-go"
+import "github.com/inngest/inngestgo"
 
 func main() {
-  inngestgo.Send(context.Background(), inngestgo.Event{
+  client, err := inngestgo.NewClient(inngestgo.ClientOpts{
+		AppID: "core",
+  })
+  if err != nil {
+    panic(err)
+  }
+  
+  client.Send(context.Background(), inngestgo.Event{
     Name: "storefront/cart.checkout.completed",
     ID: "cart-checkout-completed-ed12c8bde",
     Data: map[string]any{

--- a/pages/docs/guides/background-jobs.mdx
+++ b/pages/docs/guides/background-jobs.mdx
@@ -94,8 +94,8 @@ Let's walk through the code step by step:
 ```go
 import (
     "time"
-    "github.com/inngest/inngest-go"
-    "github.com/inngest/inngest-go/step"
+    "github.com/inngest/inngestgo"
+    "github.com/inngest/inngestgo/step"
 )
 
 inngestgo.CreateFunction(
@@ -132,7 +132,7 @@ inngestgo.CreateFunction(
 Your `sendSignUpEmail` function will be triggered whenever Inngest receives an event called `app/user.created`. is received. You send this event to Inngest like so:
 
 ```go
-_, err := inngestgo.Send(context.Background(), inngestgo.Event{
+_, err := client.Send(context.Background(), inngestgo.Event{
     Name: "app/user.created", // This matches the event used in `createFunction`
     Data: map[string]interface{}{
         "email": "test@example.com",

--- a/pages/docs/guides/delayed-functions.mdx
+++ b/pages/docs/guides/delayed-functions.mdx
@@ -90,8 +90,8 @@ You can delay jobs using the [`step.Sleep()`](https://pkg.go.dev/github.com/inng
 ```go
 import (
     "time"
-    "github.com/inngest/inngest-go"
-    "github.com/inngest/inngest-go/step"
+    "github.com/inngest/inngestgo"
+    "github.com/inngest/inngestgo/step"
 )
 
 inngestgo.CreateFunction(

--- a/pages/docs/guides/fan-out-jobs.mdx
+++ b/pages/docs/guides/fan-out-jobs.mdx
@@ -116,6 +116,14 @@ First, set up a `/signup` route handler to send an event to Inngest when a user 
 
 ```go {{ filename: "main.go" }}
 func main() {
+    // Initialize the Inngest SDK client
+    client, err := inngestgo.NewClient(inngestgo.ClientOpts{
+		  AppID: "core",
+	  })
+	  if err != nil {
+		  panic(err)
+	  }
+
     // Initialize your HTTP server
     mux := http.NewServeMux()
 
@@ -136,7 +144,7 @@ func main() {
         }
 
         // Send event to Inngest
-        _, err := inngestgo.Send(r.Context(), inngestgo.Event{
+        _, err := client.Send(r.Context(), inngestgo.Event{
             Name: "app/user.signup",
             Data: map[string]interface{}{
                 "user": map[string]interface{}{
@@ -164,8 +172,8 @@ Next, define two functions: `sendWelcomeEmail` and `startStripeTrial`. As you ca
 
 ```go {{ filename: "inngest/functions.go" }}
 import (
-    "github.com/inngest/inngest-go"
-    "github.com/inngest/inngest-go/step"
+    "github.com/inngest/inngestgo"
+    "github.com/inngest/inngestgo/step"
 )
 
 func sendWelcomeEmail(client inngestgo.Client) (inngestgo.ServableFunction, error) {

--- a/pages/docs/guides/multi-step-functions.mdx
+++ b/pages/docs/guides/multi-step-functions.mdx
@@ -152,7 +152,7 @@ Consider this simple [Inngest function](/docs/learn/inngest-functions) which sen
 <CodeGroup>
 ```go
 import (
-    "github.com/inngest/inngest-go"
+    "github.com/inngest/inngestgo"
 )
 
 inngestgo.CreateFunction(
@@ -178,13 +178,13 @@ However, there is a new requirement: if a user hasn't created a post on our plat
 ### 1. Convert to a step function
 
 First, let's convert this function into a multi-step function:
-- Add a `github.com/inngest/inngest-go/step` import
+- Add a `github.com/inngest/inngestgo/step` import
 - Wrap `sendEmail()` call in a [`step.Run()`](https://pkg.go.dev/github.com/inngest/inngestgo@v0.7.4/step#Run) method.
 
 ```go
 import (
-    "github.com/inngest/inngest-go"
-    "github.com/inngest/inngest-go/step"
+    "github.com/inngest/inngestgo"
+    "github.com/inngest/inngestgo/step"
 )
 
 inngestgo.CreateFunction(
@@ -218,8 +218,8 @@ To do this, we can use the [`step.WaitForEvent()`](https://pkg.go.dev/github.com
 <CodeGroup>
 ```go
 import (
-    "github.com/inngest/inngest-go"
-    "github.com/inngest/inngest-go/step"
+    "github.com/inngest/inngestgo"
+    "github.com/inngest/inngestgo/step"
 )
 
 inngestgo.CreateFunction(
@@ -265,8 +265,8 @@ Finally, we can use the `postCreated` variable to send the reminder email if the
 <CodeGroup>
 ```go
 import (
-    "github.com/inngest/inngest-go"
-    "github.com/inngest/inngest-go/step"
+    "github.com/inngest/inngestgo"
+    "github.com/inngest/inngestgo/step"
 )
 
 inngestgo.CreateFunction(

--- a/pages/docs/guides/sending-events-from-functions.mdx
+++ b/pages/docs/guides/sending-events-from-functions.mdx
@@ -101,7 +101,7 @@ By using [`step.sendEvent()`](/docs/reference/functions/step-send-event) Inngest
 </GuideSection>
 <GuideSection show="go">
 
-To send events from within functions, you  will use [`inngestgo.Send()`](https://pkg.go.dev/github.com/inngest/inngestgo#Send). This method takes a single event, or an array of events. The example below uses an array of events.
+To send events from within functions, you  will use [`step.Send()`](https://pkg.go.dev/github.com/inngest/inngestgo/step#Send) or [`step.SendMany()`](https://pkg.go.dev/github.com/inngest/inngestgo/step#SendMany)
 
 This is an example of a [scheduled function](/docs/guides/scheduled-functions) that sends a weekly activity email to all users.
 

--- a/pages/docs/guides/working-with-loops.mdx
+++ b/pages/docs/guides/working-with-loops.mdx
@@ -107,8 +107,8 @@ Let's start with a simple example to illustrate the concept:
 ```go
 import (
     "fmt"
-    "github.com/inngest/inngest-go"
-    "github.com/inngest/inngest-go/step"
+    "github.com/inngest/inngestgo"
+    "github.com/inngest/inngestgo/step"
 )
 
 inngestgo.CreateFunction(
@@ -191,8 +191,8 @@ With this in mind, here is how the previous example can be fixed:
 ```go
 import (
     "fmt"
-    "github.com/inngest/inngest-go"
-    "github.com/inngest/inngest-go/step"
+    "github.com/inngest/inngestgo"
+    "github.com/inngest/inngestgo/step"
 )
 
 inngestgo.CreateFunction(

--- a/pages/docs/usage-limits/inngest.mdx
+++ b/pages/docs/usage-limits/inngest.mdx
@@ -76,7 +76,7 @@ await inngest.send(events);
 // this `events` list will need to be <= 5000
 events := []inngestgo.Event{{Name: "<event-name>", Data: {}}}
 
-ids, err := inngestgo.SendMany(ctx, events)
+ids, err := client.SendMany(ctx, events)
 ```
 
 ```python {{ title: "Python" }}


### PR DESCRIPTION
Update go snippets with latest APIs for sending events.

Docs still refer to inngest.Send which I think was deprecated in v0.8 Go SDK in favour of client.Send.