### PR TITLE
Update schema docs to include `.fromSchema`

### DIFF
--- a/pages/docs/reference/client/create.mdx
+++ b/pages/docs/reference/client/create.mdx
@@ -66,48 +66,34 @@ We recommend setting the [`INNGEST_EVENT_KEY`](/docs/sdk/environment-variables#i
 
 ## Defining Event Payload Types
 
-You can leverage TypeScript or Zod to define your event payload types. When you pass types to the Inngest client, events are fully typed when using them with `inngest.send()` and `inngest.createFunction()`. This can more easily alert you to issues with your code during compile time.
+You can leverage TypeScript, Zod, Valibot, or any schema library that
+implements the [Standard Schema interface](https://standardschema.dev/) to define
+your event payload types.
+
+When you pass types to the Inngest client,
+events are fully typed when using them with `inngest.send()` and
+`inngest.createFunction()`. This can more easily alert you to issues with your
+code during compile time.
 
 <Callout>
 Click the toggles on the top left of the code block to see the different methods available!
 </Callout>
 
 <CodeGroup forceTabs={true}>
-```ts {{ title: "Zod" }}
-import { EventSchemas, Inngest, type LiteralZodEventSchema } from "inngest";
+```ts {{ title: "Standard Schema" }}
+import { EventSchemas, Inngest } from "inngest";
 import { z } from "zod";
 
-// Define each event individually
-const productPurchasedEvent = z.object({
-  name: z.literal("shop/product.purchased"),
-  data: z.object({ productId: z.string() }),
-});
-
-// You can use satisfies to provide some autocomplete when writing the event
-const productViewedEvent = z.object({
-  name: z.literal("shop/product.viewed"),
-  data: z.object({ productId: z.string() }),
-}) satisfies LiteralZodEventSchema;
-
-// Or all together in a single object
-const eventsMap = {
-  "app/account.created": {
-    data: z.object({
+export const inngest = new Inngest({
+  schemas: new EventSchemas().fromSchema({
+    "app/account.created": z.object({
       userId: z.string(),
     }),
-  },
-  "app/subscription.started": {
-    data: z.object({
+    "app/subscription.started": z.object({
       userId: z.string(),
       planId: z.string(),
     }),
-  },
-};
-
-export const inngest = new Inngest({
-  schemas: new EventSchemas()
-    .fromZod([productPurchasedEvent, productViewedEvent])
-    .fromZod(eventsMap),
+  }),
 });
 ```
 ```ts {{ title: "Union" }}
@@ -166,11 +152,9 @@ type Events = {
 };
 
 const zodEventSchemas = {
-  "app/account.created": {
-    data: z.object({
-      userId: z.string(),
-    }),
-  },
+  "app/account.created": z.object({
+    userId: z.string(),
+  }),
 };
 
 type AppPostCreated = {
@@ -187,7 +171,7 @@ export const inngest = new Inngest({
   schemas: new EventSchemas()
     .fromRecord<Events>()
     .fromUnion<AppPostCreated | AppPostDeleted>()
-    .fromZod(zodEventSchemas),
+    .fromSchema(zodEventSchemas),
 });
 ```
 </CodeGroup>


### PR DESCRIPTION
## Summary

Adds docs for `.fromSchema()` for defining event schemas in TypeScript, added in `inngest@3.42.0`.