### PR TITLE
Updated Realtime doc to include Python and added Subscribe page

### DIFF
--- a/pages/docs/features/realtime.mdx
+++ b/pages/docs/features/realtime.mdx
@@ -18,7 +18,7 @@ Realtime user experience is a core requirement for any web application, especial
 
 ## Concepts
 
-There are two core parts of Realtime: **publishing** and **[subscribing](/docs/features/realtime/subscribe)**. You **publish** data from your functions and **subscribe** to data in your application, either browser or server.
+There are two core parts of Realtime: **[publishing](#publishing)** and **[subscribing](#subscribing)**. You **publish** data from your functions and **subscribe** to data in your application, either browser or server.
 
 Publishing data is done using the `publish()` function and has three components:
 
@@ -28,7 +28,7 @@ Publishing data is done using the `publish()` function and has three components:
 
 ## Quick start
 
-In this guide, we'll cover how to use realtime with our TypeScript SDK, subscribing from the client (browser). Start by installing the `@inngest/realtime` package:
+In this guide, we'll cover how to use realtime, publishing from an Inngest function and subscribing from the client (browser). Start by installing the `@inngest/realtime` package:
 
 <GuideSelector
   options={[
@@ -56,18 +56,8 @@ bun add @inngest/realtime
 deno add jsr:@inngest/realtime
 ```
 </CodeGroup>
-</GuideSection>
-
-<GuideSection show="python">
-```shell {{ title: "Python" }}
-pip install inngest
-```
-</GuideSection>
 
 
-
-
-<GuideSection show="typescript">
   <Info>
     This guide requires `@inngest/realtime` version `0.4.0` or higher.
   </Info>
@@ -83,9 +73,10 @@ pip install inngest
 
 ### Publishing
 
+<GuideSection show="typescript">
+
 To publish data from your Inngest functions, you'll need to add the `realtimeMiddleware()` to your Inngest client. This will automatically add the `publish()` function to your Inngest functions.
 
-<GuideSection show="typescript">
 ```ts {{ title: "client.ts" }}
 import { Inngest } from "inngest";
 // ℹ️ Import the middleware from the middleware sub-package:
@@ -103,16 +94,8 @@ Now, in your Inngest functions, the `publish()` function will be available as a 
 
 <GuideSection show="python">
 
-```py {{ title: "client.py" }}
-import logging
+To publish data from your Inngest functions, you'll need to import the experimental.realtime module. This is where you'll find the publish and publish_sync functions.
 
-import inngest
-
-logger = logging.getLogger("uvicorn.inngest")
-logger.setLevel(logging.DEBUG)
-
-inngest_client = inngest.Inngest(app_id="fast_api_example", logger=logger)
-```
 </GuideSection>
 
 <GuideSection show="typescript">
@@ -131,13 +114,15 @@ inngest.createFunction(
     });
 
     // Publish data to a user-specific channel, on the "ai" topic.
-    await publish({
-      channel: `user:${event.data.userId}`,
-      topic: "ai",
-      data: {
-        response: response,
-        success: true,
-      },
+    await step.run("ai-response-to-user", () => {
+      await publish({
+        channel: `user:${event.data.userId}`,
+        topic: "ai",
+        data: {
+          response: response,
+          success: true,
+        },
+      })
     });
     // ℹ️ Want type-safety with channels and topics? See the typed channels tab above.
   }
@@ -180,14 +165,19 @@ inngest.createFunction(
     });
 
     // Publish data to a user-specific channel, on the "ai" topic.
-    await publish(
-      userChannel(event.data.userId).ai({
-        response: response,
-        success: true,
-      })
-    );
+    await step.run("ai-response-to-user", () => {
+      await publish(
+        userChannel(event.data.userId).ai({
+          response: response,
+          success: true,
+        })
+      );
+    });
 
-    await publish(logsChannel().info("All went well"));
+
+    await step.run("log-all-went-well", () => {
+      await publish(logsChannel().info("All went well"));
+    });
   }
 );
 ```
@@ -210,20 +200,163 @@ from .client import inngest_client
 )
 async def python_realtime_publish(ctx: inngest.Context) -> str:
     async def my_first_step() -> dict[str, str]:
-        return {"message": "My llm response from python!"}
+        result = {"message": "My llm response from python!"}
+        await realtime.publish(
+            client=inngest_client,
+            channel="user:user_123456789",
+            topic="messages",
+            data=result,
+        )
+        return result
 
-    result = await ctx.step.run("my-first-step", my_first_step)
+    await ctx.step.run("my-first-step", my_first_step)
 
-    await realtime.publish(
-        client=inngest_client,
-        channel="user:user_123456789",
-        topic="messages",
-        data=result,
-    )
-
-    return "Hello world!"
+    return "Finished!"
 ```
 </GuideSection>
+
+### Subscribing
+
+To subscribe to data on the client (browser), you'll need to create a subscription token and use the `subscribe()` function which also requires `channel` and `topic` to be specified.
+
+Your application uses the Inngest SDK to create a token, which is then used by the subscribe function to connect to the Inngest WebSocket server.
+
+
+<Steps>
+  <Step title="Create a subscription token">
+    Subscription tokens are required to securely establish a connection to the Inngest WebSocket server.
+
+    Your application must create tokens on the server and pass them to the client. You can create a new endpoint to generate a token, ensuring that the user is authorized to subscribe to a given channel and topics.
+
+    Here's an example of a server endpoint that creates a token, scoped to a user's channel and specific topics.
+
+    <CodeGroup>
+    ```ts {{ title: "Next.js - Server action" }}
+    // ex. /app/actions/get-subscribe-token.ts
+    "use server";
+
+    import { inngest } from "@/inngest/client";
+    // See the "Typed channels (recommended)" section above for more details:
+    import { userChannel } from "@/inngest/functions/helloWorld";
+    import { getSubscriptionToken, Realtime } from "@inngest/realtime";
+    import { getSession } from "@/app/lib/session"; // this could be any auth provider
+
+    export type UserChannelToken = Realtime.Token<typeof userChannel, ["ai"]>;
+
+    export async function fetchRealtimeSubscriptionToken(): Promise<UserChannelToken> {
+      const { userId } = await getSession();
+
+      // This creates a token using the Inngest API that is bound to the channel and topic:
+      const token = await getSubscriptionToken(inngest, {
+        channel: `user:${userId}`,
+        topics: ["ai"],
+      });
+
+      return token;
+    }
+    ```
+
+    ```ts {{ title: "Express" }}
+    import { inngest } from "./inngest/client";
+    import { getSubscriptionToken } from "@inngest/realtime";
+    import { getSession } from "src/session"; // this could be any auth provider
+
+    app.post("/api/get-subscribe-token", async (req, res) => {
+      const { userId } = getSession(req)
+
+      // This creates a token using the Inngest API that is bound to the channel and topic:
+      const token = await getSubscriptionToken(inngest, {
+        channel: `user:${userId}`,
+        topics: ["ai"],
+      })
+
+      res.json({ token })
+    })
+    ```
+
+    ```py {{ title: "Python - Fast API" }}
+    @app.get("/api/get_subscription_token")
+    async def get_realtime_token():
+    # Here, you can get params from the request to;
+    user_id = session["user_id"]
+    # - Authorize what the user is allowed to subscribe to
+    # - Allow the client to specify what topics they want to subscribe to
+    return await realtime.get_subscription_token(
+        client=inngest_client,
+        channel=f"user:{user_id}",
+        topics=["messages"],
+    )
+    ```
+    </CodeGroup>
+  </Step>
+  <Step title="Subscribe to a channel">
+    Once you have a token, you can subscribe to a channel by calling the `subscribe` function with the token. You can also subscribe using the `useInngestSubscription` React hook. Read more about the [React hook here](/docs/features/realtime/react-hooks).
+
+    <CodeGroup>
+
+    ```ts {{ title: "React hook - useInngestSubscription()" }}
+    // ex: ./app/page.tsx
+    "use client";
+
+    // ℹ️ Import the hook from the hooks sub-package:
+    import { useInngestSubscription } from "@inngest/realtime/hooks";
+    import { useState } from "react";
+    import { fetchRealtimeSubscriptionToken } from "./actions";
+
+    export default function Home() {
+      // The hook automatically fetches the token from the server.
+      // The server checks that the user is authorized to subscribe to
+      // the channel and topic, then returns a token:
+      const { data, error, freshData, state, latestData } = useInngestSubscription({
+        refreshToken: fetchRealtimeSubscriptionToken,
+      });
+
+      return (
+        <div>
+          {data.map((message, i) => (
+            <div key={i}>{message.data}</div>
+          ))}
+        </div>
+      );
+    }
+    ```
+
+    ```ts {{ title: "Basic subscribe" }}
+    import { subscribe } from "@inngest/realtime";
+
+    // The server checks that the user is authorized to subscribe to
+    // the channel and topic, then returns a token:
+    const { token } = await fetch("/api/get-subscribe-token", {
+      method: "POST",
+      credentials: "include",
+    }).then(res => res.json());
+
+    // The token is bound to the channel and topic, so we can
+    // subscribe to the channel and topic:
+    const stream = await subscribe(token);
+
+    for await (const message of stream) {
+      console.log(message)
+    }
+    ```
+
+    </CodeGroup>
+
+
+    {/* TODO - We need other docs for typing - it's complex and needs more examples with different
+      frameworks and whatnot.
+
+    <Info>
+      Both Next.js Server Actions and `subscribe()` approaches offer a fully typed experience.
+
+      The Next.js Server Action relies on the `Realtime.Token<>` type helper to get a typed token.
+
+      The `subscribe()` approach uses the `typeOnlyChannel()` helper to get a typed channel.
+    </Info>*/}
+
+    That's all you need to do to subscribe to a channel from the client!
+  </Step>
+</Steps>
 
 </GuideSelector>
 

--- a/pages/docs/features/realtime.mdx
+++ b/pages/docs/features/realtime.mdx
@@ -2,11 +2,11 @@ import {
   RiNextjsFill,
   RiNodejsFill,
 } from "@remixicon/react";
-import { Info, CodeGroup, Steps, Step, CardGroup, Card, VersionBadge } from "src/shared/Docs/mdx";
+import { Info, CodeGroup, Steps, Step, CardGroup, Card, VersionBadge, GuideSelector, GuideSection } from "src/shared/Docs/mdx";
 
 export const description = 'Learn how to use realtime to stream data from Inngest functions to your users.';
 
-# Realtime <VersionBadge version="TypeScript SDK v3.32.0+" /> <VersionBadge version="Go SDK v0.9.0+" />
+# Realtime <VersionBadge version="TypeScript SDK v3.32.0+" /> <VersionBadge version="Go SDK v0.9.0+" /> <VersionBadge version="Python v0.5.9+" />
 
 <Info>
   Realtime is currently in developer preview. Some details including APIs are still subject to change during this period. Read more about the [developer preview here](#developer-preview).
@@ -18,7 +18,7 @@ Realtime user experience is a core requirement for any web application, especial
 
 ## Concepts
 
-There are two core parts of Realtime: **publishing** and **subscribing**. You **publish** data from your functions and **subscribe** to data in your application, either browser or server.
+There are two core parts of Realtime: **publishing** and **[subscribing](/docs/features/realtime/subscribe)**. You **publish** data from your functions and **subscribe** to data in your application, either browser or server.
 
 Publishing data is done using the `publish()` function and has three components:
 
@@ -26,17 +26,18 @@ Publishing data is done using the `publish()` function and has three components:
 * `topic` - A category of data within a `channel`, e.g., `llm_text_stream` or `upload_progress`. This is helpful to differentiate between types of data that you might use in different parts of your application.
 * `data` - The data to be published to the realtime stream.
 
-Subscribing is done with the `subscribe()` function and also requires `channel` and `topic` to be specified.
-
-To securely subscribe to data, you must create a **subscription token**. Your application uses the Inngest SDK to create a token, which is then used by the subscribe function to connect to the Inngest WebSocket server.
-
-<Info>
-  During **local development**, you are able to subscribe to data without a token for testing purposes. Tokens are required for production.
-</Info>
-
 ## Quick start
 
 In this guide, we'll cover how to use realtime with our TypeScript SDK, subscribing from the client (browser). Start by installing the `@inngest/realtime` package:
+
+<GuideSelector
+  options={[
+    { key: "typescript", title: "TypeScript" },
+    { key: "python", title: "Python" },
+  ]}
+>
+
+<GuideSection show="typescript">
 
 <CodeGroup>
 ```shell {{ title: "npm" }}
@@ -55,15 +56,36 @@ bun add @inngest/realtime
 deno add jsr:@inngest/realtime
 ```
 </CodeGroup>
+</GuideSection>
 
-<Info>
-  This guide requires `@inngest/realtime` version `0.4.0` or higher.
-</Info>
+<GuideSection show="python">
+```shell {{ title: "Python" }}
+pip install inngest
+```
+</GuideSection>
+
+
+
+
+<GuideSection show="typescript">
+  <Info>
+    This guide requires `@inngest/realtime` version `0.4.0` or higher.
+  </Info>
+</GuideSection>
+
+<GuideSection show="python">
+  <Info>
+    This guide requires `inngest` version `0.5.9` or higher.
+  </Info>
+</GuideSection>
+
+
 
 ### Publishing
 
 To publish data from your Inngest functions, you'll need to add the `realtimeMiddleware()` to your Inngest client. This will automatically add the `publish()` function to your Inngest functions.
 
+<GuideSection show="typescript">
 ```ts {{ title: "client.ts" }}
 import { Inngest } from "inngest";
 // ℹ️ Import the middleware from the middleware sub-package:
@@ -77,8 +99,25 @@ export const inngest = new Inngest({
 
 Now, in your Inngest functions, the `publish()` function will be available as a parameter to your handler function. When publishing data, you'll need to specify the `channel` and `topic` you want to publish to and any data you want to publish.
 
-<CodeGroup>
+</GuideSection>
 
+<GuideSection show="python">
+
+```py {{ title: "client.py" }}
+import logging
+
+import inngest
+
+logger = logging.getLogger("uvicorn.inngest")
+logger.setLevel(logging.DEBUG)
+
+inngest_client = inngest.Inngest(app_id="fast_api_example", logger=logger)
+```
+</GuideSection>
+
+<GuideSection show="typescript">
+
+<CodeGroup>
 ```tsx {{ title: "Basic (untyped)" }}
 import { inngest } from "./client";
 
@@ -154,137 +193,41 @@ inngest.createFunction(
 ```
 </CodeGroup>
 
+</GuideSection>
+
+<GuideSection show="python">
+
+```py {{ title: "Python" }}
+import inngest
+from inngest.experimental import realtime
+
+from .client import inngest_client
+
+
+@inngest_client.create_function(
+    fn_id="python-realtime-publish",
+    trigger=inngest.TriggerEvent(event="realtime.test"),
+)
+async def python_realtime_publish(ctx: inngest.Context) -> str:
+    async def my_first_step() -> dict[str, str]:
+        return {"message": "My llm response from python!"}
+
+    result = await ctx.step.run("my-first-step", my_first_step)
+
+    await realtime.publish(
+        client=inngest_client,
+        channel="user:user_123456789",
+        topic="messages",
+        data=result,
+    )
+
+    return "Hello world!"
+```
+</GuideSection>
+
+</GuideSelector>
+
 {/* TODO - More on channels and topics, perhaps in a new page? */}
-
-### Subscribing
-
-To subscribe to data on the client (browser), you'll need to create a subscription token and use the `subscribe()` function. {/* Subscribing from the server side is covered in the [subscribing reference](/docs/features/realtime/subscribing) */}
-
-
-<Steps>
-  <Step title="Create a subscription token">
-    Subscription tokens are required to securely establish a connection to the Inngest WebSocket server.
-
-    Your application must create tokens on the server and pass them to the client. You can create a new endpoint to generate a token, ensuring that the user is authorized to subscribe to a given channel and topics.
-
-    Here's an example of a server endpoint that creates a token, scoped to a user's channel and specific topics.
-
-    <CodeGroup>
-    ```ts {{ title: "Next.js - Server action" }}
-    // ex. /app/actions/get-subscribe-token.ts
-    "use server";
-
-    import { inngest } from "@/inngest/client";
-    // See the "Typed channels (recommended)" section above for more details:
-    import { userChannel } from "@/inngest/functions/helloWorld";
-    import { getSubscriptionToken, Realtime } from "@inngest/realtime";
-    import { getSession } from "@/app/lib/session"; // this could be any auth provider
-
-    export type UserChannelToken = Realtime.Token<typeof userChannel, ["ai"]>;
-
-    export async function fetchRealtimeSubscriptionToken(): Promise<UserChannelToken> {
-      const { userId } = await getSession();
-
-      // This creates a token using the Inngest API that is bound to the channel and topic:
-      const token = await getSubscriptionToken(inngest, {
-        channel: `user:${userId}`,
-        topics: ["ai"],
-      });
-
-      return token;
-    }
-    ```
-
-    ```ts {{ title: "Express" }}
-    import { inngest } from "./inngest/client";
-    import { getSubscriptionToken } from "@inngest/realtime";
-    import { getSession } from "src/session"; // this could be any auth provider
-
-    app.post("/api/get-subscribe-token", async (req, res) => {
-      const { userId } = getSession(req)
-
-      // This creates a token using the Inngest API that is bound to the channel and topic:
-      const token = await getSubscriptionToken(inngest, {
-        channel: `user:${userId}`,
-        topics: ["ai"],
-      })
-
-      res.json({ token })
-    })
-    ```
-    </CodeGroup>
-  </Step>
-  <Step title="Subscribe to a channel">
-    Once you have a token, you can subscribe to a channel by calling the `subscribe` function with the token. You can also subscribe using the `useInngestSubscription` React hook. Read more about the [React hook here](/docs/features/realtime/react-hooks).
-
-    <CodeGroup>
-
-    ```ts {{ title: "React hook - useInngestSubscription()" }}
-    // ex: ./app/page.tsx
-    "use client";
-
-    // ℹ️ Import the hook from the hooks sub-package:
-    import { useInngestSubscription } from "@inngest/realtime/hooks";
-    import { useState } from "react";
-    import { fetchRealtimeSubscriptionToken } from "./actions";
-
-    export default function Home() {
-      // The hook automatically fetches the token from the server.
-      // The server checks that the user is authorized to subscribe to
-      // the channel and topic, then returns a token:
-      const { data, error, freshData, state, latestData } = useInngestSubscription({
-        refreshToken: fetchRealtimeSubscriptionToken,
-      });
-
-      return (
-        <div>
-          {data.map((message, i) => (
-            <div key={i}>{message.data}</div>
-          ))}
-        </div>
-      );
-    }
-    ```
-
-    ```ts {{ title: "Basic subscribe" }}
-    import { subscribe } from "@inngest/realtime";
-
-    // The server checks that the user is authorized to subscribe to
-    // the channel and topic, then returns a token:
-    const { token } = await fetch("/api/get-subscribe-token", {
-      method: "POST",
-      credentials: "include",
-    }).then(res => res.json());
-
-    // The token is bound to the channel and topic, so we can
-    // subscribe to the channel and topic:
-    const stream = await subscribe(token);
-
-    for await (const message of stream) {
-      console.log(message)
-    }
-    ```
-
-    </CodeGroup>
-
-
-    {/* TODO - We need other docs for typing - it's complex and needs more examples with different
-      frameworks and whatnot.
-
-    <Info>
-      Both Next.js Server Actions and `subscribe()` approaches offer a fully typed experience.
-
-      The Next.js Server Action relies on the `Realtime.Token<>` type helper to get a typed token.
-
-      The `subscribe()` approach uses the `typeOnlyChannel()` helper to get a typed channel.
-    </Info>*/}
-
-    That's all you need to do to subscribe to a channel from the client!
-  </Step>
-</Steps>
-
-
-
 
 
 {/*
@@ -346,7 +289,7 @@ Realtime is supported in the following SDKs:
 | ---------- | ------- | --------- | ------- |
 | TypeScript | ✅      | ✅        | >=v3.32.0  |
 | Golang     | ✅      | ✅        | >=v0.9.0  |
-| Python     | In progress | In progress         | -       |
+| Python     | ✅      | -       | >=v0.5.9  |
 
 ## Limitations
 

--- a/pages/docs/features/realtime.mdx
+++ b/pages/docs/features/realtime.mdx
@@ -96,6 +96,8 @@ Now, in your Inngest functions, the `publish()` function will be available as a 
 
 To publish data from your Inngest functions, you'll need to import the experimental.realtime module. This is where you'll find the publish and publish_sync functions.
 
+See the [Fast API example](https://github.com/inngest/inngest-py/tree/main/examples/fast_api_realtime) for more information.
+
 </GuideSection>
 
 <GuideSection show="typescript">
@@ -110,11 +112,7 @@ inngest.createFunction(
   async ({ event, step, publish }) => {
 
     const response = await step.run('generate-response', () => {
-      return llm.generateResponse(event.data.prompt);
-    });
-
-    // Publish data to a user-specific channel, on the "ai" topic.
-    await step.run("ai-response-to-user", () => {
+      const response = llm.generateResponse(event.data.prompt);
       await publish({
         channel: `user:${event.data.userId}`,
         topic: "ai",
@@ -124,6 +122,7 @@ inngest.createFunction(
         },
       })
     });
+
     // ℹ️ Want type-safety with channels and topics? See the typed channels tab above.
   }
 );
@@ -160,12 +159,8 @@ inngest.createFunction(
   { event: "ai/recommendation.requested" },
   async ({ event, step, publish }) => {
 
-    const response = await step.run('generate-response', () => {
-      return llm.generateResponse(event.data.prompt);
-    });
-
-    // Publish data to a user-specific channel, on the "ai" topic.
-    await step.run("ai-response-to-user", () => {
+    await step.run('generate-response', () => {
+      const response = llm.generateResponse(event.data.prompt)
       await publish(
         userChannel(event.data.userId).ai({
           response: response,
@@ -173,7 +168,6 @@ inngest.createFunction(
         })
       );
     });
-
 
     await step.run("log-all-went-well", () => {
       await publish(logsChannel().info("All went well"));
@@ -275,7 +269,7 @@ Your application uses the Inngest SDK to create a token, which is then used by t
     ```
 
     ```py {{ title: "Python - Fast API" }}
-    @app.get("/api/get_subscription_token")
+    @app.get("/api/get-subscription-token")
     async def get_realtime_token():
     # Here, you can get params from the request to;
     user_id = session["user_id"]

--- a/pages/docs/features/realtime/subscribe.mdx
+++ b/pages/docs/features/realtime/subscribe.mdx
@@ -2,7 +2,7 @@ import { Steps, Step, CodeGroup } from "src/shared/Docs/mdx";
 
 export const description = 'Learn how to subscribe to data from Inngest functions.';
 
-# Subscribing
+### Subscribing
 
 To subscribe to data on the client (browser), you'll need to create a subscription token and use the `subscribe()` function which also requires `channel` and `topic` to be specified.
 
@@ -61,7 +61,7 @@ Your application uses the Inngest SDK to create a token, which is then used by t
     })
     ```
 
-    ```py {{ title: "Python" }}
+    ```py {{ title: "Python - Fast API" }}
     @app.get("/api/get_subscription_token")
     async def get_realtime_token():
     # Here, you can get params from the request to;

--- a/pages/docs/features/realtime/subscribe.mdx
+++ b/pages/docs/features/realtime/subscribe.mdx
@@ -1,0 +1,146 @@
+import { Steps, Step, CodeGroup } from "src/shared/Docs/mdx";
+
+export const description = 'Learn how to subscribe to data from Inngest functions.';
+
+# Subscribing
+
+To subscribe to data on the client (browser), you'll need to create a subscription token and use the `subscribe()` function which also requires `channel` and `topic` to be specified.
+
+Your application uses the Inngest SDK to create a token, which is then used by the subscribe function to connect to the Inngest WebSocket server.
+
+
+<Steps>
+  <Step title="Create a subscription token">
+    Subscription tokens are required to securely establish a connection to the Inngest WebSocket server.
+
+    Your application must create tokens on the server and pass them to the client. You can create a new endpoint to generate a token, ensuring that the user is authorized to subscribe to a given channel and topics.
+
+    Here's an example of a server endpoint that creates a token, scoped to a user's channel and specific topics.
+
+    <CodeGroup>
+    ```ts {{ title: "Next.js - Server action" }}
+    // ex. /app/actions/get-subscribe-token.ts
+    "use server";
+
+    import { inngest } from "@/inngest/client";
+    // See the "Typed channels (recommended)" section above for more details:
+    import { userChannel } from "@/inngest/functions/helloWorld";
+    import { getSubscriptionToken, Realtime } from "@inngest/realtime";
+    import { getSession } from "@/app/lib/session"; // this could be any auth provider
+
+    export type UserChannelToken = Realtime.Token<typeof userChannel, ["ai"]>;
+
+    export async function fetchRealtimeSubscriptionToken(): Promise<UserChannelToken> {
+      const { userId } = await getSession();
+
+      // This creates a token using the Inngest API that is bound to the channel and topic:
+      const token = await getSubscriptionToken(inngest, {
+        channel: `user:${userId}`,
+        topics: ["ai"],
+      });
+
+      return token;
+    }
+    ```
+
+    ```ts {{ title: "Express" }}
+    import { inngest } from "./inngest/client";
+    import { getSubscriptionToken } from "@inngest/realtime";
+    import { getSession } from "src/session"; // this could be any auth provider
+
+    app.post("/api/get-subscribe-token", async (req, res) => {
+      const { userId } = getSession(req)
+
+      // This creates a token using the Inngest API that is bound to the channel and topic:
+      const token = await getSubscriptionToken(inngest, {
+        channel: `user:${userId}`,
+        topics: ["ai"],
+      })
+
+      res.json({ token })
+    })
+    ```
+
+    ```py {{ title: "Python" }}
+    @app.get("/api/get_subscription_token")
+    async def get_realtime_token():
+    # Here, you can get params from the request to;
+    user_id = session["user_id"]
+    # - Authorize what the user is allowed to subscribe to
+    # - Allow the client to specify what topics they want to subscribe to
+    return await realtime.get_subscription_token(
+        client=inngest_client,
+        channel=f"user:{user_id}",
+        topics=["messages"],
+    )
+    ```
+    </CodeGroup>
+  </Step>
+  <Step title="Subscribe to a channel">
+    Once you have a token, you can subscribe to a channel by calling the `subscribe` function with the token. You can also subscribe using the `useInngestSubscription` React hook. Read more about the [React hook here](/docs/features/realtime/react-hooks).
+
+    <CodeGroup>
+
+    ```ts {{ title: "React hook - useInngestSubscription()" }}
+    // ex: ./app/page.tsx
+    "use client";
+
+    // ℹ️ Import the hook from the hooks sub-package:
+    import { useInngestSubscription } from "@inngest/realtime/hooks";
+    import { useState } from "react";
+    import { fetchRealtimeSubscriptionToken } from "./actions";
+
+    export default function Home() {
+      // The hook automatically fetches the token from the server.
+      // The server checks that the user is authorized to subscribe to
+      // the channel and topic, then returns a token:
+      const { data, error, freshData, state, latestData } = useInngestSubscription({
+        refreshToken: fetchRealtimeSubscriptionToken,
+      });
+
+      return (
+        <div>
+          {data.map((message, i) => (
+            <div key={i}>{message.data}</div>
+          ))}
+        </div>
+      );
+    }
+    ```
+
+    ```ts {{ title: "Basic subscribe" }}
+    import { subscribe } from "@inngest/realtime";
+
+    // The server checks that the user is authorized to subscribe to
+    // the channel and topic, then returns a token:
+    const { token } = await fetch("/api/get-subscribe-token", {
+      method: "POST",
+      credentials: "include",
+    }).then(res => res.json());
+
+    // The token is bound to the channel and topic, so we can
+    // subscribe to the channel and topic:
+    const stream = await subscribe(token);
+
+    for await (const message of stream) {
+      console.log(message)
+    }
+    ```
+
+    </CodeGroup>
+
+
+    {/* TODO - We need other docs for typing - it's complex and needs more examples with different
+      frameworks and whatnot.
+
+    <Info>
+      Both Next.js Server Actions and `subscribe()` approaches offer a fully typed experience.
+
+      The Next.js Server Action relies on the `Realtime.Token<>` type helper to get a typed token.
+
+      The `subscribe()` approach uses the `typeOnlyChannel()` helper to get a typed channel.
+    </Info>*/}
+
+    That's all you need to do to subscribe to a channel from the client!
+  </Step>
+</Steps>

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -696,6 +696,10 @@ const sectionHome: (NavGroup | NavLink)[] = [
             href: "/docs/features/realtime",
           },
           {
+            title: "Subscribing",
+            href: "/docs/features/realtime/subscribe",
+          },
+          {
             title: "React hooks / Next.js",
             href: "/docs/features/realtime/react-hooks",
           },

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -696,10 +696,6 @@ const sectionHome: (NavGroup | NavLink)[] = [
             href: "/docs/features/realtime",
           },
           {
-            title: "Subscribing",
-            href: "/docs/features/realtime/subscribe",
-          },
-          {
             title: "React hooks / Next.js",
             href: "/docs/features/realtime/react-hooks",
           },


### PR DESCRIPTION
I went ahead and made subscribe its own page. I feel that could be confusing to people and having it explicitly clear that subscribe is a new step I think can help out as people start getting setup. 