### PR TITLE
Add step metadata how-to guide

### DIFF
--- a/pages/docs/features/inngest-functions/steps-workflows/step-metadata-how-to.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-metadata-how-to.mdx
@@ -1,12 +1,14 @@
 import { CodeGroup, VersionBadge, Info, Warning } from "src/shared/Docs/mdx";
 
-export const description = "Practical guides for attaching metadata to steps and runs, using custom kinds, batching updates, and working with cross-run metadata.";
+export const description = "Practical guides for attaching metadata to function runs, using custom kinds, batching updates, and working with cross-run metadata.";
 
-# Step metadata how-to <VersionBadge version="TypeScript only" />
+# Metadata how-to <VersionBadge version="TypeScript only" />
 
-This page walks through common tasks with step metadata. For the full API surface, see the [step metadata reference](/docs/features/inngest-functions/steps-workflows/metadata).
+When you're debugging a failed run or trying to understand what happened during execution, the function's input and output only tell part of the story. Metadata lets you attach your own context to a run so it shows up right in the trace view. That might be a payment ID from Stripe, a customer tier, token counts from an LLM call, or a flag marking a run as part of an A/B test.
 
-## Attach metadata to a step
+There are two ways to add metadata from within a function. `step.metadata()` creates its own memoized step and attaches metadata to the run. `inngest.metadata` is the underlying client API and can be called inside a `step.run()` callback, in the function body, or from external contexts like an API route. For the full API surface, see the [metadata reference](/docs/features/inngest-functions/steps-workflows/metadata).
+
+## Add metadata to a run
 
 The simplest approach is `step.metadata()`. Pass a unique memoization ID and call `.update()` with your key-value pairs.
 
@@ -31,9 +33,9 @@ const processOrder = inngest.createFunction(
 );
 ```
 
-`step.metadata("record-payment-info")` creates its own memoized step under the hood. That means the update runs exactly once, even if the function re-executes during later steps. It also means you cannot call `step.metadata()` inside another step.
+`step.metadata("record-payment-info")` creates its own memoized step under the hood. That means the update runs exactly once, even if the function re-executes during later steps.
 
-If you need to attach metadata from within a `step.run()` callback, use `inngest.metadata` instead:
+If you need to attach metadata from within an existing `step.run()` callback, use `inngest.metadata` instead. When called inside a step, the metadata is batched with the step's output in a single response. This makes it durable. The metadata persists even if the function retries later steps.
 
 ```ts
 const processOrder = inngest.createFunction(
@@ -47,8 +49,6 @@ const processOrder = inngest.createFunction(
   },
 );
 ```
-
-When called inside `step.run()`, the metadata update is batched with the step's output in a single response. This makes it durable. The metadata persists even if the function retries later steps.
 
 ## Use custom kinds to group metadata
 
@@ -66,7 +66,7 @@ await step.metadata("tracking-meta").update(
 );
 ```
 
-In the dashboard, these show up as separate sections: "User Metadata (billing)" and "User Metadata (analytics)". This keeps things readable when a step has several categories of metadata.
+In the dashboard, these show up as separate sections: "User Metadata (billing)" and "User Metadata (analytics)". This keeps things readable when a run has several categories of metadata.
 
 ## Batch multiple updates in one step
 
@@ -152,6 +152,6 @@ await inngest.metadata.run(runId).update({
 
 ## View metadata in the dashboard
 
-Metadata appears in the trace detail panel when you select a step or run in the function timeline. Each entry shows the kind label, scope, timestamp, and key-value pairs sorted alphabetically.
+Metadata appears in the trace detail panel when you select a run or step in the function timeline. Each entry shows the kind label, scope, timestamp, and key-value pairs sorted alphabetically.
 
 ![Trace view showing metadata in the detail panel](/assets/docs/features/step-metadata/trace-view-overview.png)

--- a/pages/docs/features/inngest-functions/steps-workflows/step-metadata-how-to.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-metadata-how-to.mdx
@@ -4,13 +4,15 @@ export const description = "Practical guides for attaching metadata to function 
 
 # Metadata how-to <VersionBadge version="TypeScript only" />
 
-When you're debugging a failed run or trying to understand what happened during execution, the function's input and output only tell part of the story. Metadata lets you attach your own context to a run so it shows up right in the trace view. That might be a payment ID from Stripe, a customer tier, token counts from an LLM call, or a flag marking a run as part of an A/B test.
+`step.metadata()` is a step tool, like `step.run()`, `step.sleep()`, or `step.waitForEvent()`. It attaches custom key-value data to your function runs. Like every step tool, it takes a memoization ID, executes exactly once, and appears as its own step in the trace.
 
-There are two ways to add metadata from within a function. `step.metadata()` creates its own memoized step and attaches metadata to the run. `inngest.metadata` is the underlying client API and can be called inside a `step.run()` callback, in the function body, or from external contexts like an API route. For the full API surface, see the [metadata reference](/docs/features/inngest-functions/steps-workflows/metadata).
+When you're debugging a failed run or trying to understand what happened during execution, the function's input and output only tell part of the story. Metadata lets you attach your own context so it shows up right in the trace view. That might be a payment ID from Stripe, a customer tier, token counts from an LLM call, or a flag marking a run as part of an A/B test.
+
+For the full API surface, see the [metadata reference](/docs/features/inngest-functions/steps-workflows/metadata).
 
 ## Add metadata to a run
 
-The simplest approach is `step.metadata()`. Pass a unique memoization ID and call `.update()` with your key-value pairs.
+`step.metadata()` works like any other step tool. Pass a memoization ID and call `.update()` with your key-value pairs. The ID ensures the update runs exactly once, even if the function re-executes during later steps.
 
 ```ts
 const processOrder = inngest.createFunction(
@@ -20,6 +22,7 @@ const processOrder = inngest.createFunction(
       return await chargeCustomer(event.data.customerId, event.data.amount);
     });
 
+    // Creates its own step in the trace, attaches metadata to the run
     await step.metadata("record-payment-info").update({
       paymentId: charge.id,
       processor: "stripe",
@@ -33,9 +36,11 @@ const processOrder = inngest.createFunction(
 );
 ```
 
-`step.metadata("record-payment-info")` creates its own memoized step under the hood. That means the update runs exactly once, even if the function re-executes during later steps.
+In the trace view, this run would show three steps: "process-payment," "record-payment-info," and "send-confirmation." The metadata from "record-payment-info" is visible on the run.
 
-If you need to attach metadata from within an existing `step.run()` callback, use `inngest.metadata` instead. When called inside a step, the metadata is batched with the step's output in a single response. This makes it durable. The metadata persists even if the function retries later steps.
+### Add metadata from within an existing step
+
+If you want to attach metadata without creating a separate step, use `inngest.metadata` inside a `step.run()` callback. The metadata is batched with the step's output in a single response, making it durable.
 
 ```ts
 const processOrder = inngest.createFunction(
@@ -43,6 +48,7 @@ const processOrder = inngest.createFunction(
   async ({ event, step }) => {
     const user = await step.run("fetch-user", async () => {
       const user = await fetchUser(event.data.userId);
+      // Batched with the step output, no additional step created
       await inngest.metadata.update({ company: user.company });
       return user;
     });
@@ -84,13 +90,13 @@ All three updates share the same memoization step and execute exactly once.
 
 ## Scope metadata to a specific target
 
-By default, metadata auto-detects its scope: run-level when outside a step, step-level when inside one. You can override this with the builder methods:
+By default, metadata attaches to the run. You can override this with the builder methods to target a specific step or extended trace span:
 
 ```ts
 const myFunction = inngest.createFunction(
   { id: "my-function", triggers: [{ event: "app/task.started" }] },
   async ({ event, step }) => {
-    // Explicitly scope to the current run
+    // Explicitly scope to the current run (same as default)
     await step.metadata("run-status").run().update({
       priority: "high",
     });

--- a/pages/docs/features/inngest-functions/steps-workflows/step-metadata-how-to.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-metadata-how-to.mdx
@@ -1,0 +1,157 @@
+import { CodeGroup, VersionBadge, Info, Warning } from "src/shared/Docs/mdx";
+
+export const description = "Practical guides for attaching metadata to steps and runs, using custom kinds, batching updates, and working with cross-run metadata.";
+
+# Step metadata how-to <VersionBadge version="TypeScript only" />
+
+This page walks through common tasks with step metadata. For the full API surface, see the [step metadata reference](/docs/features/inngest-functions/steps-workflows/metadata).
+
+## Attach metadata to a step
+
+The simplest approach is `step.metadata()`. Pass a unique memoization ID and call `.update()` with your key-value pairs.
+
+```ts
+const processOrder = inngest.createFunction(
+  { id: "process-order", triggers: [{ event: "shop/order.created" }] },
+  async ({ event, step }) => {
+    const charge = await step.run("process-payment", async () => {
+      return await chargeCustomer(event.data.customerId, event.data.amount);
+    });
+
+    await step.metadata("record-payment-info").update({
+      paymentId: charge.id,
+      processor: "stripe",
+      amount: event.data.amount,
+    });
+
+    await step.run("send-confirmation", async () => {
+      await sendEmail(event.data.email, charge.receiptUrl);
+    });
+  },
+);
+```
+
+`step.metadata("record-payment-info")` creates its own memoized step under the hood. That means the update runs exactly once, even if the function re-executes during later steps. It also means you cannot call `step.metadata()` inside another step.
+
+If you need to attach metadata from within a `step.run()` callback, use `inngest.metadata` instead:
+
+```ts
+const processOrder = inngest.createFunction(
+  { id: "process-order", triggers: [{ event: "shop/order.created" }] },
+  async ({ event, step }) => {
+    const user = await step.run("fetch-user", async () => {
+      const user = await fetchUser(event.data.userId);
+      await inngest.metadata.update({ company: user.company });
+      return user;
+    });
+  },
+);
+```
+
+When called inside `step.run()`, the metadata update is batched with the step's output in a single response. This makes it durable. The metadata persists even if the function retries later steps.
+
+## Use custom kinds to group metadata
+
+By default, all metadata lands under the "default" kind. Pass a second argument to `.update()` to organize metadata into named groups:
+
+```ts
+await step.metadata("payment-meta").update(
+  { invoiceId: "inv_123", total: 99.99 },
+  "billing",
+);
+
+await step.metadata("tracking-meta").update(
+  { source: "organic", campaign: "spring-2025" },
+  "analytics",
+);
+```
+
+In the dashboard, these show up as separate sections: "User Metadata (billing)" and "User Metadata (analytics)". This keeps things readable when a step has several categories of metadata.
+
+## Batch multiple updates in one step
+
+Use `.do()` to send several metadata updates within a single memoized step. This avoids creating a separate step for each update:
+
+```ts
+await step.metadata("update-all-statuses").do(async (builder) => {
+  await builder.update({ phase: "started", initiator: "system" }, "workflow");
+  await builder.update({ estimatedDuration: 30 }, "timing");
+  await builder.update({ region: "us-east-1" }, "infra");
+});
+```
+
+All three updates share the same memoization step and execute exactly once.
+
+## Scope metadata to a specific target
+
+By default, metadata auto-detects its scope: run-level when outside a step, step-level when inside one. You can override this with the builder methods:
+
+```ts
+const myFunction = inngest.createFunction(
+  { id: "my-function", triggers: [{ event: "app/task.started" }] },
+  async ({ event, step }) => {
+    // Explicitly scope to the current run
+    await step.metadata("run-status").run().update({
+      priority: "high",
+    });
+
+    // Scope to a specific step by its ID
+    await step.metadata("step-annotation").step("process-data").update({
+      recordsProcessed: 1500,
+    });
+
+    // Scope to an extended trace span
+    await step.metadata("span-details").span(spanId).update({
+      externalCallDuration: 230,
+    });
+  },
+);
+```
+
+Builder methods are chainable and self-removing. Once you call `.run()`, you can't also call `.step()` on the same builder.
+
+## Update metadata on a different run
+
+You can attach metadata to a completed or in-progress run from a separate function. This is useful for post-processing, like scoring the output of an AI run:
+
+```ts
+const evaluateRun = inngest.createFunction(
+  { id: "evaluate-run", triggers: [{ event: "ai/run.completed" }] },
+  async ({ event, step }) => {
+    const score = await step.run("score-output", async () => {
+      return await evaluateOutput(event.data.output);
+    });
+
+    await step.metadata("record-score")
+      .run(event.data.runId)
+      .update({
+        qualityScore: score.quality,
+        relevanceScore: score.relevance,
+        evaluatedAt: Date.now(),
+      });
+  },
+);
+```
+
+When targeting a different run, the update is sent via REST API (not batched), since the target run has a different execution context.
+
+## Update metadata from outside a function
+
+Use `inngest.metadata` with an explicit run ID to update metadata from an API route or external service:
+
+```ts
+await inngest.metadata.run(runId).update({
+  approvedBy: "admin@example.com",
+  approvalTimestamp: Date.now(),
+});
+```
+
+<Warning>
+  Calling `inngest.metadata.update()` in the function body but outside of a `step.run()` is not durable. The function re-executes from the top on each subsequent step, so that update will fire again during every driver call. Use `step.metadata()` or call `inngest.metadata` inside a `step.run()` for durable updates.
+</Warning>
+
+## View metadata in the dashboard
+
+Metadata appears in the trace detail panel when you select a step or run in the function timeline. Each entry shows the kind label, scope, timestamp, and key-value pairs sorted alphabetically.
+
+![Trace view showing metadata in the detail panel](/assets/docs/features/step-metadata/trace-view-overview.png)

--- a/pages/docs/features/inngest-functions/steps-workflows/step-metadata-how-to.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-metadata-how-to.mdx
@@ -8,7 +8,7 @@ export const description = "Practical guides for attaching metadata to function 
 
 When you're debugging a failed run or trying to understand what happened during execution, the function's input and output only tell part of the story. Metadata lets you attach your own context so it shows up right in the trace view. That might be a payment ID from Stripe, a customer tier, token counts from an LLM call, or a flag marking a run as part of an A/B test.
 
-For the full API surface, see the [metadata reference](/docs/features/inngest-functions/steps-workflows/metadata).
+For the full API surface, see the [metadata reference](/docs/reference/typescript/functions/metadata).
 
 ## Add metadata to a run
 


### PR DESCRIPTION
## Summary

Adds a practical **how-to** page for step metadata following the Diataxis framework. Each section is a discrete task with code and just enough context inline:

- Attach metadata to a step (both `step.metadata` and `inngest.metadata` inside `step.run`)
- Use custom kinds to group metadata
- Batch multiple updates in one step
- Scope metadata to a specific target
- Update metadata on a different run
- Update metadata from outside a function
- View metadata in the dashboard

Explanation content (batched vs API path, durability) is folded inline as context rather than a standalone section.

Companion to the reference page PR. Relates to DEV-276.

## Requested reviewers

@AndyInternet @djfarrelly