### PR TITLE
fix: DEV-292 - fix 7 broken links across docs and blog posts

### DIFF
--- a/content/blog/completing-the-jamstack.mdx
+++ b/content/blog/completing-the-jamstack.mdx
@@ -6,7 +6,7 @@ date: 2022-11-02
 author: Dan Farrelly
 ---
 
-The Jamstack has come a long way from a simple concept on how to build front-ends to an entire ecosystem and approach to building products in general. The frameworks, tools and platforms have ushered in a new era of serverless development that is performant and easily scalable with a seamless SDLC. The "stack" moniker kind of undersells it as it's not your tech stack, à la LAMP or MEAN, but an approach to building modern applications. It's 2022 and we've gotten to the a place where the [Jamstack](https://en.wikipedia.org/wiki/Jamstack) seems almost complete - but is it truly complete?
+The Jamstack has come a long way from a simple concept on how to build front-ends to an entire ecosystem and approach to building products in general. The frameworks, tools and platforms have ushered in a new era of serverless development that is performant and easily scalable with a seamless SDLC. The "stack" moniker kind of undersells it as it's not your tech stack, à la LAMP or MEAN, but an approach to building modern applications. It's 2022 and we've gotten to the a place where the [Jamstack](https://www.netlify.com/jamstack/) seems almost complete - but is it truly complete?
 
 ## Where is the Jamstack in 2022
 

--- a/content/blog/completing-the-jamstack.mdx
+++ b/content/blog/completing-the-jamstack.mdx
@@ -6,11 +6,11 @@ date: 2022-11-02
 author: Dan Farrelly
 ---
 
-The Jamstack has come a long way from a simple concept on how to build front-ends to an entire ecosystem and approach to building products in general. The frameworks, tools and platforms have ushered in a new era of serverless development that is performant and easily scalable with a seamless SDLC. The “stack” moniker kind of undersells it as it's not your tech stack, à la LAMP or MEAN, but an approach to building modern applications. It's 2022 and we've gotten to the a place where the [Jamstack](https://jamstack.org/) seems almost complete - but is it truly complete?
+The Jamstack has come a long way from a simple concept on how to build front-ends to an entire ecosystem and approach to building products in general. The frameworks, tools and platforms have ushered in a new era of serverless development that is performant and easily scalable with a seamless SDLC. The "stack" moniker kind of undersells it as it's not your tech stack, à la LAMP or MEAN, but an approach to building modern applications. It's 2022 and we've gotten to the a place where the [Jamstack](https://en.wikipedia.org/wiki/Jamstack) seems almost complete - but is it truly complete?
 
 ## Where is the Jamstack in 2022
 
-The Jamstack as a concept was broadly introduced in 2016 and at the time it was a vision for how we should be building *front-ends*. “JAM” started with three concepts - JavaScript, APIs and Markup. It has evolved into a modern way to build applications for the web in general - not just front-ends. This shift has changed how applications are delivered, how business logic is written and where state lives.
+The Jamstack as a concept was broadly introduced in 2016 and at the time it was a vision for how we should be building *front-ends*. "JAM" started with three concepts - JavaScript, APIs and Markup. It has evolved into a modern way to build applications for the web in general - not just front-ends. This shift has changed how applications are delivered, how business logic is written and where state lives.
 
 ### JavaScript & Markup → Frameworks
 
@@ -20,11 +20,11 @@ Frameworks have embraced this space providing some great tooling to both render 
 
 At the onset of the Jamstack paradigm, most APIs were likely run on separate backend servers, whether a container, droplet or some other PaaS. The advent of serverless and innovation on the front-end platform side pushed developers to drop the long running services and embrace functions-as-a-service (FaaS) platforms to write their synchronous API endpoints. Serverless functions are simpler to reason about for developers and FaaS platforms enabled developers to not have to worry about managing uptime and removed some overhead for thinking about scaling a backend.
 
-This is where the Jamstack started to embrace backend development and became more of a true “stack.” Frameworks like [Next.js](/docs/learn/serving-inngest-functions#framework-next-js) and platforms like [Vercel](/blog/vercel-integration) & [Netlify](/docs/deploy/netlify) embraced this demand and started seamlessly integrating FaaS into their previously front-end app hosting services.
+This is where the Jamstack started to embrace backend development and became more of a true "stack." Frameworks like [Next.js](/docs/learn/serving-inngest-functions#framework-next-js) and platforms like [Vercel](/blog/vercel-integration) & [Netlify](/docs/deploy/netlify) embraced this demand and started seamlessly integrating FaaS into their previously front-end app hosting services.
 
 ### APIs → Serverless databases and services
 
-The API evolution of the original “JAM” did not stop at serverless functions. The “serverless” concept took over every other *-as-a-service that could be imagined: databases, websockets, CMSes,  authentication backends, etc.. Every managed service that could be “serverless” would become serverless meaning the service would scale with your usage and needs. Planetscale, Neon, MongoDB Serverless, Pusher, Contentful among others all addressed the demand by applying the same concepts to managed services.
+The API evolution of the original "JAM" did not stop at serverless functions. The "serverless" concept took over every other *-as-a-service that could be imagined: databases, websockets, CMSes,  authentication backends, etc.. Every managed service that could be "serverless" would become serverless meaning the service would scale with your usage and needs. Planetscale, Neon, MongoDB Serverless, Pusher, Contentful among others all addressed the demand by applying the same concepts to managed services.
 
 ![Graphic displaying the deliver, functionality, and backing services layers of the Jamstack in 2022](/assets/blog/completing-the-jamstack/jamstack-in-2022.jpg)
 
@@ -40,7 +40,7 @@ Asynchronous work is a huge part of any application. It includes a great deal: r
 
 ![Graphic displaying asynchronous work complimenting the state of the Jamstack in 2022](/assets/blog/completing-the-jamstack/jamstack-missing-pieces.jpg)
 
-When it comes to asynchronous work, developers are still reaching for queues and workers in some regard. Even if some queues like SQS consider themselves “serverless,” they're just pipes. The developer needs to determine how data should flow through the pipe, how to handle the output of that pipe and what to do if pipe's output isn't handled successfully. This does not align with the ethos of the evolution that we have seen in the Jamstack era.
+When it comes to asynchronous work, developers are still reaching for queues and workers in some regard. Even if some queues like SQS consider themselves "serverless," they're just pipes. The developer needs to determine how data should flow through the pipe, how to handle the output of that pipe and what to do if pipe's output isn't handled successfully. This does not align with the ethos of the evolution that we have seen in the Jamstack era.
 
 
 ## Completing the picture
@@ -49,7 +49,7 @@ Developers need modern solutions for these things. There are some options for ba
 
 What would this solution look like [for modern developers](/blog/modern-serverless-job-scheduler)?
 
-- **Centered around events** - Events describe intent and action which make them ideal for reasoning about a system. Events are used in the front-end (“user clicked button”), on the backend (HTTP requests = Events), and when communicating with other systems (webhooks). It should also have a simple API requiring no pre-configuration of a queue before sending data.
+- **Centered around events** - Events describe intent and action which make them ideal for reasoning about a system. Events are used in the front-end ("user clicked button"), on the backend (HTTP requests = Events), and when communicating with other systems (webhooks). It should also have a simple API requiring no pre-configuration of a queue before sending data.
 - **It calls your code, your code doesn't call it** - It should follow the model of serverless API functions and be automatically run on-demand as needed - there should not be some idling process checking for jobs to perform that you need to worry about scaling.
 - **Scales automatically** - This should be a given in 2022, but it should be a system that works from MVP to the enterprise.
 - **Great defaults, power as you need it** - Functionality every system needs for reliability and scalability should be included by default. From automatic retries of failures, concurrency, and throttling - developers should not have to roll this on their own.
@@ -63,5 +63,3 @@ With Inngest, we've created a platform with these principles to enable developer
 We've had Jamstack developers and non-Jamstackers tell us that we're filling a clear need in their stack - [read out docs to give us a try](/docs) and let us know what you think!
 
 _PS - We'll be launching a brand new way to build multi-step serverless workflows with delays, conditional logic and coordinate between events. Reach out to our team [on Discord](/discord) to get early access._
-
-

--- a/content/blog/how-to-build-a-production-ai-image-generation-pipeline-with-fal-ai-and-inngest.mdx
+++ b/content/blog/how-to-build-a-production-ai-image-generation-pipeline-with-fal-ai-and-inngest.mdx
@@ -153,7 +153,7 @@ This is where the combination of fal.ai and Inngest pays off in ways that matter
 
 ### **Step-level retries protect your inference costs.**
 
-Each `step.run` is a checkpoint. The result of every step is memoized once it completes. If the S3 upload on step 3 fails and retries, fal.ai doesn't run again — `requestId` and `result` are already stored. At $0.03–$0.08 per image this matters at any meaningful scale. [NonRetriableError](https://www.inngest.com/docs/reference/functions/errors) tells Inngest not to retry when retrying genuinely can't help — like a generation timeout.
+Each `step.run` is a checkpoint. The result of every step is memoized once it completes. If the S3 upload on step 3 fails and retries, fal.ai doesn't run again — `requestId` and `result` are already stored. At $0.03–$0.08 per image this matters at any meaningful scale. [NonRetriableError](https://www.inngest.com/docs/features/inngest-functions/error-retries/inngest-errors) tells Inngest not to retry when retrying genuinely can't help — like a generation timeout.
 
 ### **Per-user fairness comes from one line of config.**
 

--- a/content/blog/redwood-handler.mdx
+++ b/content/blog/redwood-handler.mdx
@@ -13,7 +13,7 @@ Redwood is an opinionated, full-stack, JavaScript/TypeScript web application fra
 
 Part of Redwood's roster is its [Serverless Functions](https://docs.redwoodjs.com/docs/serverless-functions/), which are a great way to add server-side logic to your application. Inngest's RedwoodJS handler allows you to register those functions with Inngest and use Inngest's event-driven infrastructure to trigger them as background jobs, scheduled tasks, or complex step functions.
 
-<aside>To get started right away, check out our <a href="/docs/learn/serving-inngest-functions?ref=blog-redwood-handler#framework-redwood">RedwoodJS Framework Guide</a> or the <a href="https://github.com/inngest/sdk-example-redwoodjs-vercel">inngest/sdk-example-redwoodjs-vercel</a> repo.</aside>
+<aside>To get started right away, check out our <a href="/docs/learn/serving-inngest-functions?ref=blog-redwood-handler#framework-redwood">RedwoodJS Framework Guide</a>.</aside>
 
 Like [all of our other handlers](https://www.inngest.com/docs/functions?ref=blog-redwood-handler#serving), the Redwood handler is simple to use.
 
@@ -50,5 +50,4 @@ By pairing Redwood with Inngest, you can deploy your serverless functions as usu
 
 ## Getting started
 
-Check out the [RedwoodJS Framework Guide](/docs/learn/serving-inngest-functions?ref=blog-redwood-handler#framework-redwood) or the [inngest/sdk-example-redwoodjs-vercel](https://github.com/inngest/sdk-example-redwoodjs-vercel) repository to start your journey, or jump into our [Writing functions](/docs/functions?ref=blog-redwood-handler) documentation to see what's possible with Inngest!
-
+Check out the [RedwoodJS Framework Guide](/docs/learn/serving-inngest-functions?ref=blog-redwood-handler#framework-redwood) to start your journey, or jump into our [Writing functions](/docs/functions?ref=blog-redwood-handler) documentation to see what's possible with Inngest!

--- a/pages/docs/examples/realtime.mdx
+++ b/pages/docs/examples/realtime.mdx
@@ -79,7 +79,7 @@ By creating a channel with a unique identifier, you can stream updates for a spe
 <CardGroup cols={2}>
 
   <Card
-    href="https://github.com/inngest/inngest-js/tree/main/examples/realtime/nodejs/realtime-single-run-subscription"
+    href="https://github.com/inngest/inngest-js/tree/main/examples/realtime/single-run-subscription"
     title={"Explore the full source code"}
     icon={<RiNodejsFill className="text-basis h-8 w-8"/>}
     iconPlacement="top"
@@ -176,7 +176,7 @@ The `globalChannel` will be used to stream updates for all posts, and the `postC
 <CardGroup cols={2}>
 
   <Card
-    href="https://github.com/inngest/inngest-js/tree/main/examples/realtime/nodejs/realtime-across-multiple-channels"
+    href="https://github.com/inngest/inngest-js/tree/main/examples/realtime/realtime-across-multiple-channels"
     title={"Explore the full source code"}
     icon={<RiNodejsFill className="text-basis h-8 w-8"/>}
     iconPlacement="top"
@@ -244,7 +244,7 @@ The `confirmationId` links the published message to the reply event, ensuring th
 <CardGroup cols={2}>
 
   <Card
-    href="https://github.com/inngest/inngest-js/tree/main/examples/realtime/nodejs/realtime-human-in-the-loop"
+    href="https://github.com/inngest/inngest-js/tree/main/examples/realtime/realtime-human-in-the-loop"
     title={"Explore the full source code"}
     icon={<RiNodejsFill className="text-basis h-8 w-8"/>}
     iconPlacement="top"
@@ -274,4 +274,3 @@ The `confirmationId` links the published message to the reply event, ensuring th
 }}/>
 
 </ResourceGrid>
-

--- a/pages/docs/learn/how-functions-are-executed.mdx
+++ b/pages/docs/learn/how-functions-are-executed.mdx
@@ -114,7 +114,7 @@ Temporal is a pull-based durable execution platform, and teams often evaluate bo
 
 **Programming model.** Temporal uses a deterministic replay model where your entire workflow function is re-executed from the beginning on each step, relying on an internal event history to skip completed work. This requires developers to learn and follow strict determinism rules. Inngest uses a step-based memoization model where each step runs once, its result is persisted, and subsequent executions skip completed steps by injecting their stored results. This uses standard language features with no custom runtime rules.
 
-**Flow control.** Inngest includes [concurrency controls](/docs/functions/concurrency), [prioritization](/docs/guides/priority), [throttling](/docs/functions/throttle), [debouncing](/docs/functions/debounce), [rate limiting](/docs/functions/rate-limit), and [idempotency](/docs/functions/idempotency) as built-in features of the SDK, available in every environment: local development, self-hosted, and cloud. Temporal has recently introduced priority and fairness features for task queues, but fairness is a paid feature available only in Temporal Cloud.
+**Flow control.** Inngest includes [concurrency controls](/docs/functions/concurrency), [prioritization](/docs/guides/priority), [throttling](/docs/guides/throttling), [debouncing](/docs/guides/debounce), [rate limiting](/docs/guides/rate-limiting), and [idempotency](/docs/guides/handling-idempotency) as built-in features of the SDK, available in every environment: local development, self-hosted, and cloud. Temporal has recently introduced priority and fairness features for task queues, but fairness is a paid feature available only in Temporal Cloud.
 
 **Self-hosting.** Inngest can be self-hosted as a single binary with SQLite or Postgres as a backing store. Temporal self-hosting requires running multiple server components with a Cassandra or Postgres dependency, along with separate worker infrastructure.
 
@@ -122,7 +122,7 @@ Temporal is a pull-based durable execution platform, and teams often evaluate bo
 | --- | --- | --- |
 | **Infrastructure** | No separate infrastructure. Serve (serverless) or Connect (workers) on your compute. | Requires Temporal Server cluster + separate worker processes. |
 | **Programming model** | Step-based memoization with standard language primitives. | Deterministic replay with strict runtime rules. |
-| **Flow control** | Built-in: [concurrency](/docs/functions/concurrency), [priority](/docs/guides/priority), [throttling](/docs/functions/throttle), [debounce](/docs/functions/debounce), [rate limiting](/docs/functions/rate-limit). Available everywhere. | Priority and fairness features are paid, cloud-only. |
+| **Flow control** | Built-in: [concurrency](/docs/functions/concurrency), [priority](/docs/guides/priority), [throttling](/docs/guides/throttling), [debounce](/docs/guides/debounce), [rate limiting](/docs/guides/rate-limiting). Available everywhere. | Priority and fairness features are paid, cloud-only. |
 | **Self-hosting** | Single binary with SQLite or Postgres. | Multi-component cluster with Cassandra/Postgres. |
 | **Serverless support** | Native. Designed for serverless-first environments. | Requires persistent worker processes; not serverless-native. |
 

--- a/scripts/brokenLinkChecker.ts
+++ b/scripts/brokenLinkChecker.ts
@@ -67,6 +67,7 @@ const options = {
     "https://react.email/", // 429s
     "https://docs.deno.com/",
     "https://banger.show", // 520s
+    "https://muckrack.com", // 403s, requires human verification
   ],
 };
 


### PR DESCRIPTION
Fixes 7 broken links flagged by Aaron's link checker scan.

## Internal fixes (4)
- **fal.ai blog post**: NonRetriableError link updated from `/docs/reference/functions/errors` (404) to `/docs/features/inngest-functions/error-retries/inngest-errors`
- **Realtime examples page**: 3 GitHub example links had an extra `/nodejs/` in the path after the examples directory was restructured. Removed from all three (single-run-subscription, across-multiple-channels, human-in-the-loop)

## External fixes (3)
- **muckrack.com** (403): Added to `brokenLinkChecker.ts` ignore list. Legit URL that requires human verification to access.
- **Redwood blog post**: Removed 2 references to deleted `inngest/sdk-example-redwoodjs-vercel` repo. Framework guide link preserved.
- **Jamstack blog post**: Replaced expired `jamstack.org` link with Netlify Jamstack link per Dan's suggestion to use trusted sources for SEO.

Linear: DEV-292