### PR TITLE
pricing: show X for Dedicated slack channel on Pro tier

### DIFF
--- a/components/RedesignedPricing/plans.ts
+++ b/components/RedesignedPricing/plans.ts
@@ -333,7 +333,7 @@ export const FEATURES: Feature[] = [
     description: "Direct P0 support from our team",
     plans: {
       [PLAN_NAMES.basicFree]: false,
-      [PLAN_NAMES.pro]: "$200",
+      [PLAN_NAMES.pro]: false,
       [PLAN_NAMES.enterprise]: true,
     },
     section: "platform",


### PR DESCRIPTION
Pro previously displayed $200; use the same not-included icon as Basic.

Made-with: Cursor