### PR TITLE
Add docs for schema transformation limitations

### DIFF
--- a/pages/docs/reference/typescript/v4/functions/triggers.mdx
+++ b/pages/docs/reference/typescript/v4/functions/triggers.mdx
@@ -203,6 +203,33 @@ inngest.createFunction(
   Wildcard event types cannot define a schema, since the matched events may have different payload shapes.
 </Callout>
 
+### Schema transformations
+
+Schema transforms (e.g. Zod's `.transform()`) are not supported with `eventType()`. Only the "input" shape of a schema can be used for validation.
+
+<Callout>
+  **Why transforms aren't supported:** When you send an event using a schema with a transform, the data is transformed on the producer side before being sent to Inngest. For example, if your schema transforms `{ input: "hello" }` into `{ output: 5 }`, the platform receives `{ output: 5 }`. When that event triggers a function, the SDK tries to validate the incoming data using the same schema, but the schema expects the _input_ shape (`{ input: string }`) not the _output_ shape (`{ output: number }`). This means validation will fail because StandardSchema transforms can only validate input-shaped data.
+</Callout>
+
+If you need to transform event data, do it inside your function handler instead:
+
+```ts
+const rawEvent = eventType("app/data.received", {
+  schema: z.object({ input: z.string() }),
+});
+
+inngest.createFunction(
+  {
+    id: "process-data",
+    triggers: [rawEvent],
+  },
+  async ({ event }) => {
+    // Transform inside the handler, not in the schema
+    const output = event.data.input.length;
+  }
+);
+```
+
 ---
 
 ## `cron`


### PR DESCRIPTION
Closes DEV-302

## Summary

Adds documentation explaining why schema transformations (e.g. Zod's `.transform()`) are not supported with `eventType()`. The new section includes:

- Clear explanation of the limitation
- Technical reasoning behind why transforms fail validation
- Practical guidance on transforming data inside function handlers instead

## Changes

Added "Schema transformations" subsection under the `eventType()` reference in `pages/docs/reference/typescript/v4/functions/triggers.mdx`.

The section clarifies that only the "input" shape of a schema can be used for validation, explains the mismatch that occurs when transforms are applied on the producer side, and provides a code example showing the recommended pattern of transforming data in the handler instead.

## Related

- Reference: [`eventType()` documentation](https://inngest.dev/docs/reference/typescript/v4/functions/triggers#eventtype)