### PR TITLE
Add architecture documentation page

### DIFF
--- a/pages/docs/architecture.mdx
+++ b/pages/docs/architecture.mdx
@@ -39,7 +39,7 @@ Run scheduling depends on the global **event stream**, so an unhealthy event str
 
 ### Queue
 
-The queue holds every step of every run between executions. It is a multi-tenant, fair queue with first-class support for [priority](/docs/guides/priority), [singleton](/docs/guides/singleton), and the constraint data used by concurrency and throttling.
+The queue holds every step of every run between executions. It is a multi-tenant, fair queue that stores queue items and the constraint data used by concurrency, throttling, priority, and singleton — but the gating logic itself runs in the executor at lease time, not in the queue.
 
 Enqueue latency, lease time, and time-in-queue are all queue concerns — when a function is "slow to start", the queue is usually where to look first.
 
@@ -51,7 +51,7 @@ The state store holds everything Inngest needs to resume a function: the trigger
 
 ### Executor (Function Execution)
 
-The executor leases a queue item, loads the run's state, and invokes the next step against your code. At lease time it also enforces per-function [concurrency limits](/docs/guides/concurrency) and [throttling](/docs/guides/throttling) — these are checked during function execution rather than in the queue itself, so a function saturating its concurrency only blocks its own items, not the queue as a whole.
+The executor leases a queue item, loads the run's state, and invokes the next step against your code. At lease time it also enforces per-function [concurrency limits](/docs/guides/concurrency), [throttling](/docs/guides/throttling), [priority](/docs/guides/priority), and [singleton](/docs/guides/singleton) — these are checked during function execution rather than in the queue itself, so a function saturating its concurrency only blocks its own items, not the queue as a whole.
 
 It then captures the result (success, error, or a new step request), writes it to the state store, and enqueues whatever comes next. Retries, error classification, and step output truncation also happen here.
 
@@ -96,11 +96,11 @@ Flow control features are not all enforced in the same place. Where a feature ru
 | [Rate limits](/docs/guides/rate-limiting) | Run Scheduling | Drops extra runs before they are created. |
 | [Concurrency](/docs/guides/concurrency) | Function Execution | Enforced by the executor at lease time. |
 | [Throttling](/docs/guides/throttling) | Function Execution | Enforced by the executor at lease time. |
-| [Priority](/docs/guides/priority) | Queue | Decides which queue item is leased next. |
-| [Singleton](/docs/guides/singleton) | Queue | Prevents concurrent runs of the same key. |
+| [Priority](/docs/guides/priority) | Function Execution | Decides which queue item the executor leases next. |
+| [Singleton](/docs/guides/singleton) | Function Execution | Enforced by the executor; prevents concurrent runs of the same key. |
 | `step.waitForEvent`, `step.invoke`, `cancelOn` | Pauses + Event Stream | Share pause-matching; depend on the global event stream. |
 
-A useful rule of thumb: **features that decide whether a run happens at all run in Scheduling; features that decide when an existing run runs next run in the Queue or Executor.**
+A useful rule of thumb: **features that decide whether a run happens at all run in Scheduling; features that decide when an existing run runs next run in the Executor.**
 
 ## Reading the architecture during an incident
 

--- a/pages/docs/architecture.mdx
+++ b/pages/docs/architecture.mdx
@@ -11,10 +11,10 @@ Inngest is built from a small set of independent subsystems. Each one owns a sin
 1. Your service (or another function) sends an event to the **Event API**.
 2. The event is fanned out to every function that subscribes to it; this is **run scheduling**.
 3. Each new run, and every step within it, becomes an item on the **queue**.
-4. The **executor** pulls from the queue and invokes your function, either over HTTP (**serve**) or over a persistent worker connection (**Connect**).
+4. The **executor** pulls from the queue and invokes your function, either over HTTP (**serve**) or over a persistent worker connection (**[Connect](/docs/setup/connect)**).
 5. The result of each step is written to the **state store**, and the next step is enqueued. This repeats until the function completes.
 
-Steps that wait, such as [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event), [`step.invoke`](/docs/guides/invoking-functions-directly), `step.sleep`, and [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events), leave a **pause** in the state store instead of an immediate queue item. The pause is resumed by an incoming event, a signal, or a timer.
+Steps that wait, such as [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event), [`step.invoke`](/docs/guides/invoking-functions-directly), [`step.sleep`](/docs/features/inngest-functions/steps-workflows/sleeps), and [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events), leave a **pause** in the state store instead of an immediate queue item. The pause is resumed by an incoming event, a signal, or a timer.
 
 ## Subsystems
 
@@ -106,7 +106,7 @@ When something looks wrong, the subsystem usually narrows itself down quickly:
 
 - `inngest.send()` is failing or slow → **Event API**.
 - Events are accepted but functions never start → **Scheduler** or **Queue**.
-- Runs start but get stuck mid-flight → **Executor**, your **serve endpoint**, or **Connect Gateway**.
+- Runs start but get stuck mid-flight → **Executor**, your **serve endpoint**, or **[Connect](/docs/setup/connect) Gateway**.
 - [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event) or [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events) is not firing → **Scheduler** or **State store** (pauses).
 - Dashboards and the REST API are slow but runs are fine → **REST API**, not the runtime.
 

--- a/pages/docs/architecture.mdx
+++ b/pages/docs/architecture.mdx
@@ -32,13 +32,16 @@ The scheduler consumes from the event stream and decides which functions to invo
 
 - Matches the event name against function triggers (including wildcards and CEL expressions).
 - Resumes any **pauses** that are waiting for this event (`step.waitForEvent`, `cancelOn`, `step.invoke` replies).
+- Evaluates [batching](/docs/guides/batching), [debounce](/docs/guides/debounce), and [rate limits](/docs/guides/rate-limiting) to decide whether (and when) to create a run.
 - Creates new function runs and enqueues their first step.
 
-Batching, debounce, and `rateLimit` are also evaluated here, before a run is created.
+Run scheduling depends on the global **event stream**, so an unhealthy event stream delays run creation across the system.
 
 ### Queue
 
-The queue is the heart of Inngest. It is a multi-tenant, fair queue with first-class support for [concurrency limits](/docs/guides/concurrency), [throttling](/docs/guides/throttling), [priority](/docs/guides/priority), and [singleton](/docs/guides/singleton) constraints. Every step of every run is a queue item. Enqueue latency, lease time, and time-in-queue are all queue concerns — when a function is "slow to start", the queue is usually where to look first.
+The queue holds every step of every run between executions. It is a multi-tenant, fair queue with first-class support for [priority](/docs/guides/priority), [singleton](/docs/guides/singleton), and the constraint data used by concurrency and throttling.
+
+Enqueue latency, lease time, and time-in-queue are all queue concerns — when a function is "slow to start", the queue is usually where to look first.
 
 For background reading, see [How we built a fair multi-tenant queuing system](/blog/building-the-inngest-queue-pt-i-fairness-multi-tenancy).
 
@@ -48,7 +51,9 @@ The state store holds everything Inngest needs to resume a function: the trigger
 
 ### Executor (Function Execution)
 
-The executor leases a queue item, loads the run's state, and invokes the next step against your code. It then captures the result (success, error, or a new step request), writes it to the state store, and enqueues whatever comes next. The executor is also where retries, error classification, and step output truncation happen.
+The executor leases a queue item, loads the run's state, and invokes the next step against your code. At lease time it also enforces per-function [concurrency limits](/docs/guides/concurrency) and [throttling](/docs/guides/throttling) — these are checked during function execution rather than in the queue itself, so a function saturating its concurrency only blocks its own items, not the queue as a whole.
+
+It then captures the result (success, error, or a new step request), writes it to the state store, and enqueues whatever comes next. Retries, error classification, and step output truncation also happen here.
 
 Each step is executed as a separate request to your code, so the executor never holds long-lived references to your application — your function can scale, deploy, or restart freely between steps.
 
@@ -69,7 +74,7 @@ A pause is a row in the state store that says "resume this run when X happens". 
 - `step.invoke` — resume on the completion of another function run.
 - [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events) — cancel the run if a matching event arrives.
 
-Pauses are matched by the scheduler against incoming events, so latency on `waitForEvent` and `cancelOn` depends on both the scheduler and the state store, not on the queue.
+All three share the same pause-matching infrastructure, and all three depend on the global **event stream**: every inbound event is checked against outstanding pauses before it can wake a run. That means `waitForEvent`, `cancelOn`, and `invoke` latency track the health of the scheduler and event stream, not the queue.
 
 ### APIs
 
@@ -79,6 +84,23 @@ Two APIs sit alongside the runtime:
 - **[Checkpointing API](/docs/setup/checkpointing)** — used by the SDK to stream step results back to Inngest as they complete, instead of waiting for the next request. This reduces tail latency for multi-step functions.
 
 These APIs are independent of the executor, so a degraded REST API does not stop runs from executing, and a degraded executor does not stop you from reading run history.
+
+## Flow control by subsystem
+
+Flow control features are not all enforced in the same place. Where a feature runs tells you which subsystem to look at when it misbehaves.
+
+| Feature | Subsystem | Notes |
+| --- | --- | --- |
+| [Batching](/docs/guides/batching) | Run Scheduling | Accumulates events before a run is created. |
+| [Debounce](/docs/guides/debounce) | Run Scheduling | Delays run creation until a quiet period passes. |
+| [Rate limits](/docs/guides/rate-limiting) | Run Scheduling | Drops extra runs before they are created. |
+| [Concurrency](/docs/guides/concurrency) | Function Execution | Enforced by the executor at lease time. |
+| [Throttling](/docs/guides/throttling) | Function Execution | Enforced by the executor at lease time. |
+| [Priority](/docs/guides/priority) | Queue | Decides which queue item is leased next. |
+| [Singleton](/docs/guides/singleton) | Queue | Prevents concurrent runs of the same key. |
+| `step.waitForEvent`, `step.invoke`, `cancelOn` | Pauses + Event Stream | Share pause-matching; depend on the global event stream. |
+
+A useful rule of thumb: **features that decide whether a run happens at all run in Scheduling; features that decide when an existing run runs next run in the Queue or Executor.**
 
 ## Reading the architecture during an incident
 

--- a/pages/docs/architecture.mdx
+++ b/pages/docs/architecture.mdx
@@ -1,0 +1,93 @@
+import { Callout } from "shared/Docs/mdx";
+
+export const description = "An overview of Inngest's core subsystems — event ingestion, run scheduling, the queue and state store, the executor, the Connect Gateway, and pauses — so you can reason about which subsystem is involved in any given function run or incident.";
+
+# Architecture
+
+Inngest is built from a small set of independent subsystems. Each one owns a single responsibility in the lifecycle of a function run, and each one can fail or degrade independently. This page is a short tour of those subsystems so you can quickly orient yourself when reading status updates, debugging a slow run, or planning capacity.
+
+If you only remember one thing: **a function run flows event → schedule → queue → executor → your code**, with the **state store** holding everything in between. Pauses, Connect, and the public APIs are supporting subsystems around that core path.
+
+## The path of a function run
+
+1. Your service (or another function) sends an event to the **Event API**.
+2. The event is fanned out to every function that subscribes to it — this is **run scheduling**.
+3. Each new run, and every step within it, becomes an item on the **queue**.
+4. The **executor** pulls from the queue and invokes your function — either over HTTP (**serve**) or over a persistent worker connection (**Connect**).
+5. The result of each step is written to the **state store**, and the next step is enqueued. This repeats until the function completes.
+
+Steps that wait — `step.waitForEvent`, `step.invoke`, `step.sleep`, and `cancelOn` — leave a **pause** in the state store instead of an immediate queue item. The pause is resumed by an incoming event, a signal, or a timer.
+
+## Subsystems
+
+### Event Ingestion (Event API)
+
+The Event API is the public ingress point for all events. It authenticates the request with your event key, validates the payload, and writes events onto the internal **event stream**. Once an event has a 200 response from `inngest.send()`, Inngest is responsible for it — even if every downstream subsystem is currently degraded.
+
+The Event API is intentionally one of the smallest subsystems we run, because availability of ingestion is the most important guarantee Inngest makes.
+
+### Run Scheduling
+
+The scheduler consumes from the event stream and decides which functions to invoke. For every event, it:
+
+- Matches the event name against function triggers (including wildcards and CEL expressions).
+- Resumes any **pauses** that are waiting for this event (`step.waitForEvent`, `cancelOn`, `step.invoke` replies).
+- Creates new function runs and enqueues their first step.
+
+Batching, debounce, and `rateLimit` are also evaluated here, before a run is created.
+
+### Queue
+
+The queue is the heart of Inngest. It is a multi-tenant, fair queue with first-class support for [concurrency limits](/docs/guides/concurrency), [throttling](/docs/guides/throttling), [priority](/docs/guides/priority), and [singleton](/docs/guides/singleton) constraints. Every step of every run is a queue item. Enqueue latency, lease time, and time-in-queue are all queue concerns — when a function is "slow to start", the queue is usually where to look first.
+
+For background reading, see [How we built a fair multi-tenant queuing system](/blog/building-the-inngest-queue-pt-i-fairness-multi-tenancy).
+
+### State Store
+
+The state store holds everything Inngest needs to resume a function: the triggering event(s), the memoized result of every completed step, attempt counts, and any active pauses. Because state is persisted outside your function process, a run can resume on different infrastructure after a failure or deploy. See [How Durable execution works](/docs/learn/how-functions-are-executed) for how memoization uses this store.
+
+### Executor (Function Execution)
+
+The executor leases a queue item, loads the run's state, and invokes the next step against your code. It then captures the result (success, error, or a new step request), writes it to the state store, and enqueues whatever comes next. The executor is also where retries, error classification, and step output truncation happen.
+
+Each step is executed as a separate request to your code, so the executor never holds long-lived references to your application — your function can scale, deploy, or restart freely between steps.
+
+### SDK Connection: Serve and Connect
+
+The executor invokes your code in one of two ways:
+
+- **[Serve](/docs/learn/serving-inngest-functions)** — the executor sends an HTTP request to an endpoint exposed by your application. This is the default for serverless and HTTP-based deployments.
+- **[Connect](/docs/setup/connect)** — your workers open a persistent connection to the **Connect Gateway**, and the executor delivers work over that connection. This is preferred for long-lived workers, environments without a public HTTP endpoint, and workloads that benefit from avoiding per-step HTTP overhead.
+
+The Connect Gateway is its own subsystem. If Connect is degraded, serve-based functions are unaffected, and vice versa.
+
+### Pauses (`waitForEvent`, `invoke`, `cancelOn`)
+
+A pause is a row in the state store that says "resume this run when X happens". Three things create pauses:
+
+- `step.waitForEvent` and `step.waitForSignal` — resume on a matching event or signal.
+- `step.invoke` — resume on the completion of another function run.
+- [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events) — cancel the run if a matching event arrives.
+
+Pauses are matched by the scheduler against incoming events, so latency on `waitForEvent` and `cancelOn` depends on both the scheduler and the state store, not on the queue.
+
+### APIs
+
+Two APIs sit alongside the runtime:
+
+- **[REST API](https://api-docs.inngest.com/docs/inngest-api/1j9i5603g5768-introduction)** — read runs, events, and metrics; trigger cancellations and replays. Used by dashboards, your own tooling, and CI workflows.
+- **[Checkpointing API](/docs/setup/checkpointing)** — used by the SDK to stream step results back to Inngest as they complete, instead of waiting for the next request. This reduces tail latency for multi-step functions.
+
+These APIs are independent of the executor, so a degraded REST API does not stop runs from executing, and a degraded executor does not stop you from reading run history.
+
+## Reading the architecture during an incident
+
+When something looks wrong, the subsystem usually narrows itself down quickly:
+
+- `inngest.send()` is failing or slow → **Event API**.
+- Events are accepted but functions never start → **Scheduler** or **Queue**.
+- Runs start but get stuck mid-flight → **Executor**, your **serve endpoint**, or **Connect Gateway**.
+- `step.waitForEvent` or `cancelOn` is not firing → **Scheduler** or **State store** (pauses).
+- Dashboards and the REST API are slow but runs are fine → **REST API**, not the runtime.
+
+Each subsystem is reported on independently in our [status page](https://status.inngest.com), so the failure mode you observe should map directly to one of the subsystems above.

--- a/pages/docs/architecture.mdx
+++ b/pages/docs/architecture.mdx
@@ -16,7 +16,7 @@ If you only remember one thing: **a function run flows event → schedule → qu
 4. The **executor** pulls from the queue and invokes your function — either over HTTP (**serve**) or over a persistent worker connection (**Connect**).
 5. The result of each step is written to the **state store**, and the next step is enqueued. This repeats until the function completes.
 
-Steps that wait — `step.waitForEvent`, `step.invoke`, `step.sleep`, and `cancelOn` — leave a **pause** in the state store instead of an immediate queue item. The pause is resumed by an incoming event, a signal, or a timer.
+Steps that wait — [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event), [`step.invoke`](/docs/guides/invoking-functions-directly), `step.sleep`, and `cancelOn` — leave a **pause** in the state store instead of an immediate queue item. The pause is resumed by an incoming event, a signal, or a timer.
 
 ## Subsystems
 
@@ -31,7 +31,7 @@ The Event API is intentionally one of the smallest subsystems we run, because av
 The scheduler consumes from the event stream and decides which functions to invoke. For every event, it:
 
 - Matches the event name against function triggers (including wildcards and CEL expressions).
-- Resumes any **pauses** that are waiting for this event (`step.waitForEvent`, `cancelOn`, `step.invoke` replies).
+- Resumes any **pauses** that are waiting for this event ([`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event), `cancelOn`, [`step.invoke`](/docs/guides/invoking-functions-directly) replies).
 - Evaluates [batching](/docs/guides/batching), [debounce](/docs/guides/debounce), and [rate limits](/docs/guides/rate-limiting) to decide whether (and when) to create a run.
 - Creates new function runs and enqueues their first step.
 
@@ -70,8 +70,8 @@ The Connect Gateway is its own subsystem. If Connect is degraded, serve-based fu
 
 A pause is a row in the state store that says "resume this run when X happens". Three things create pauses:
 
-- `step.waitForEvent` and `step.waitForSignal` — resume on a matching event or signal.
-- `step.invoke` — resume on the completion of another function run.
+- [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event) and [`step.waitForSignal`](/docs/features/inngest-functions/steps-workflows/wait-for-signal) — resume on a matching event or signal.
+- [`step.invoke`](/docs/guides/invoking-functions-directly) — resume on the completion of another function run.
 - [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events) — cancel the run if a matching event arrives.
 
 All three share the same pause-matching infrastructure, and all three depend on the global **event stream**: every inbound event is checked against outstanding pauses before it can wake a run. That means `waitForEvent`, `cancelOn`, and `invoke` latency track the health of the scheduler and event stream, not the queue.
@@ -98,7 +98,7 @@ Flow control features are not all enforced in the same place. Where a feature ru
 | [Throttling](/docs/guides/throttling) | Function Execution | Enforced by the executor at lease time. |
 | [Priority](/docs/guides/priority) | Function Execution | Decides which queue item the executor leases next. |
 | [Singleton](/docs/guides/singleton) | Function Execution | Enforced by the executor; prevents concurrent runs of the same key. |
-| `step.waitForEvent`, `step.invoke`, `cancelOn` | Pauses + Event Stream | Share pause-matching; depend on the global event stream. |
+| [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event), [`step.invoke`](/docs/guides/invoking-functions-directly), `cancelOn` | Pauses + Event Stream | Share pause-matching; depend on the global event stream. |
 
 A useful rule of thumb: **features that decide whether a run happens at all run in Scheduling; features that decide when an existing run runs next run in the Executor.**
 
@@ -109,7 +109,7 @@ When something looks wrong, the subsystem usually narrows itself down quickly:
 - `inngest.send()` is failing or slow → **Event API**.
 - Events are accepted but functions never start → **Scheduler** or **Queue**.
 - Runs start but get stuck mid-flight → **Executor**, your **serve endpoint**, or **Connect Gateway**.
-- `step.waitForEvent` or `cancelOn` is not firing → **Scheduler** or **State store** (pauses).
+- [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event) or `cancelOn` is not firing → **Scheduler** or **State store** (pauses).
 - Dashboards and the REST API are slow but runs are fine → **REST API**, not the runtime.
 
 Each subsystem is reported on independently in our [status page](https://status.inngest.com), so the failure mode you observe should map directly to one of the subsystems above.

--- a/pages/docs/architecture.mdx
+++ b/pages/docs/architecture.mdx
@@ -1,28 +1,26 @@
 import { Callout } from "shared/Docs/mdx";
 
-export const description = "An overview of Inngest's core subsystems — event ingestion, run scheduling, the queue and state store, the executor, the Connect Gateway, and pauses — so you can reason about which subsystem is involved in any given function run or incident.";
+export const description = "An overview of Inngest's core subsystems, including event ingestion, run scheduling, the queue and state store, the executor, the Connect Gateway, and pauses, so you can reason about which subsystem is involved in any given function run or incident.";
 
 # Architecture
 
 Inngest is built from a small set of independent subsystems. Each one owns a single responsibility in the lifecycle of a function run, and each one can fail or degrade independently. This page is a short tour of those subsystems so you can quickly orient yourself when reading status updates, debugging a slow run, or planning capacity.
 
-If you only remember one thing: **a function run flows event → schedule → queue → executor → your code**, with the **state store** holding everything in between. Pauses, Connect, and the public APIs are supporting subsystems around that core path.
-
 ## The path of a function run
 
 1. Your service (or another function) sends an event to the **Event API**.
-2. The event is fanned out to every function that subscribes to it — this is **run scheduling**.
+2. The event is fanned out to every function that subscribes to it; this is **run scheduling**.
 3. Each new run, and every step within it, becomes an item on the **queue**.
-4. The **executor** pulls from the queue and invokes your function — either over HTTP (**serve**) or over a persistent worker connection (**Connect**).
+4. The **executor** pulls from the queue and invokes your function, either over HTTP (**serve**) or over a persistent worker connection (**Connect**).
 5. The result of each step is written to the **state store**, and the next step is enqueued. This repeats until the function completes.
 
-Steps that wait — [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event), [`step.invoke`](/docs/guides/invoking-functions-directly), `step.sleep`, and `cancelOn` — leave a **pause** in the state store instead of an immediate queue item. The pause is resumed by an incoming event, a signal, or a timer.
+Steps that wait, such as [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event), [`step.invoke`](/docs/guides/invoking-functions-directly), `step.sleep`, and [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events), leave a **pause** in the state store instead of an immediate queue item. The pause is resumed by an incoming event, a signal, or a timer.
 
 ## Subsystems
 
 ### Event Ingestion (Event API)
 
-The Event API is the public ingress point for all events. It authenticates the request with your event key, validates the payload, and writes events onto the internal **event stream**. Once an event has a 200 response from `inngest.send()`, Inngest is responsible for it — even if every downstream subsystem is currently degraded.
+The Event API is the public ingress point for all events. It authenticates the request with your event key, validates the payload, and writes events onto the internal **event stream**. Once an event has a 200 response from `inngest.send()`, Inngest is responsible for it, even if every downstream subsystem is currently degraded.
 
 The Event API is intentionally one of the smallest subsystems we run, because availability of ingestion is the most important guarantee Inngest makes.
 
@@ -31,7 +29,7 @@ The Event API is intentionally one of the smallest subsystems we run, because av
 The scheduler consumes from the event stream and decides which functions to invoke. For every event, it:
 
 - Matches the event name against function triggers (including wildcards and CEL expressions).
-- Resumes any **pauses** that are waiting for this event ([`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event), `cancelOn`, [`step.invoke`](/docs/guides/invoking-functions-directly) replies).
+- Resumes any **pauses** that are waiting for this event ([`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event), [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events), [`step.invoke`](/docs/guides/invoking-functions-directly) replies).
 - Evaluates [batching](/docs/guides/batching), [debounce](/docs/guides/debounce), and [rate limits](/docs/guides/rate-limiting) to decide whether (and when) to create a run.
 - Creates new function runs and enqueues their first step.
 
@@ -39,9 +37,9 @@ Run scheduling depends on the global **event stream**, so an unhealthy event str
 
 ### Queue
 
-The queue holds every step of every run between executions. It is a multi-tenant, fair queue that stores queue items and the constraint data used by concurrency, throttling, priority, and singleton — but the gating logic itself runs in the executor at lease time, not in the queue.
+The queue holds every step of every run between executions. It is a multi-tenant, fair queue that stores queue items and the constraint data used by concurrency, throttling, priority, and singleton; the gating logic itself runs in the executor at lease time, not in the queue.
 
-Enqueue latency, lease time, and time-in-queue are all queue concerns — when a function is "slow to start", the queue is usually where to look first.
+Enqueue latency, lease time, and time-in-queue are all queue concerns; when a function is "slow to start", the queue is usually where to look first.
 
 For background reading, see [How we built a fair multi-tenant queuing system](/blog/building-the-inngest-queue-pt-i-fairness-multi-tenancy).
 
@@ -51,18 +49,18 @@ The state store holds everything Inngest needs to resume a function: the trigger
 
 ### Executor (Function Execution)
 
-The executor leases a queue item, loads the run's state, and invokes the next step against your code. At lease time it also enforces per-function [concurrency limits](/docs/guides/concurrency), [throttling](/docs/guides/throttling), [priority](/docs/guides/priority), and [singleton](/docs/guides/singleton) — these are checked during function execution rather than in the queue itself, so a function saturating its concurrency only blocks its own items, not the queue as a whole.
+The executor leases a queue item, loads the run's state, and invokes the next step against your code. At lease time it also enforces per-function [concurrency limits](/docs/guides/concurrency), [throttling](/docs/guides/throttling), [priority](/docs/guides/priority), and [singleton](/docs/guides/singleton); these are checked during function execution rather than in the queue itself, so a function saturating its concurrency only blocks its own items, not the queue as a whole.
 
 It then captures the result (success, error, or a new step request), writes it to the state store, and enqueues whatever comes next. Retries, error classification, and step output truncation also happen here.
 
-Each step is executed as a separate request to your code, so the executor never holds long-lived references to your application — your function can scale, deploy, or restart freely between steps.
+Each step is executed as a separate request to your code, so the executor never holds long-lived references to your application; your function can scale, deploy, or restart freely between steps.
 
 ### SDK Connection: Serve and Connect
 
 The executor invokes your code in one of two ways:
 
-- **[Serve](/docs/learn/serving-inngest-functions)** — the executor sends an HTTP request to an endpoint exposed by your application. This is the default for serverless and HTTP-based deployments.
-- **[Connect](/docs/setup/connect)** — your workers open a persistent connection to the **Connect Gateway**, and the executor delivers work over that connection. This is preferred for long-lived workers, environments without a public HTTP endpoint, and workloads that benefit from avoiding per-step HTTP overhead.
+- **[Serve](/docs/learn/serving-inngest-functions)**, where the executor sends an HTTP request to an endpoint exposed by your application. This is the default for serverless and HTTP-based deployments.
+- **[Connect](/docs/setup/connect)**, where your workers open a persistent connection to the **Connect Gateway** and the executor delivers work over that connection. This is preferred for long-lived workers, environments without a public HTTP endpoint, and workloads that benefit from avoiding per-step HTTP overhead.
 
 The Connect Gateway is its own subsystem. If Connect is degraded, serve-based functions are unaffected, and vice versa.
 
@@ -70,18 +68,18 @@ The Connect Gateway is its own subsystem. If Connect is degraded, serve-based fu
 
 A pause is a row in the state store that says "resume this run when X happens". Three things create pauses:
 
-- [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event) and [`step.waitForSignal`](/docs/features/inngest-functions/steps-workflows/wait-for-signal) — resume on a matching event or signal.
-- [`step.invoke`](/docs/guides/invoking-functions-directly) — resume on the completion of another function run.
-- [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events) — cancel the run if a matching event arrives.
+- [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event) and [`step.waitForSignal`](/docs/features/inngest-functions/steps-workflows/wait-for-signal), which resume on a matching event or signal.
+- [`step.invoke`](/docs/guides/invoking-functions-directly), which resumes on the completion of another function run.
+- [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events), which cancels the run if a matching event arrives.
 
-All three share the same pause-matching infrastructure, and all three depend on the global **event stream**: every inbound event is checked against outstanding pauses before it can wake a run. That means `waitForEvent`, `cancelOn`, and `invoke` latency track the health of the scheduler and event stream, not the queue.
+All three share the same pause-matching infrastructure, and all three depend on the global **event stream**: every inbound event is checked against outstanding pauses before it can wake a run. That means `waitForEvent`, [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events), and `invoke` latency track the health of the scheduler and event stream, not the queue.
 
 ### APIs
 
 Two APIs sit alongside the runtime:
 
-- **[REST API](https://api-docs.inngest.com/docs/inngest-api/1j9i5603g5768-introduction)** — read runs, events, and metrics; trigger cancellations and replays. Used by dashboards, your own tooling, and CI workflows.
-- **[Checkpointing API](/docs/setup/checkpointing)** — used by the SDK to stream step results back to Inngest as they complete, instead of waiting for the next request. This reduces tail latency for multi-step functions.
+- **[REST API](https://api-docs.inngest.com/docs/inngest-api/1j9i5603g5768-introduction)**, for reading runs, events, and metrics, and for triggering cancellations and replays. Used by dashboards, your own tooling, and CI workflows.
+- **[Checkpointing API](/docs/setup/checkpointing)**, used by the SDK to stream step results back to Inngest as they complete, instead of waiting for the next request. This reduces tail latency for multi-step functions.
 
 These APIs are independent of the executor, so a degraded REST API does not stop runs from executing, and a degraded executor does not stop you from reading run history.
 
@@ -98,7 +96,7 @@ Flow control features are not all enforced in the same place. Where a feature ru
 | [Throttling](/docs/guides/throttling) | Function Execution | Enforced by the executor at lease time. |
 | [Priority](/docs/guides/priority) | Function Execution | Decides which queue item the executor leases next. |
 | [Singleton](/docs/guides/singleton) | Function Execution | Enforced by the executor; prevents concurrent runs of the same key. |
-| [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event), [`step.invoke`](/docs/guides/invoking-functions-directly), `cancelOn` | Pauses + Event Stream | Share pause-matching; depend on the global event stream. |
+| [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event), [`step.invoke`](/docs/guides/invoking-functions-directly), [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events) | Pauses + Event Stream | Share pause-matching; depend on the global event stream. |
 
 A useful rule of thumb: **features that decide whether a run happens at all run in Scheduling; features that decide when an existing run runs next run in the Executor.**
 
@@ -109,7 +107,7 @@ When something looks wrong, the subsystem usually narrows itself down quickly:
 - `inngest.send()` is failing or slow → **Event API**.
 - Events are accepted but functions never start → **Scheduler** or **Queue**.
 - Runs start but get stuck mid-flight → **Executor**, your **serve endpoint**, or **Connect Gateway**.
-- [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event) or `cancelOn` is not firing → **Scheduler** or **State store** (pauses).
+- [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event) or [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events) is not firing → **Scheduler** or **State store** (pauses).
 - Dashboards and the REST API are slow but runs are fine → **REST API**, not the runtime.
 
 Each subsystem is reported on independently in our [status page](https://status.inngest.com), so the failure mode you observe should map directly to one of the subsystems above.

--- a/pages/docs/architecture.mdx
+++ b/pages/docs/architecture.mdx
@@ -20,7 +20,7 @@ Steps that wait, such as [`step.waitForEvent`](/docs/features/inngest-functions/
 
 ### Event Ingestion (Event API)
 
-The Event API is the public ingress point for all events. It authenticates the request with your event key, validates the payload, and writes events onto the internal **event stream**. Once an event has a 200 response from `inngest.send()`, Inngest is responsible for it, even if every downstream subsystem is currently degraded.
+The Event API is the public ingress point for all events. It authenticates the request with your event key, validates the payload, and writes events onto the internal **event stream**. Once an event has a 200 response from [`inngest.send()`](/docs/events), Inngest is responsible for it, even if every downstream subsystem is currently degraded.
 
 The Event API is intentionally one of the smallest subsystems we run, because availability of ingestion is the most important guarantee Inngest makes.
 
@@ -104,7 +104,7 @@ A useful rule of thumb: **features that decide whether a run happens at all run 
 
 When something looks wrong, the subsystem usually narrows itself down quickly:
 
-- `inngest.send()` is failing or slow → **Event API**.
+- [`inngest.send()`](/docs/events) is failing or slow → **Event API**.
 - Events are accepted but functions never start → **Scheduler** or **Queue**.
 - Runs start but get stuck mid-flight → **Executor**, your **serve endpoint**, or **[Connect](/docs/setup/connect) Gateway**.
 - [`step.waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event) or [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events) is not firing → **Scheduler** or **State store** (pauses).

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -668,10 +668,6 @@ const sectionLearn: (NavGroup | NavLink)[] = [
     defaultOpen: true,
     links: [
       {
-        title: "Architecture",
-        href: `/docs/architecture`,
-      },
-      {
         title: "How Durable execution works",
         href: `/docs/learn/how-functions-are-executed`,
       },
@@ -1168,6 +1164,10 @@ const sectionLearn: (NavGroup | NavLink)[] = [
   {
     title: "Resources",
     links: [
+      {
+        title: "Architecture",
+        href: `/docs/architecture`,
+      },
       {
         title: "Security",
         href: "/docs/learn/security",

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -668,6 +668,10 @@ const sectionLearn: (NavGroup | NavLink)[] = [
     defaultOpen: true,
     links: [
       {
+        title: "Architecture",
+        href: `/docs/architecture`,
+      },
+      {
         title: "How Durable execution works",
         href: `/docs/learn/how-functions-are-executed`,
       },


### PR DESCRIPTION
## Summary
Added a comprehensive architecture documentation page that explains Inngest's core subsystems and how they work together to execute functions.

## Key Changes
- Created new `pages/docs/architecture.mdx` documentation page
- Documented the complete lifecycle of a function run: event ingestion → scheduling → queue → execution → state persistence
- Explained all major subsystems:
  - Event Ingestion (Event API)
  - Run Scheduling
  - Queue
  - State Store
  - Executor (Function Execution)
  - SDK Connection (Serve and Connect)
  - Pauses (waitForEvent, invoke, cancelOn)
  - APIs (REST API and Checkpointing API)
- Included a quick reference guide for diagnosing issues during incidents by mapping symptoms to specific subsystems
- Added links to related documentation and blog posts for deeper learning

## Notable Details
- The page emphasizes the core execution path: "event → schedule → queue → executor → your code" with the state store holding everything in between
- Includes practical guidance for debugging by mapping observable symptoms (slow sends, stuck runs, etc.) to specific subsystems
- References the status page for independent subsystem monitoring
- Provides context on how pauses work separately from the main queue path

https://claude.ai/code/session_01SvjzY1Lr1hXGntxbUaBDQu