### PR TITLE
Document optional jitter field for cron triggers

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/pages/docs/guides/scheduled-functions.mdx
+++ b/pages/docs/guides/scheduled-functions.mdx
@@ -247,3 +247,58 @@ On the free plan, if your function fails 20 times consecutively it will automati
 
 Inngest's cron behavior follows the underlying cron library and does not apply special DST correction. To reduce risk, avoid transition-hour schedules (such as `2:00 AM` in many US regions, or `12:00 AM` in some other regions), and prefer `TZ=UTC` when you need consistent execution timing.
 </Callout>
+
+## Adding jitter
+
+By default, cron functions fire at the exact scheduled time. If you have many cron functions on the same schedule, they all fire at once which can create load spikes on your system or on third-party APIs.
+
+You can add an optional `jitter` to spread out the execution. When jitter is set, each cron occurrence fires at a random time within the jitter window after the scheduled boundary. The jitter is deterministic per occurrence — retries and restarts produce the same delay.
+
+Jitter must be between 1 second and 5 minutes.
+
+<LanguageSelector>
+
+<LanguageSection show="typescript">
+
+```ts
+inngest.createFunction(
+  {
+    id: "hourly-sync",
+    triggers: [{ cron: "0 * * * *", jitter: "5m" }],
+  },
+  async ({ step }) => {
+    // Fires at a random time within 5 minutes after each hour
+  }
+);
+```
+
+</LanguageSection>
+<LanguageSection show="go">
+
+```go
+inngestgo.CreateFunction(
+    client,
+    inngestgo.FunctionOpts{Name: "hourly-sync"},
+    inngestgo.CronTriggerWithJitter("0 * * * *", 5*time.Minute),
+    func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+        // Fires at a random time within 5 minutes after each hour
+        return nil, nil
+    },
+)
+```
+
+</LanguageSection>
+<LanguageSection show="python">
+
+```python
+@inngest_client.create_function(
+    fn_id="hourly-sync",
+    trigger=inngest.TriggerCron(cron="0 * * * *", jitter="5m"),
+)
+async def hourly_sync(ctx: inngest.Context) -> None:
+    # Fires at a random time within 5 minutes after each hour
+    pass
+```
+
+</LanguageSection>
+</LanguageSelector>

--- a/pages/docs/guides/scheduled-functions.mdx
+++ b/pages/docs/guides/scheduled-functions.mdx
@@ -252,7 +252,7 @@ Inngest's cron behavior follows the underlying cron library and does not apply s
 
 By default, cron functions fire at the exact scheduled time. If you have many cron functions on the same schedule, they all fire at once which can create load spikes on your system or on third-party APIs.
 
-You can add an optional `jitter` to spread out the execution. When jitter is set, each cron occurrence fires at a random time within the jitter window after the scheduled boundary. The jitter is deterministic per occurrence — retries and restarts produce the same delay.
+You can add an optional `jitter` to spread out the execution. When jitter is set, each cron occurrence fires at a random time within the jitter window after the scheduled boundary.
 
 Jitter must be between 1 second and 5 minutes.
 

--- a/pages/docs/reference/python/functions/create.mdx
+++ b/pages/docs/reference/python/functions/create.mdx
@@ -184,7 +184,7 @@ The `create_function` decorator accepts a configuration and wraps a plain functi
     A [unix-cron](https://crontab.guru/) compatible schedule string. <br/>Optional timezone prefix, e.g. `TZ=Europe/Paris 0 12 * * 5`.
   </Property>
   <Property name="jitter" type="str">
-    A duration string (e.g. `"30s"`, `"5m"`) that adds a random delay after the scheduled boundary. Each occurrence fires at a deterministic random time within the jitter window. Must be between `"1s"` and `"5m"`. See the [jitter guide](/docs/guides/scheduled-functions#adding-jitter) for details.
+    A duration string (e.g. `"30s"`, `"5m"`) that adds a random delay after the scheduled boundary. Each occurrence fires at a random time within the jitter window. Must be between `"1s"` and `"5m"`. See the [jitter guide](/docs/guides/scheduled-functions#adding-jitter) for details.
   </Property>
 </Properties>
 

--- a/pages/docs/reference/python/functions/create.mdx
+++ b/pages/docs/reference/python/functions/create.mdx
@@ -183,6 +183,9 @@ The `create_function` decorator accepts a configuration and wraps a plain functi
   <Property name="cron" type="str" required>
     A [unix-cron](https://crontab.guru/) compatible schedule string. <br/>Optional timezone prefix, e.g. `TZ=Europe/Paris 0 12 * * 5`.
   </Property>
+  <Property name="jitter" type="str">
+    A duration string (e.g. `"30s"`, `"5m"`) that adds a random delay after the scheduled boundary. Each occurrence fires at a deterministic random time within the jitter window. Must be between `"1s"` and `"5m"`. See the [jitter guide](/docs/guides/scheduled-functions#adding-jitter) for details.
+  </Property>
 </Properties>
 
 ### Multiple Triggers

--- a/pages/docs/reference/typescript/v4/functions/triggers.mdx
+++ b/pages/docs/reference/typescript/v4/functions/triggers.mdx
@@ -258,6 +258,23 @@ inngest.createFunction(
   </Property>
 </Properties>
 
+<Info>
+The `cron()` helper accepts a schedule string only. To add optional fields like `jitter`, use the object trigger form directly: `{ cron: "0 * * * *", jitter: "30s" }`. See the [jitter section](/docs/guides/scheduled-functions#adding-jitter) for details.
+</Info>
+
+### Cron trigger object
+
+You can also pass a cron trigger as an object, which supports additional options:
+
+<Properties>
+  <Property name="cron" type="string" required>
+    A [unix-cron](https://crontab.guru/) compatible schedule string.
+  </Property>
+  <Property name="jitter" type="string">
+    A duration string (e.g. `"30s"`, `"5m"`) that adds a random delay after the scheduled boundary. Each occurrence fires at a random time within the jitter window. Must be between `"1s"` and `"5m"`.
+  </Property>
+</Properties>
+
 ### Examples
 
 <CodeGroup>
@@ -281,6 +298,18 @@ inngest.createFunction(
   },
   async ({ step }) => {
     // Runs at 9am ET on weekdays
+  }
+);
+```
+
+```ts {{ title: "With jitter" }}
+inngest.createFunction(
+  {
+    id: "hourly-sync",
+    triggers: [{ cron: "0 * * * *", jitter: "5m" }],
+  },
+  async ({ step }) => {
+    // Fires at a random time within 5 minutes after each hour
   }
 );
 ```


### PR DESCRIPTION
Add jitter documentation to the scheduled functions guide with examples. Update the TypeScript trigger reference with the cron trigger object form and jitter property.

Note- There isn’t currently a Go reference page in this repo parallel to the TypeScript and Python trigger docs, (i.e.  there wasn’t an equivalent place to add a Go-specific jitter blurb.)

