### PR TITLE
EXE-1595: Update docs on waitForEvent's timeout

### DIFF
--- a/pages/docs/reference/typescript/v4/functions/cancel-on.mdx
+++ b/pages/docs/reference/typescript/v4/functions/cancel-on.mdx
@@ -103,8 +103,10 @@ Match expressions can be simple equalities or be more complex. Read [our guide t
 
         * `event.data.userId == async.data.userId && async.data.billing_plan == 'pro'`
       </Property>
-      <Property name="timeout" type="string">
-        The amount of time to wait to receive the cancelling event. A time string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`
+      <Property name="timeout" type="string | Date">
+        How long to wait to receive the cancelling event. Either:
+        - A duration string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`, or
+        - An absolute `Date`.
       </Property>
     </Properties>
   </Property>

--- a/pages/docs/reference/typescript/v4/functions/step-invoke.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-invoke.mdx
@@ -62,7 +62,7 @@ const mainFunction = inngest.createFunction(
           </Property>
           <Property name="timeout" type="string | number | Date">
             {/* Purposefully not mentioning the default timeout of 1 year, as we expect to lower this very soon. */}
-            The amount of time to wait for the invoked function to complete. The time to wait can be specified using a `number` of milliseconds, an `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`, or a `Date` object.
+            How long to wait for the invoked function to complete. Either a `number` of milliseconds, an `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`, or a `Date` representing an absolute deadline.
 
             If the timeout is reached, the step will throw an error. See [Error handling](#error-handling) below. Note that the invoked function will continue to run even if this step times out.
           </Property>

--- a/pages/docs/reference/typescript/v4/functions/step-wait-for-event.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-wait-for-event.mdx
@@ -21,8 +21,10 @@ Use `step.waitForEvent()` to pause your function's execution until a matching ev
           <Property name="event" type="string | EventType" required>
             The name of a given event to wait for, or an [`eventType()`](/docs/reference/typescript/v4/functions/triggers#eventtype) result for typed return values.
           </Property>
-          <Property name="timeout" type="string" required>
-            The amount of time to wait to receive the event. A time string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`
+          <Property name="timeout" type="string | Date" required>
+            How long to wait to receive the event. Either:
+            - A duration string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`, or
+            - An absolute `Date`.
           </Property>
           <Property name="match" type="string">
             The property to match the event trigger and the wait event, using dot-notation, e.g. `data.userId`. Cannot be combined with `if`.
@@ -53,6 +55,13 @@ Use `step.waitForEvent()` to pause your function's execution until a matching ev
     event: "app/subscription.created",
     timeout: "30d",
     if: "event.data.userId == async.data.userId && async.data.billing_plan == 'pro'",
+  });
+
+  // Wait until a specific deadline
+  const response = await step.waitForEvent("wait-for-response", {
+    event: "app/response.received",
+    timeout: new Date("2026-05-01T00:00:00Z"),
+    match: "data.requestId",
   });
 
   // Use eventType() for typed return values

--- a/pages/docs/reference/typescript/v4/functions/step-wait-for-signal.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-wait-for-signal.mdx
@@ -43,7 +43,7 @@ and any data you want to inject into the function run.
   </Col>
   <Col>
   ```ts
-  // Wait 15m for an approval
+  // Wait 7d for an approval
   const approval = await step.waitForSignal("wait-for-approval", {
     signal: "task/71651db4-9f27-466a-a6be-4759b9784b3c",
     timeout: "7d",

--- a/pages/docs/reference/typescript/v4/functions/step-wait-for-signal.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-wait-for-signal.mdx
@@ -23,8 +23,10 @@ and any data you want to inject into the function run.
           <Property name="signal" type="string" required>
             A unique identifier for the signal, used to resume this function run.
           </Property>
-          <Property name="timeout" type="string" required>
-            The amount of time to wait to receive the signal. A time string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`.
+          <Property name="timeout" type="string | Date" required>
+            How long to wait to receive the signal. Either:
+            - A duration string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`, or
+            - An absolute `Date`.
 
             If the signal is not received before this timeout, the run will resume with an undefined return value.
           </Property>


### PR DESCRIPTION
- With https://github.com/inngest/inngest/pull/4048 and https://github.com/inngest/inngest/pull/4056, we'll accept Dates as an arg in step.waitForEvent, step.waitForSignal, step.invoke, and cancelOn[]
- Update the docs to match

## Vercel previews

- [cancel-on](https://website-git-scott-waitforevent-timeout-inngest.vercel.app/docs/reference/typescript/v4/functions/cancel-on)
- [step-invoke](https://website-git-scott-waitforevent-timeout-inngest.vercel.app/docs/reference/typescript/v4/functions/step-invoke)
- [step-wait-for-event](https://website-git-scott-waitforevent-timeout-inngest.vercel.app/docs/reference/typescript/v4/functions/step-wait-for-event)
- [step-wait-for-signal](https://website-git-scott-waitforevent-timeout-inngest.vercel.app/docs/reference/typescript/v4/functions/step-wait-for-signal)