### PR TITLE
Add AI files and structured data for LLM discoverability

### DIFF
--- a/app/(llms)/llms.txt/route.ts
+++ b/app/(llms)/llms.txt/route.ts
@@ -19,6 +19,12 @@ export async function GET() {
 
   const overview = `# Inngest
 
+> Inngest is the durable workflow engine for AI applications. It provides step-level retries, event coordination, throttling, concurrency controls, and human-in-the-loop patterns. Write reliable background jobs and multi-step AI pipelines as regular code, with built-in observability and zero infrastructure to manage.
+
+- [Documentation](${process.env.NEXT_PUBLIC_HOST}/docs-markdown/)
+- [Full documentation as single file](${process.env.NEXT_PUBLIC_HOST}/llms-full.txt)
+- [LLM integration context](${process.env.NEXT_PUBLIC_HOST}/llm-context.md)
+
 ## Learn
 
 ${recursiveLinks(learnDocs)}

--- a/public/ai.txt
+++ b/public/ai.txt
@@ -1,0 +1,18 @@
+# ai.txt - AI Usage Policy for inngest.com
+# Learn more: https://ai-txt.org
+
+User-agent: *
+Allow-AI-Training: yes
+Allow-AI-Summarization: yes
+Allow-AI-Citation: yes
+Allow-AI-Inference: yes
+
+# Inngest documentation is designed to be consumed by AI systems.
+# We provide structured formats for LLM consumption:
+#
+# llms.txt:      https://www.inngest.com/llms.txt
+# llms-full.txt: https://www.inngest.com/llms-full.txt
+# Markdown API:  https://www.inngest.com/docs-markdown/{path}
+# AGENTS.md:     https://github.com/inngest/website/blob/main/AGENTS.md
+#
+# Contact: support@inngest.com

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,58 +7,23 @@ Allow: /
 # See also: /llms.txt, /llms-full.txt, /ai.txt
 
 User-agent: GPTBot
-Allow: /docs/
-Allow: /blog/
-Allow: /patterns/
-Allow: /llms.txt
-Allow: /llms-full.txt
-Allow: /docs-markdown/
-Disallow: /app/
-
 User-agent: ChatGPT-User
-Allow: /docs/
-Allow: /blog/
-Allow: /patterns/
-Allow: /llms.txt
-Allow: /llms-full.txt
-Allow: /docs-markdown/
-Disallow: /app/
-
 User-agent: ClaudeBot
-Allow: /docs/
-Allow: /blog/
-Allow: /patterns/
-Allow: /llms.txt
-Allow: /llms-full.txt
-Allow: /docs-markdown/
-Disallow: /app/
-
-User-agent: Google-Extended
-Allow: /
-
 User-agent: PerplexityBot
-Allow: /docs/
-Allow: /blog/
-Allow: /patterns/
-Allow: /llms.txt
-Allow: /llms-full.txt
-Allow: /docs-markdown/
-Disallow: /app/
-
 User-agent: Amazonbot
-Allow: /docs/
-Allow: /blog/
-Allow: /patterns/
-Disallow: /app/
-
-User-agent: Bytespider
-Disallow: /
-
 User-agent: CCBot
 Allow: /docs/
 Allow: /blog/
 Allow: /patterns/
-Disallow: /app/
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs-markdown/
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Bytespider
+Disallow: /
 
 # Host
 Host: https://www.inngest.com

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,64 @@
-# *
+# Standard crawlers
 User-agent: *
 Allow: /
+
+# AI Crawlers
+# Inngest welcomes AI crawlers to index our documentation.
+# See also: /llms.txt, /llms-full.txt, /ai.txt
+
+User-agent: GPTBot
+Allow: /docs/
+Allow: /blog/
+Allow: /patterns/
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs-markdown/
+Disallow: /app/
+
+User-agent: ChatGPT-User
+Allow: /docs/
+Allow: /blog/
+Allow: /patterns/
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs-markdown/
+Disallow: /app/
+
+User-agent: ClaudeBot
+Allow: /docs/
+Allow: /blog/
+Allow: /patterns/
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs-markdown/
+Disallow: /app/
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /docs/
+Allow: /blog/
+Allow: /patterns/
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs-markdown/
+Disallow: /app/
+
+User-agent: Amazonbot
+Allow: /docs/
+Allow: /blog/
+Allow: /patterns/
+Disallow: /app/
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: CCBot
+Allow: /docs/
+Allow: /blog/
+Allow: /patterns/
+Disallow: /app/
 
 # Host
 Host: https://www.inngest.com

--- a/public/tdmrep.json
+++ b/public/tdmrep.json
@@ -1,0 +1,23 @@
+{
+  "@context": "https://www.w3.org/2022/tdmrep",
+  "@type": "TDMPolicy",
+  "tdm_policy": "https://www.inngest.com/terms",
+  "tdm_reservation": 0,
+  "tdm_permissions": [
+    {
+      "type": "text-mining",
+      "status": "allowed",
+      "scope": "https://www.inngest.com/docs/*"
+    },
+    {
+      "type": "text-mining",
+      "status": "allowed",
+      "scope": "https://www.inngest.com/blog/*"
+    },
+    {
+      "type": "data-mining",
+      "status": "allowed",
+      "scope": "https://www.inngest.com/docs/*"
+    }
+  ]
+}

--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -72,6 +72,29 @@ export function Layout({
     ? GITHUB_PREFIX + sourceFilePath
     : undefined;
 
+  // Markdown alternate URL for AI/LLM discoverability
+  const docsPath = router.asPath.replace(/^\/(docs)/, "").split("?")[0].split("#")[0];
+  const markdownAlternateUrl = `https://www.inngest.com/docs-markdown${docsPath}`;
+  const canonicalUrl = `https://www.inngest.com${router.asPath.split("?")[0].split("#")[0]}`;
+
+  // JSON-LD structured data for documentation pages
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: preferredTitle,
+    description: metaDescription,
+    url: canonicalUrl,
+    publisher: {
+      "@type": "Organization",
+      name: "Inngest",
+      url: "https://www.inngest.com",
+    },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": canonicalUrl,
+    },
+  };
+
   let tsV4Banner = null;
 
   // Is any of the "Learn" pages (except for the Python quick start)
@@ -119,10 +142,21 @@ export function Layout({
           <meta name="docsearch:sdkLanguage" content={sdkLanguage} />
           <meta name="docsearch:sdkVersion" content={sdkVersion} />
 
+          {/* Markdown alternate for AI/LLM discoverability */}
+          <link rel="alternate" type="text/markdown" href={markdownAlternateUrl} />
+
           <link rel="preconnect" href="https://fonts-cdn.inngest.com/" />
           <link
             rel="stylesheet"
             href="https://fonts-cdn.inngest.com/fonts.css"
+          />
+
+          {/* Schema.org structured data for documentation */}
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(structuredData),
+            }}
           />
 
           <script dangerouslySetInnerHTML={{ __html: modeScript }} />


### PR DESCRIPTION
DEV-317

## Summary

Updates the Inngest website to follow AI files best practices for documentation discoverability by LLMs and AI agents, per [the AI files guide](https://www.tristandenyer.com/work/ai-files-for-websites-2026).

**What already existed:** llms.txt (dynamic), llms-full.txt (dynamic), docs-markdown routes, AGENTS.md, blog JSON-LD

**What this PR adds:**

- **robots.txt**: Explicit AI crawler rules — allows GPTBot, ClaudeBot, ChatGPT-User, Google-Extended, PerplexityBot, Amazonbot, CCBot on docs/blog/patterns; blocks Bytespider; blocks all AI crawlers from /app/
- **ai.txt**: AI usage permissions file declaring training, summarization, citation, and inference are allowed, with pointers to our LLM-friendly endpoints
- **tdmrep.json**: TDM Reservation Protocol file allowing text and data mining on docs and blog
- **llms.txt**: Added spec-required blockquote summary describing Inngest, plus top-level links to full docs, llms-full.txt, and llm-context.md
- **Docs Layout — JSON-LD**: TechArticle schema.org structured data on every documentation page (blog already had BlogPosting)
- **Docs Layout — Link alternate**: `<link rel="alternate" type="text/markdown">` on every docs page pointing to the corresponding /docs-markdown/ route

## Test plan

- [ ] Verify /robots.txt renders with AI crawler rules
- [ ] Verify /ai.txt is accessible
- [ ] Verify /tdmrep.json is valid JSON
- [ ] Verify /llms.txt has blockquote summary at top
- [ ] Verify docs pages have JSON-LD in page source
- [ ] Verify docs pages have `<link rel="alternate" type="text/markdown">` in head
- [ ] Verify no build errors