### PR TITLE
Fix blog date display for YYYY-MM-DD frontmatter

### DIFF
--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -24,6 +24,7 @@ import YouTube from "react-youtube-embed";
 import remarkGfm from "remark-gfm";
 import { SectionProvider } from "src/shared/Docs/SectionProvider";
 import FloatingCTA from "src/components/Blog/FloatingCTA";
+import { formatShortLocaleDate } from "src/utils/date";
 
 // @ts-ignore
 import { remarkCodeHike, recmaCodeHike } from "codehike/mdx";
@@ -155,7 +156,7 @@ export default function BlogLayout(props) {
   let dateUpdated: string | null = null;
   try {
     dateUpdated = scope.dateUpdated
-      ? new Date(scope.dateUpdated).toLocaleDateString()
+      ? formatShortLocaleDate(scope.dateUpdated)
       : null;
   } catch (err) {
     console.log(`Could not parse updated date: ${scope.dateUpdated}`);
@@ -405,11 +406,7 @@ export async function getStaticProps({ params }) {
   data.reading = readingTime(content);
   // Format the reading date.
   if (data.date) {
-    if (typeof data.date === "string") {
-      data.humanDate = new Date(data.date).toLocaleDateString();
-    } else {
-      data.humanDate = data.date.toLocaleDateString();
-    }
+    data.humanDate = formatShortLocaleDate(data.date);
   }
 
   data.tags =

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,4 +1,43 @@
+const ISO_DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Short locale date for blog/changelog lists (e.g. 5/1/2026).
+ * YYYY-MM-DD frontmatter is parsed as UTC midnight; formatting in the local
+ * timezone shifts the calendar day behind the US. Use UTC for date-only values.
+ */
+export function formatShortLocaleDate(input: string | Date): string {
+  if (typeof input === "string") {
+    const m = ISO_DATE_ONLY.exec(input.trim());
+    if (m) {
+      const t = Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+      return new Date(t).toLocaleDateString("en-US", { timeZone: "UTC" });
+    }
+    return new Date(input).toLocaleDateString("en-US");
+  }
+
+  if (
+    input.getUTCHours() === 0 &&
+    input.getUTCMinutes() === 0 &&
+    input.getUTCSeconds() === 0 &&
+    input.getUTCMilliseconds() === 0
+  ) {
+    return input.toLocaleDateString("en-US", { timeZone: "UTC" });
+  }
+
+  return input.toLocaleDateString("en-US");
+}
+
 export function formatDate(date: string) {
+  const m = ISO_DATE_ONLY.exec(date.trim());
+  if (m) {
+    const t = Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+    return new Date(t).toLocaleDateString("en-US", {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+      timeZone: "UTC",
+    });
+  }
   return new Date(date).toLocaleDateString("en-US", {
     month: "long",
     day: "numeric",

--- a/utils/markdown.ts
+++ b/utils/markdown.ts
@@ -4,6 +4,7 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 
 import { rehypeParseCodeBlocks } from "src/mdx/rehype.mjs";
 import { rehypeRemoveTwoSlashMarkup, rehypeShiki } from "src/utils/code";
+import { formatShortLocaleDate } from "src/utils/date";
 
 export type MDXFileMetadata = {
   slug: string;
@@ -47,13 +48,10 @@ export async function loadMarkdownFilesMetadata<T>(
       data.reading = readingTime(content);
       data.slug = filename.replace(/.mdx?$/, "");
       if (data.date) {
-        if (typeof data.date === "string") {
-          data.humanDate = new Date(data.date).toLocaleDateString();
-        } else {
-          data.humanDate = data.date.toLocaleDateString
-            ? data.date.toLocaleDateString()
+        data.humanDate =
+          typeof data.date === "string" || data.date instanceof Date
+            ? formatShortLocaleDate(data.date)
             : String(data.date);
-        }
       }
       if (data.tags) {
         data.tags =


### PR DESCRIPTION
Not sure if we set this up this way intentionally, or if this is just a me<>Cursor problem, but the date for blogs was always the day prior. Cursor says: ISO date-only strings parse as UTC midnight; toLocaleDateString in US timezones showed the previous calendar day. Format date-only values in UTC so published dates match frontmatter. Applies to blog posts, blog metadata loader, changelog long-form dates, and updated-at lines.