### PR TITLE
fix: redirect content download form to PDF after submit - AI in Prod Report LP

### DIFF
--- a/app/content/ai-in-production-report-2026/page.tsx
+++ b/app/content/ai-in-production-report-2026/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { generateMetadata as buildMetadata } from "src/utils/social";
 import ContentDownloadForm from "src/components/ContentDownloadForm";
+import { CONTENT_ASSETS } from "src/shared/contentAssets";
 import { ObservabilityChart } from "./ObservabilityChart";
 import { ReliabilityChart } from "./ReliabilityChart";
 import { InfrastructureChart } from "./InfrastructureChart";
@@ -110,7 +111,10 @@ function Hero() {
             className="flex flex-col justify-center scroll-mt-24 px-8 py-12 md:px-12 md:pr-16 xl:pr-24 [&_button.button]:!bg-[#a8ef3c] [&_button.button]:!text-[#0c1f10] [&_button.button:hover]:!bg-[#baf54d]"
             style={{ backgroundColor: "#000000" }}
           >
-            <ContentDownloadForm asset="ai-in-production-report-2026" />
+            <ContentDownloadForm
+              asset="ai-in-production-report-2026"
+              redirectTo={CONTENT_ASSETS["ai-in-production-report-2026"].redirectTo}
+            />
           </div>
 
         </div>

--- a/shared/contentAssets.ts
+++ b/shared/contentAssets.ts
@@ -41,9 +41,7 @@ export const CONTENT_ASSETS: Record<string, ContentAsset> = {
     description:
       "We surveyed 130 backend, full-stack, and AI engineers about what it takes to run reliable AI workflows in production. We wanted to know what's causing failures, and which infrastructure choices—across orchestration, observability, evals, and agent frameworks—actually reduce the burden of reliability. Explore the patterns that predict scaling confidence.",
     buttonCopy: "Read the report",
-    // PLACEHOLDER for local testing — swap to the real interactive report URL
-    // (e.g. /reports/ai-in-production-2026) once that page is built.
-    redirectTo: "https://www.inngest.com/blog/ai-agents-inngest-durable-steps",
+    redirectTo: "https://www.inngest.com/assets/reports/2026-benchmark/2026-durable-execution-benchmark-report.pdf",
   },
 };
 


### PR DESCRIPTION
Updates the `redirectTo` URL for the `ai-in-production-report-2026` content asset so that users are sent directly to the PDF after submitting the download form.

## Changes
- `shared/contentAssets.ts`: replaced the placeholder blog post redirect with the PDF URL (`/assets/reports/2026-benchmark/2026-durable-execution-benchmark-report.pdf`)