### PR TITLE
EXE-1708: Add docs for new Temporal.* types for .Timeout fields

### DIFF
--- a/pages/docs/reference/typescript/v4/functions/cancel-on.mdx
+++ b/pages/docs/reference/typescript/v4/functions/cancel-on.mdx
@@ -103,10 +103,13 @@ Match expressions can be simple equalities or be more complex. Read [our guide t
 
         * `event.data.userId == async.data.userId && async.data.billing_plan == 'pro'`
       </Property>
-      <Property name="timeout" type="string | Date">
+      <Property name="timeout" type="string | number | Date | Temporal.Duration | Temporal.Instant | Temporal.ZonedDateTime">
         How long to wait to receive the cancelling event. Either:
-        - A duration string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`, or
-        - An absolute `Date`.
+        - A duration string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`,
+        - A `number` of milliseconds,
+        - An absolute `Date`,
+        - A [`Temporal.Duration`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration) for a relative wait, or
+        - A [`Temporal.Instant`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant) or [`Temporal.ZonedDateTime`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime) for an absolute deadline.
       </Property>
     </Properties>
   </Property>

--- a/pages/docs/reference/typescript/v4/functions/step-invoke.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-invoke.mdx
@@ -60,9 +60,14 @@ const mainFunction = inngest.createFunction(
           <Property name="user" type="object">
             Optional user context for the invocation.
           </Property>
-          <Property name="timeout" type="string | number | Date">
+          <Property name="timeout" type="string | number | Date | Temporal.Duration | Temporal.Instant | Temporal.ZonedDateTime">
             {/* Purposefully not mentioning the default timeout of 1 year, as we expect to lower this very soon. */}
-            How long to wait for the invoked function to complete. Either a `number` of milliseconds, an `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`, or a `Date` representing an absolute deadline.
+            How long to wait for the invoked function to complete. Either:
+            - A duration string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`,
+            - A `number` of milliseconds,
+            - An absolute `Date`,
+            - A [`Temporal.Duration`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration) for a relative wait, or
+            - A [`Temporal.Instant`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant) or [`Temporal.ZonedDateTime`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime) for an absolute deadline.
 
             If the timeout is reached, the step will throw an error. See [Error handling](#error-handling) below. Note that the invoked function will continue to run even if this step times out.
           </Property>

--- a/pages/docs/reference/typescript/v4/functions/step-wait-for-event.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-wait-for-event.mdx
@@ -21,10 +21,13 @@ Use `step.waitForEvent()` to pause your function's execution until a matching ev
           <Property name="event" type="string | EventType" required>
             The name of a given event to wait for, or an [`eventType()`](/docs/reference/typescript/v4/functions/triggers#eventtype) result for typed return values.
           </Property>
-          <Property name="timeout" type="string | Date" required>
+          <Property name="timeout" type="string | number | Date | Temporal.Duration | Temporal.Instant | Temporal.ZonedDateTime" required>
             How long to wait to receive the event. Either:
-            - A duration string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`, or
-            - An absolute `Date`.
+            - A duration string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`,
+            - A `number` of milliseconds,
+            - An absolute `Date`,
+            - A [`Temporal.Duration`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration) for a relative wait, or
+            - A [`Temporal.Instant`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant) or [`Temporal.ZonedDateTime`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime) for an absolute deadline.
           </Property>
           <Property name="match" type="string">
             The property to match the event trigger and the wait event, using dot-notation, e.g. `data.userId`. Cannot be combined with `if`.

--- a/pages/docs/reference/typescript/v4/functions/step-wait-for-signal.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-wait-for-signal.mdx
@@ -23,10 +23,13 @@ and any data you want to inject into the function run.
           <Property name="signal" type="string" required>
             A unique identifier for the signal, used to resume this function run.
           </Property>
-          <Property name="timeout" type="string | Date" required>
+          <Property name="timeout" type="string | number | Date | Temporal.Duration | Temporal.Instant | Temporal.ZonedDateTime" required>
             How long to wait to receive the signal. Either:
-            - A duration string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`, or
-            - An absolute `Date`.
+            - A duration string compatible with the [ms](https://npm.im/ms) package, e.g. `"30m"`, `"3 hours"`, or `"2.5d"`,
+            - A `number` of milliseconds,
+            - An absolute `Date`,
+            - A [`Temporal.Duration`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration) for a relative wait, or
+            - A [`Temporal.Instant`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant) or [`Temporal.ZonedDateTime`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime) for an absolute deadline.
 
             If the signal is not received before this timeout, the run will resume with an undefined return value.
           </Property>


### PR DESCRIPTION
- In https://github.com/inngest/inngest-js/pull/1504, we added support for new Temporal.* types
- Let's update the docs for them!
- We skip updating the V3 docs, as this change is V4 only