### PR TITLE
Fix report graph download 404 in production

### DIFF
--- a/app/api/report-graph-download/[id]/route.ts
+++ b/app/api/report-graph-download/[id]/route.ts
@@ -1,7 +1,7 @@
-import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { getReportGraph } from "app/content/ai-in-production-report-2026/graphs";
+import { getFullURL } from "src/utils/social";
 
 export async function GET(
   _request: Request,
@@ -13,16 +13,13 @@ export async function GET(
     return new Response("Not found", { status: 404 });
   }
 
-  const filePath = path.join(process.cwd(), "public", graph.image);
-  let file: Buffer;
-  try {
-    file = fs.readFileSync(filePath);
-  } catch {
+  const upstream = await fetch(getFullURL(graph.image));
+  if (!upstream.ok) {
     return new Response("Not found", { status: 404 });
   }
 
   const filename = path.basename(graph.image);
-  return new Response(file, {
+  return new Response(upstream.body, {
     headers: {
       "Content-Type": "image/png",
       "Content-Disposition": `attachment; filename="${filename}"`,


### PR DESCRIPTION
The route read PNGs via fs.readFileSync from process.cwd() + 'public/'. On Vercel, public/ files are served by the static layer and are NOT bundled with serverless functions, so the read failed and the route returned 404 in production (worked locally because dev mode preserves the public dir).

Fetch the public URL via getFullURL and re-stream the body with Content-Disposition: attachment instead of reading from the filesystem.

https://claude.ai/code/session_01QnN3WdqNo3CxEPAsKAHrv3