### PR TITLE
DEV-319: Remove shipped items from self-hosting roadmap

### DIFF
--- a/pages/docs/self-hosting.mdx
+++ b/pages/docs/self-hosting.mdx
@@ -31,7 +31,7 @@ The system is composed of the following services:
 * **Event API** - Receives events from SDKs via HTTP requests. Authenticates client requests via [Event Keys](/docs/events/creating-an-event-key?ref=docs-self-hosting). The Event API publishes event payloads to an internal event stream.
 * **Event stream** - Acts as a buffer between the _Event API_ and the _Runner_.
 * **Runner** - Consumes incoming events and performs several actions:
-  * Scheduling of new “function runs” (aka jobs) given the event type, creating initial run state in the _State store_ database. Runs are added to queues given the function's flow control configuration.
+  * Scheduling of new "function runs" (aka jobs) given the event type, creating initial run state in the _State store_ database. Runs are added to queues given the function's flow control configuration.
   * Resumes functions paused via [`waitForEvent`](/docs/features/inngest-functions/steps-workflows/wait-for-event?ref=docs-self-hosting) with matching expressions.
   * Cancels running functions with matching [`cancelOn`](/docs/features/inngest-functions/cancellation/cancel-on-events?ref=docs-self-hosting) expressions.
   * Writes ingested events to a database for historical record and future replay.
@@ -312,9 +312,7 @@ You can find the chart, documentation, and configuration examples here:
 Planned features for self-hosting include:
 
 * Improved health checks.
-* Backlog monitoring endpoints for auto-scaling.
 * High availability guide.
-* Helm chart for easy deployment to Kubernetes.
 * Data retention guides and recommendations.
 * Event key and signing key management via API and UI.
 


### PR DESCRIPTION
## Summary

The self-hosting page Roadmap section listed features as "planned" that are already fully documented on the same page. This undermines trust with evaluators (8.42% sub rate, 3.5 avg views/user per Pat's audit).

Removed from roadmap:
- "Helm chart for easy deployment to Kubernetes" — has its own full section on the page
- "Backlog monitoring endpoints for auto-scaling" — KEDA-based autoscaling is documented in the Helm chart section

Remaining roadmap items are genuinely still planned.

## Reviewer note

The CLI help output on this page shows `inngest start - [Beta]`. Is `inngest start` still considered beta, or has it graduated? If it's no longer beta, we should update the help output shown on the page in a follow-up.

Closes DEV-319