### PR TITLE
AI in Production 2026: landing page CRO updates

### DIFF
--- a/app/content/ai-in-production-report-2026/FindingCTA.tsx
+++ b/app/content/ai-in-production-report-2026/FindingCTA.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+export function FindingCTA() {
+  return (
+    <div className="mt-4">
+      <button
+        onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+        className="group inline-flex items-center gap-1.5 rounded-md bg-[#a8ef3c] px-5 py-2.5 text-sm font-semibold text-[#0c1f10] transition-all hover:bg-[#baf54d]"
+      >
+        Download full report
+        <span aria-hidden="true" className="transition-transform group-hover:translate-x-0.5">
+          →
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/app/content/ai-in-production-report-2026/ScrollIndicator.tsx
+++ b/app/content/ai-in-production-report-2026/ScrollIndicator.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function ScrollIndicator() {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY < 80);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <div
+      className="fixed bottom-8 left-1/2 z-50 -translate-x-1/2 pointer-events-none transition-opacity duration-500"
+      style={{ opacity: visible ? 1 : 0 }}
+    >
+      <div className="flex animate-bounce items-center justify-center rounded-full border border-white/20 bg-white/10 p-3 backdrop-blur-sm">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="white"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 5v14" />
+          <path d="M19 12l-7 7-7-7" />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/app/content/ai-in-production-report-2026/ScrollIndicator.tsx
+++ b/app/content/ai-in-production-report-2026/ScrollIndicator.tsx
@@ -15,14 +15,14 @@ export function ScrollIndicator() {
       className="fixed bottom-8 left-1/2 z-50 -translate-x-1/2 pointer-events-none transition-opacity duration-500"
       style={{ opacity: visible ? 1 : 0 }}
     >
-      <div className="flex animate-bounce items-center justify-center rounded-full border border-white/20 bg-white/10 p-3 backdrop-blur-sm">
+      <div className="flex animate-bounce items-center justify-center rounded-full border border-[#a8ef3c]/40 bg-black/40 p-3 backdrop-blur-sm">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="20"
           height="20"
           viewBox="0 0 24 24"
           fill="none"
-          stroke="white"
+          stroke="#a8ef3c"
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"

--- a/app/content/ai-in-production-report-2026/StickyDownloadCTA.tsx
+++ b/app/content/ai-in-production-report-2026/StickyDownloadCTA.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function StickyDownloadCTA() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 400);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <div
+      className="fixed bottom-0 left-0 right-0 z-50 transition-transform duration-300"
+      style={{ transform: visible ? "translateY(0)" : "translateY(100%)" }}
+    >
+      <div className="border-t border-white/10 bg-black/80 px-6 py-4 backdrop-blur-md">
+        <div className="mx-auto flex max-w-4xl items-center justify-between gap-4">
+          <p className="hidden text-sm font-bold text-subtle sm:block">
+            AI in Production: The 2026 Benchmark Report
+          </p>
+          <button
+            onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+            className="group ml-auto inline-flex items-center gap-2 rounded-md bg-[#a8ef3c] px-6 py-2.5 text-sm font-semibold text-[#0c1f10] transition-all hover:bg-[#baf54d]"
+          >
+            Download the full report
+            <span aria-hidden="true" className="transition-transform group-hover:translate-x-0.5">
+              →
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/content/ai-in-production-report-2026/page.tsx
+++ b/app/content/ai-in-production-report-2026/page.tsx
@@ -9,6 +9,9 @@ import { StatTiles } from "./StatTiles";
 import { HeroGreenPanel } from "./HeroGreenPanel";
 import { ParallaxCard } from "./ParallaxCard";
 import { ScrollToFormButton } from "./ScrollToFormButton";
+import { FindingCTA } from "./FindingCTA";
+import { ScrollIndicator } from "./ScrollIndicator";
+import { StickyDownloadCTA } from "./StickyDownloadCTA";
 
 const PAGE_TITLE = "AI in Production: The 2026 Benchmark Report";
 const PAGE_DESCRIPTION =
@@ -40,7 +43,7 @@ const KEY_FINDINGS = [
     body: "That's twice the rate of non-AI teams. And for most, the burden is growing. Our report identifies which orchestration approaches correlate with lower — and higher — reliability burden.",
   },
   {
-    eyebrow: "04 — Summary",
+    eyebrow: "04 — What separates confident teams",
     color: "#a8ef3c",
     title: "Three infrastructure layers separate confident AI teams from the rest.",
     body: "What separates the most confident AI teams isn't bigger budgets or bigger teams — it's tighter integration between three infrastructure layers: orchestration that persists state and handles failures, observability that lives inside the workflow, and evals connected to where things actually break. When those layers share context, confidence follows.",
@@ -50,6 +53,8 @@ const KEY_FINDINGS = [
 export default function Page() {
   return (
     <div className="bg-[#212121] text-basis">
+      <ScrollIndicator />
+      <StickyDownloadCTA />
       {/* Hero is pinned on desktop; content scrolls up over it. On mobile,
           the hero scrolls normally so logos + form remain accessible. */}
       <div className="lg:sticky lg:top-0 lg:z-0">
@@ -66,8 +71,8 @@ export default function Page() {
         }}
       >
         <KeyFindings />
-        <Methodology />
         <FinalCTA />
+        <Methodology />
       </div>
     </div>
   );
@@ -80,12 +85,15 @@ function FinalCTA() {
       style={{ backgroundColor: "rgba(0, 0, 0, 0.3)" }}
     >
       <div className="mx-auto max-w-4xl px-6 py-16 text-center md:py-24">
-        <h2 className="font-whyteInktrap text-3xl font-semibold text-basis md:text-4xl">
+        <p className="font-mono text-xs uppercase tracking-[0.2em] text-[rgb(var(--color-matcha-400))]">
+          Free PDF
+        </p>
+        <h2 className="mt-3 font-whyteInktrap text-3xl font-semibold text-basis md:text-4xl">
           Get the full report.
         </h2>
         <p className="mx-auto mt-4 max-w-xl text-base text-subtle md:text-lg">
           Charts, breakouts by team size, and the patterns that predict scaling
-          confidence — all in the PDF.
+          confidence — free PDF, instant access.
         </p>
         <div className="mt-8">
           <ScrollToFormButton />
@@ -111,6 +119,9 @@ function Hero() {
             className="flex flex-col justify-center scroll-mt-24 px-8 py-12 md:px-12 md:pr-16 xl:pr-24 [&_button.button]:!bg-[#a8ef3c] [&_button.button]:!text-[#0c1f10] [&_button.button:hover]:!bg-[#baf54d]"
             style={{ backgroundColor: "#000000" }}
           >
+            <h2 className="mb-5 text-center font-whyteInktrap text-2xl font-black leading-[1.05] text-basis">
+              Download your free copy today.
+            </h2>
             <ContentDownloadForm
               asset="ai-in-production-report-2026"
               redirectTo={CONTENT_ASSETS["ai-in-production-report-2026"].redirectTo}
@@ -128,15 +139,17 @@ function KeyFindings() {
     <section className="mx-auto max-w-4xl px-6 pb-8 pt-20 md:pb-12 md:pt-28">
       <div className="max-w-3xl">
         <p className="font-mono text-xs uppercase tracking-[0.2em] text-[rgb(var(--color-matcha-400))]">
-          Key findings
+          Key findings — preview
         </p>
         <h2 className="mt-3 font-whyteInktrap text-3xl font-semibold text-basis md:text-4xl">
           What 130 engineers told us about running AI in production.
         </h2>
         <p className="mt-4 text-base text-subtle md:text-lg">
-          We wanted to know what's causing failures, and which infrastructure
-          choices — across orchestration, observability, evals, and agent
-          frameworks — actually reduce the burden of reliability.
+          A preview of what's inside. We wanted to know what's causing failures,
+          and which infrastructure choices — across orchestration, observability,
+          evals, and agent frameworks — actually reduce the burden of reliability.
+          Download our full report to go deeper with team-size breakouts, complete
+          charts, and the statistical significance behind every finding.
         </p>
       </div>
       <ul className="mt-12 flex flex-col gap-6">
@@ -169,6 +182,12 @@ function KeyFindings() {
                 <InfrastructureChart />
               </div>
             )}
+            {finding.eyebrow.startsWith("04") && (
+              <p className="text-sm text-subtle md:text-base">
+                The full report breaks down these combinations by team size with complete chart data and statistical significance.
+              </p>
+            )}
+            <FindingCTA />
           </ParallaxCard>
         ))}
       </ul>

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -332,47 +332,21 @@ export default function ContactForm({
           />
         </label>
       )}
-      {isContentDownload && (
-        <>
-          <label className="flex w-full flex-col gap-2">
-            <span>
-              Company <span className="text-warning">*</span>
-            </span>
-            <input
-              type="text"
-              name="company"
-              required
-              onChange={(e) => setCompany(e.target.value)}
-              className="w-full rounded-md border border-muted bg-canvasBase p-3 outline-none"
-            />
-          </label>
-          <label className="flex w-full flex-col gap-2">
-            <span>
-              Job Title <span className="text-warning">*</span>
-            </span>
-            <input
-              type="text"
-              name="job_title"
-              required
-              onChange={(e) => setJobTitle(e.target.value)}
-              className="w-full rounded-md border border-muted bg-canvasBase p-3 outline-none"
-            />
-          </label>
-        </>
+      {!isContentDownload && (
+        <label className="flex w-full flex-col gap-2">
+          <span>
+            {surveyLabel || "How did you hear about us?"}{" "}
+            <span className="text-warning">*</span>
+          </span>
+          <input
+            type="text"
+            name="survey"
+            required
+            onChange={(e) => setSurvey(e.target.value)}
+            className="w-full rounded-md border border-muted bg-canvasBase p-3 outline-none"
+          />
+        </label>
       )}
-      <label className="flex w-full flex-col gap-2">
-        <span>
-          {surveyLabel || "How did you hear about us?"}{" "}
-          <span className="text-warning">*</span>
-        </span>
-        <input
-          type="text"
-          name="survey"
-          required
-          onChange={(e) => setSurvey(e.target.value)}
-          className="w-full rounded-md border border-muted bg-canvasBase p-3 outline-none"
-        />
-      </label>
       {!isContentDownload && (
         <label className="flex w-full flex-col gap-2">
           <span>{messageLabel || "What can we help you with?"}</span>


### PR DESCRIPTION
Conversion optimisations to the AI in Production 2026 report landing page.

## Form
- Reduced to 2 fields (name + email) for content download forms
- Company, Job Title, and "How did you hear about us?" fields hidden — state variables kept so enrichment can backfill them, no backend changes needed

## Key Findings section
- Eyebrow updated to "Key findings — preview"
- Intro paragraph opens with "A preview of what's inside" and adds a teaser sentence pointing to the full report
- Finding #04 eyebrow renamed to "What separates confident teams"
- Teaser sentence moved below the InfrastructureChart and above the download CTA
- Per-card "Download full report →" CTA added to every finding card (new FindingCTA.tsx client component)

## Hero form panel
- Added "Download your free copy today." header above the form

## FinalCTA section
- Added "Free PDF" mono eyebrow
- Updated value prop copy to "free PDF, instant access."
- Swapped section order: Key Findings → FinalCTA → Methodology

## New UI components
- `ScrollIndicator.tsx` — bouncing frosted-glass down arrow at viewport bottom, fades out after 80px scroll
- `StickyDownloadCTA.tsx` — dark blurred bar that slides up from the bottom after 400px scroll, with bold report title and matcha green download button