### PR TITLE
docs: remove `id` option from v4 serve reference

### DIFF
--- a/pages/docs/reference/typescript/v4/serve/index.mdx
+++ b/pages/docs/reference/typescript/v4/serve/index.mdx
@@ -43,9 +43,6 @@ serve({
   <Property name="streaming" type={`true | false`}>
     Enables streaming responses back to Inngest which can enable maximum serverless function timeouts. See [reference](/docs/streaming) for more information on the configuration.  See also [`INNGEST_STREAMING`](/docs/sdk/environment-variables#inngest-streaming).
   </Property>
-  <Property name="id" type="string">
-    The ID to use to represent this application instead of the client's ID. Useful for creating many Inngest endpoints in a single application.
-  </Property>
 </Properties>
 
 <Callout>


### PR DESCRIPTION
## Summary

- Remove the `id` property row from `/docs/reference/typescript/v4/serve` — it isn't a valid v4 option.
- App identity in v4 is sourced exclusively from `client.id`; `serve({ id })` was removed in the v4 release (it was deprecated in v3 with a runtime warning, then deleted alongside the other options that moved up to the client in [#1232](https://github.com/inngest/inngest-js/pull/1232)).
- Surfaced by customer ticket T-7483: users following the docs hit `TS2353: Object literal may only specify known properties, and 'id' does not exist in type 'ServeHandlerOptions'`.

The v3 reference page intentionally keeps the `id` row since it's accurate for the v3 line.