### PR TITLE
Agent Evals: Add scoring docs (how-to + deferred scoring + reference)

### DIFF
--- a/content/changelog/2026-06-05-deferred-functions.mdx
+++ b/content/changelog/2026-06-05-deferred-functions.mdx
@@ -1,0 +1,15 @@
+export const title = "Deferred Functions: fire-and-forget background work with typed payloads";
+export const date = "2026-06-05";
+
+Deferred Functions are a new way to launch independent background work from inside an Inngest function. Call `defer("some-id", { function, data })` and the parent run keeps executing — the deferred run is fully independent, with its own retries, concurrency, step state, and typed payload.
+
+Reach for them when work should happen *because of* a run, not *as part of* it: scoring an agent's output, sending a notification, logging a side effect, or queueing follow-up work.
+
+- **Fire-and-forget** — `defer(...)` is synchronous and returns `void`. The parent doesn't block and never sees a result.
+- **Typed payloads** — Define a [Standard Schema](https://standardschema.dev/?ref=inngest) on the deferred function and `data` is validated on both the caller and receiver side, then typed in the handler.
+- **Fully independent runs** — Each call triggers its own run with its own retries, concurrency, and step state. Multiple parents can target the same deferred function.
+- **Works inside steps** — Call `defer(...)` directly in a handler or from inside `step.run()`.
+
+Deferred Functions are available now in beta via `createDefer` from `inngest/experimental` in the TypeScript SDK. A great use case is the new [deferred LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=changelog-deferred-functions).
+
+See the [Deferred Functions reference](/docs/reference/typescript/v4/functions/deferred-functions?ref=changelog-deferred-functions) for the full API.

--- a/pages/docs/features/inngest-functions/steps-workflows/deferred-scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/deferred-scoring.mdx
@@ -86,7 +86,30 @@ export default inngest.createFunction(
 );
 ```
 
-The scorer runs independently. The original function returns immediately. The score arrives when the signal does.
+## How deferred scoring works
+
+The scorer is a completely separate function run. It is enqueued when the parent run finalizes, not when the signal arrives. The scorer starts running on its own, and if it includes a `step.waitForEvent()`, it pauses and waits for that signal independently.
+
+If the signal never arrives within the timeout, the scorer still completes and returns a default score. The parent function is never affected by the scorer's lifecycle.
+
+---
+
+## Sending the signal
+
+The scorer above waits for a `support/feedback.received` event. Your app sends this event when the user takes action. For example, when a user clicks "helpful" in your UI:
+
+```ts
+// In your API route or event handler
+await inngest.send({
+  name: "support/feedback.received",
+  data: {
+    ticketId: "tk_123",
+    helpful: true,
+  },
+});
+```
+
+Inngest matches this event to any waiting scorer by the `ticketId` field. The scorer resumes, reads `feedback.data.helpful`, and returns the score.
 
 ---
 

--- a/pages/docs/features/inngest-functions/steps-workflows/deferred-scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/deferred-scoring.mdx
@@ -1,0 +1,104 @@
+import { Callout, CodeGroup } from "src/shared/Docs/mdx";
+
+export const description = "Build reusable scorers that run in the background and score based on events that arrive after a function completes."
+
+# Build a deferred scorer
+
+Sometimes you don't know how well a function performed until later. A user clicks "helpful." A support ticket gets reopened. A conversion happens hours after the initial run.
+
+Deferred scorers handle this. They run as separate functions in the background, with access to step tooling like `step.waitForEvent()`. You define what signals matter, and the scorer collects them over time.
+
+<Callout variant="info">
+  Deferred scoring uses `createScorer` from `inngest/experimental`. The API may change before GA.
+</Callout>
+
+---
+
+## Create a scorer
+
+A scorer is a function that receives input data and returns a score. Define it with `createScorer`.
+
+```ts
+import { createScorer } from "inngest/experimental";
+import { z } from "zod";
+
+export const feedbackScorer = createScorer(
+  inngest,
+  {
+    id: "feedback-scorer",
+    schema: z.object({ ticketId: z.string(), runId: z.string() }),
+  },
+  async ({ event, step }) => {
+    // Wait up to 7 days for the user to give feedback
+    const feedback = await step.waitForEvent("wait-for-feedback", {
+      event: "support/feedback.received",
+      timeout: "7d",
+      if: `async.data.ticketId == '${event.data.input.ticketId}'`,
+    });
+
+    if (!feedback) {
+      // No feedback received within the window
+      return { name: "user-feedback", value: 0.5 };
+    }
+
+    return {
+      name: "user-feedback",
+      value: feedback.data.helpful ? 1 : 0,
+    };
+  }
+);
+```
+
+Register the scorer alongside your other functions in the serve handler.
+
+```ts
+serve({
+  client: inngest,
+  functions: [...myFunctions, feedbackScorer],
+});
+```
+
+---
+
+## Trigger a scorer from a function
+
+Inside any Inngest function, use `defer()` to trigger a scorer with the data it needs.
+
+```ts
+export default inngest.createFunction(
+  { id: "handle-support-ticket", triggers: { event: "support/ticket.created" } },
+  async ({ event, step, defer }) => {
+    const response = await step.run("generate-response", async () => {
+      return await generateAIResponse(event.data.content);
+    });
+
+    // Kick off the deferred scorer in the background
+    defer("score-feedback", {
+      function: feedbackScorer,
+      data: {
+        ticketId: event.data.ticketId,
+        runId: event.data.runId,
+      },
+    });
+
+    return { response };
+  }
+);
+```
+
+The scorer runs independently. The original function returns immediately. The score arrives when the signal does.
+
+---
+
+## When to use deferred vs direct scoring
+
+**Direct scoring** (inline `step.score()`) is for outcomes you know before the function finishes. A guardrail passed. JSON parsed correctly. A tool call returned the expected format.
+
+**Deferred scoring** is for outcomes that depend on what happens next. User feedback. Ticket resolution. Conversion events. Anything that requires waiting for a signal from outside the run.
+
+---
+
+## Next steps
+
+- [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring) for inline scoring
+- [Run experiments](/docs/features/inngest-functions/steps-workflows/running-experiments) to compare variants using scores

--- a/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
@@ -1,0 +1,102 @@
+import { Callout, CodeGroup } from "src/shared/Docs/mdx";
+
+export const description = "Score Inngest function runs and steps to measure how well your AI workflows perform in production."
+
+# Score a function run
+
+Scoring lets you measure how well a function run performed. You attach a named score to a run or a specific step, and Inngest tracks it over time in traces and dashboards.
+
+This is useful for anything where "did it work?" isn't a binary answer: AI accuracy, response relevance, user satisfaction, task completion rates.
+
+<Callout variant="info">
+  Scoring requires the v4 SDK. Install with `npm install inngest@latest`.
+</Callout>
+
+---
+
+## Score the current run
+
+Inside a function, call `inngest.score()` or `step.score()` with a name and a numeric value.
+
+```ts
+export default inngest.createFunction(
+  { id: "summarize-ticket", triggers: { event: "support/ticket.created" } },
+  async ({ event, step }) => {
+    const summary = await step.run("generate-summary", async () => {
+      return await generateSummary(event.data.content);
+    });
+
+    const passed = await step.run("check-guardrails", async () => {
+      return validateOutput(summary);
+    });
+
+    // Score this run based on whether guardrails passed
+    await step.score({ name: "guardrail-pass", value: passed ? 1 : 0 });
+
+    return { summary, passed };
+  }
+);
+```
+
+`step.score()` attaches the score to the current run. Use it when you know the outcome before the function finishes.
+
+---
+
+## Score a specific step
+
+Score within a step to attach the measurement directly to that step's trace.
+
+```ts
+await step.run("call-model", async () => {
+  const result = await callModel(prompt);
+  const confidence = result.metadata.confidence;
+
+  // Score this specific step
+  await inngest.score({ name: "model-confidence", value: confidence });
+
+  return result;
+});
+```
+
+The score appears on the step in the trace view, not just the run.
+
+---
+
+## Score from outside a function
+
+You can score any run from external code. Pass the `runId` and optionally a `stepId`.
+
+```ts
+await inngest.score({
+  name: "user-feedback",
+  value: 1,
+  runId: "01ABC123...",
+});
+
+// Score a specific step in that run
+await inngest.score({
+  name: "accuracy",
+  value: 0.9,
+  runId: "01ABC123...",
+  stepId: "generate-summary",
+});
+```
+
+This is how you score based on signals that arrive after the function finishes: a user clicks "helpful," a support ticket gets resolved, a conversion happens downstream.
+
+---
+
+## Where scores appear
+
+Scores show up in two places:
+
+**Trace views.** Each score is attached to the run or step it was scored against. You can see what a run scored alongside its execution timeline.
+
+**Function dashboards.** Score aggregates over time show trends. A degrading score after a prompt change tells you something broke. A stable score after a model swap tells you the change is safe.
+
+---
+
+## Next steps
+
+- [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring) for outcomes that take time to resolve
+- [Run experiments](/docs/features/inngest-functions/steps-workflows/running-experiments) to compare models or prompts with traffic splits

--- a/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
+++ b/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
@@ -1,0 +1,155 @@
+import { Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
+
+export const description = "Fire-and-forget independent work with typed data using deferred functions."
+
+# Deferred Functions
+
+A deferred function is an Inngest function that runs in the background as a side effect of another run. Instead of the usual triggers, a parent run launches it by calling `defer("some-id", { function, data })`. The parent doesn't wait, doesn't see a result, and keeps executing. The deferred run is fully independent: its own retries, concurrency, step state, and typed payload.
+
+<Callout variant="info">
+  Deferred functions are experimental. `createDefer` is imported from `inngest/experimental` and the API may change before GA.
+</Callout>
+
+Use deferred functions for work that should happen *because of* a run, not *as part of* it: scoring an agent's output, sending a notification, logging a side effect, queueing follow-up work. Any function can call the same deferred function, and each call is its own run.
+
+## When to use
+
+| Tool                            | Returns to caller?  | Independent execution?    |
+| ------------------------------- | ------------------- | ------------------------- |
+| `step.invoke(fn, { data })`     | Yes (awaits result) | No (caller blocks)        |
+| `step.sendEvent(...)`           | No                  | Yes (any matching fn)     |
+| `defer(id, { function, data })` | No                  | Yes (single typed target) |
+
+A common use case is an [LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring) that runs against the output of an agent run.
+
+---
+
+## Defining a deferred function
+
+Use `createDefer` to define a deferred function:
+
+```ts
+import { createDefer } from "inngest/experimental";
+import { z } from "zod";
+
+export const sendEmail = createDefer(
+  inngest,
+  {
+    id: "send-email",
+    schema: z.object({ to: z.string(), body: z.string() }),
+    concurrency: { limit: 5 },
+  },
+  async ({ event, step }) => {
+    event.data.to; // typed from `schema`
+    event.data.body;
+  }
+);
+```
+
+A deferred function is a regular Inngest function with its own retries, concurrency, and step state. Register it alongside your other functions in the serve handler:
+
+```ts
+serve({ client: inngest, functions: [...myFunctions, sendEmail] });
+```
+
+### `createDefer(client, config, handler): DeferredFunction`
+
+`createDefer` mirrors [`inngest.createFunction`](/docs/reference/typescript/v4/functions/create) with a few differences:
+
+- The client is the first positional argument.
+- `triggers` is not accepted — the function is triggered implicitly by `defer(...)`.
+- `schema` describes the payload that callers send.
+- `onFailure` and `batchEvents` are not currently supported.
+
+<Properties>
+  <Property name="client" type="Inngest" required>
+    Your Inngest client instance.
+  </Property>
+  <Property name="config" type="object" required>
+    Function configuration. Accepts the same options as `inngest.createFunction` (`concurrency`, `throttle`, `rateLimit`, etc.) except `triggers`, `onFailure`, and `batchEvents`, and adds `schema`.
+    <Properties nested>
+      <Property name="id" type="string" required>
+        A unique identifier for the function.
+      </Property>
+      <Property name="schema" type="StandardSchemaV1">
+        A [Standard Schema](https://standardschema.dev/) describing the payload that callers send via `defer(...)`. Optional. When present, `data` is validated on both the caller and receiver side and types `event.data` in the handler. Without a schema, `data` falls back to `Record<string, any>`.
+      </Property>
+    </Properties>
+  </Property>
+  <Property name="handler" type="function" required>
+    The async handler. Receives the same arguments as a normal Inngest function handler.
+  </Property>
+</Properties>
+
+---
+
+## Calling `defer`
+
+`defer` is always available on the handler context of any Inngest function:
+
+```ts
+const orderPlaced = inngest.createFunction(
+  { id: "order-placed", triggers: { event: "order/placed" } },
+  async ({ defer }) => {
+    defer("send", {
+      function: sendEmail,
+      data: { to: "a@b.com", body: "hi" },
+    });
+  }
+);
+```
+
+`defer(...)` is **synchronous and fire-and-forget**. It returns `void` and the parent run continues immediately. The deferred run starts when the parent run finalizes.
+
+It also works inside `step.run()`:
+
+```ts
+await step.run("notify", async () => {
+  defer("send", { function: sendEmail, data: { to, body } });
+});
+```
+
+### `defer(id, options): void`
+
+<Properties>
+  <Property name="id" type="string" required>
+    A unique identifier for this call. Must be unique within the parent run — unlike step IDs, no implicit index is appended to dedupe. (This is because `defer` can be used inside `step.run()`, where an implicit index would change on re-entry.)
+  </Property>
+  <Property name="options" type="object" required>
+    <Properties nested>
+      <Property name="function" type="DeferredFunction" required>
+        The deferred function to trigger.
+      </Property>
+      <Property name="data" type="object" required>
+        Payload to send to the deferred function. Typed from `function.schema` when present.
+      </Property>
+    </Properties>
+  </Property>
+</Properties>
+
+---
+
+## Schemas
+
+When `schema` is provided on the deferred function:
+
+- `data` is validated at the call site (synchronously).
+- `data` is validated again on the receiver side. This catches serialization round-trips that change the shape (e.g. a `Date` becoming an ISO string).
+- The same schema types `event.data` in the handler.
+
+Call-site validation must be synchronous because `defer(...)` itself is sync. If the schema's `validate` returns a Promise, the SDK logs an error and the call is skipped. Receiver-side validation is async, so async validators work there.
+
+---
+
+## Error handling
+
+`defer(...)` is fire-and-forget, so a bad call should not derail the surrounding handler.
+
+- **Call-site errors** (for example, a synchronous schema failure) are logged via the internal logger and the call is silently skipped. The parent run continues normally and the deferred function does not fire.
+- **Receiver-side errors** (the deferred run reading invalid `event.data`, or the handler throwing) fail the deferred run itself with normal retry semantics.
+
+---
+
+## Sharing across parent functions
+
+A deferred function is one Inngest function in the backend. Multiple parents can hold a reference to it; each `defer(...)` call triggers an independent run with its own retries and concurrency state.

--- a/pages/docs/reference/typescript/v4/functions/scoring.mdx
+++ b/pages/docs/reference/typescript/v4/functions/scoring.mdx
@@ -1,0 +1,145 @@
+import { Callout, Properties, Property, Row, Col } from "src/shared/Docs/mdx";
+
+export const description = "API reference for scoring function runs and steps in Inngest."
+
+# Scoring
+
+Score function runs and steps to track how well your workflows perform over time.
+
+<Callout variant="info">
+  Scoring is in beta. Install the latest SDK with `npm install inngest@latest`.
+</Callout>
+
+---
+
+## `inngest.score(options)`
+
+Score a run or step. Can be called inside or outside a function.
+
+<Properties>
+  <Property name="name" type="string" required>
+    A label for the score. Use consistent names across runs for aggregation. Examples: `"accuracy"`, `"user-feedback"`, `"guardrail-pass"`.
+  </Property>
+  <Property name="value" type="number" required>
+    The score value. Numeric. Use 0-1 for percentages, integers for counts, or any range that fits your use case.
+  </Property>
+  <Property name="runId" type="string">
+    The run to score. Required when scoring from outside a function. Omit when scoring the current run from inside a function.
+  </Property>
+  <Property name="stepId" type="string">
+    The step to score. Optional. When provided, the score attaches to that specific step in the trace view.
+  </Property>
+</Properties>
+
+```ts
+// Score the current run (inside a function)
+await inngest.score({ name: "accuracy", value: 0.9 });
+
+// Score a specific run (from anywhere)
+await inngest.score({ name: "accuracy", value: 0.9, runId: "01ABC..." });
+
+// Score a specific step
+await inngest.score({
+  name: "accuracy",
+  value: 0.9,
+  runId: "01ABC...",
+  stepId: "generate-summary",
+});
+```
+
+---
+
+## `step.score(options)`
+
+Score the current run from within a step context. Same options as `inngest.score()` but `runId` is automatically set to the current run.
+
+<Properties>
+  <Property name="name" type="string" required>
+    Score label.
+  </Property>
+  <Property name="value" type="number" required>
+    Score value.
+  </Property>
+</Properties>
+
+```ts
+await step.score({ name: "guardrail-pass", value: 1 });
+```
+
+---
+
+## `createScorer(client, config, handler)`
+
+Create a reusable deferred scorer. Returns an Inngest function that can be triggered via `defer()`.
+
+Imported from `inngest/experimental`.
+
+<Properties>
+  <Property name="client" type="Inngest" required>
+    Your Inngest client instance.
+  </Property>
+  <Property name="config" type="object" required>
+    <Properties nested>
+      <Property name="id" type="string" required>
+        Unique identifier for the scorer function.
+      </Property>
+      <Property name="schema" type="ZodSchema" required>
+        Zod schema defining the input data the scorer expects.
+      </Property>
+    </Properties>
+  </Property>
+  <Property name="handler" type="function" required>
+    Async function that receives `event` and `step`, and returns `{ name: string, value: number }`.
+  </Property>
+</Properties>
+
+```ts
+import { createScorer } from "inngest/experimental";
+import { z } from "zod";
+
+export const verbosityScorer = createScorer(
+  inngest,
+  { id: "verbosity-scorer", schema: z.object({ text: z.string() }) },
+  async ({ event }) => {
+    const wordCount = event.data.input.text.split(" ").length;
+    return { name: "verbosity", value: wordCount };
+  }
+);
+```
+
+---
+
+## `defer(id, options)`
+
+Trigger a deferred scorer from inside a function. Available as a handler argument.
+
+<Properties>
+  <Property name="id" type="string" required>
+    A deterministic identifier for this deferred call.
+  </Property>
+  <Property name="options" type="object" required>
+    <Properties nested>
+      <Property name="function" type="InngestFunction" required>
+        The scorer function to trigger.
+      </Property>
+      <Property name="data" type="object" required>
+        Input data matching the scorer's schema.
+      </Property>
+    </Properties>
+  </Property>
+</Properties>
+
+```ts
+defer("score-feedback", {
+  function: feedbackScorer,
+  data: { ticketId: "tk_123", runId: "run_456" },
+});
+```
+
+---
+
+## Further reading
+
+- [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring)
+- [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring)
+- [Run experiments](/docs/features/inngest-functions/steps-workflows/running-experiments)

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -314,6 +314,11 @@ const sectionReference: (NavGroup | NavLink)[] = [
         tag: "new",
       },
       {
+        title: "Deferred Functions",
+        href: tsRef("v4", "functions/deferred-functions"),
+        tag: "beta",
+      },
+      {
         title: "Steps",
         links: [
           {


### PR DESCRIPTION
## Summary

Adds documentation for the scoring APIs that are part of the Agent Evals product (Tier 1 launch, target June 30 GA).

Three new pages:

- **Scoring how-to** (`/docs/features/.../scoring.mdx`): Direct scoring of runs and steps. Covers inline scoring, step-level scoring, scoring from outside a function, and where scores appear in traces and dashboards.

- **Deferred scoring how-to** (`/docs/features/.../deferred-scoring.mdx`): Building reusable scorers with `createScorer` from `inngest/experimental`. Covers `defer()`, `step.waitForEvent()` for async signals like user feedback, and when to use deferred vs direct scoring.

- **Scoring reference** (`/docs/reference/typescript/v4/functions/scoring.mdx`): API reference for `inngest.score()`, `step.score()`, `createScorer()`, and `defer()`. Parameters, types, code examples.

## Reviewer notes

- API examples are based on the Internal Alpha Docs in Notion. Tony/Jack should verify the APIs match the current SDK branch (`inngest@pr-1521`).
- These pages are not yet linked from the nav (`navigationStructure.ts`). We can add nav entries when the feature moves to public beta.
- The existing `group.experiment()` reference and "Running experiments" how-to are already live and cross-linked from these new pages.

## Context

Lauren requested an update on AI product docs for the closed beta. Experimentation docs were already shipped (DEV-299). These scoring docs fill the remaining gap.