### PR TITLE
Add AI in Production 2026 report CTA branch & add to 13 blog posts

### DIFF
--- a/content/blog/after-the-agent-signs-in.mdx
+++ b/content/blog/after-the-agent-signs-in.mdx
@@ -7,6 +7,7 @@ image: /assets/blog/after-the-agent-signs-in/featured-image/featured-image.png
 date: 2026-04-21
 category: engineering
 author: Sterling Chin
+primaryCTA: "report2026"
 ---
 
 *Companion to: [Inngest + Stripe Projects: Ship Durable Apps Without Leaving the Terminal](https://www.inngest.com/blog/inngest-stripe-projects-ship-durable-apps-without-leaving-the-terminal)*

--- a/content/blog/ai-agents-inngest-durable-steps.mdx
+++ b/content/blog/ai-agents-inngest-durable-steps.mdx
@@ -6,6 +6,7 @@ date: 2026-03-17
 category: engineering
 author: Dan Farrelly
 showSubtitle: true
+primaryCTA: "report2026"
 ---
 
 Most AI agent tutorials stop at the happy path — call the LLM, run a tool, loop. But the moment you ship an agent to production, you hit the real problems: tool calls fail, LLM providers rate-limit you, long-running tasks time out, and you can't see what the hell happened when something goes wrong.

--- a/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
+++ b/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
@@ -4,6 +4,7 @@ subtitle: Every six months, the "right" way to build an AI agent changes. How ca
 image: /assets/blog/background-agents-are-here/featured-image-gold.png
 date: 2026-05-08
 author: Dan Farrelly
+primaryCTA: "report2026"
 ---
 
 Every six months, the "right" way to build an AI agent changes.

--- a/content/blog/build-self-learning-agent.mdx
+++ b/content/blog/build-self-learning-agent.mdx
@@ -6,6 +6,7 @@ image: /assets/blog/i-built-a-self-improving-agent-it-taught-itself-to-cheat/fea
 date: 2026-04-16
 category: engineering
 author: "Mitchell Alderson (guest post)"
+primaryCTA: "report2026"
 ---
 
 I built an AI agent that improves its own prompts. Within hours of running the evaluation pipeline, the LLM discovered it could game the scoring system.

--- a/content/blog/building-durable-agents.mdx
+++ b/content/blog/building-durable-agents.mdx
@@ -5,6 +5,7 @@ showSubtitle: false
 subtitle: "How to stop your AI agents from breaking in production — and start making them debuggable, deterministic, and durable."
 date: 2025-10-30
 author: Keoni Murray
+primaryCTA: "report2026"
 ---
 **Your AI agent works perfectly in testing. Then you ship it.**
 

--- a/content/blog/context-engineering-in-practice.mdx
+++ b/content/blog/context-engineering-in-practice.mdx
@@ -6,6 +6,7 @@ subtitle: "A lot has been written about Context Engineering theory and its princ
 date: 2025-11-07
 author: Charly Poly
 disableCTA: false
+primaryCTA: "report2026"
 ---
 
 A lot has been written about Context Engineering theory and its principles, with few examples. At Inngest, we are fortunate to experience context engineering in practice through our exchanges with our [community](http://inngest.com/discord) and [customers](http://inngest.com/customers), which include leading AI products such as [Outtake](/customers/outtake), [Replit](/blog/inngest-replit-vibe-code-ai-agents), and 11x.

--- a/content/blog/durable-execution-key-to-harnessing-ai-agents.mdx
+++ b/content/blog/durable-execution-key-to-harnessing-ai-agents.mdx
@@ -5,6 +5,7 @@ image: /assets/blog/durable-execution-key-to-harnessing-ai-agents/featured-image
 date: 2026-02-19
 author: Charly Poly
 category: engineering
+primaryCTA: "report2026"
 ---
 
 ### Key Takeaways

--- a/content/blog/hanging-promises-for-control-flow.mdx
+++ b/content/blog/hanging-promises-for-control-flow.mdx
@@ -5,6 +5,7 @@ image: /assets/blog/hanging-promises-for-control-flow/featured-image.jpg
 date: 2026-04-07
 author: Aaron Harper
 category: engineering
+primaryCTA: "report2026"
 ---
 
 You can't cancel a JavaScript promise. There's no `.cancel()` method, no `AbortController` integration, no built-in way to say "never mind, stop." The TC39 committee [considered adding cancellation](https://github.com/tc39/proposal-cancelable-promises) in 2016, but the proposal was withdrawn after heated debate. Part of the problem is that cancelling arbitrary code mid-execution can leave resources in a dirty state (open handles, half-written data), so true cancellation requires cooperative cleanup, which undermines the simplicity people want from a `.cancel()` method.

--- a/content/blog/how-to-build-a-production-ai-image-generation-pipeline-with-fal-ai-and-inngest.mdx
+++ b/content/blog/how-to-build-a-production-ai-image-generation-pipeline-with-fal-ai-and-inngest.mdx
@@ -5,6 +5,7 @@ image: /assets/blog/how-to-build-a-production-ai-image-generation-pipeline-with-
 date: 2026-03-24
 author: Lauren Craigie
 category: engineering
+primaryCTA: "report2026"
 ---
 
 Building a production AI image app involves two distinct problems.

--- a/content/blog/principles-of-durable-execution.mdx
+++ b/content/blog/principles-of-durable-execution.mdx
@@ -5,7 +5,7 @@ image: /assets/blog/principles-of-durable-execution/featured-image.png
 date: 2024-12-10
 dateUpdated: 2026-01-07
 author: Dan Farrelly
-primaryCTA: sales
+primaryCTA: "report2026"
 floatingCTA: true
 category: engineering
 teaser:

--- a/content/blog/three-patterns-you-need-for-agentic-systems.md
+++ b/content/blog/three-patterns-you-need-for-agentic-systems.md
@@ -4,6 +4,7 @@ subtitle: "Every agentic system that actually ships ends up needing three delega
 image: /assets/blog/three-patterns-you-need-for-agentic-systems/blog-banner.png
 date: 2026-03-11
 author: Dan Farrelly
+primaryCTA: "report2026"
 ---
 
 **Every agentic system that actually ships ends up needing three delegation patterns: one that blocks, one that fires and forgets, and one that runs later. The question isn't whether you need sub-agents — it's how you wire them up.**

--- a/content/blog/vercel-long-running-background-functions.mdx
+++ b/content/blog/vercel-long-running-background-functions.mdx
@@ -6,6 +6,7 @@ date: 2023-03-31
 dateUpdated: 2024-06-06
 author: Dan Farrelly
 disableCTA: true
+primaryCTA: "report2026"
 ---
 
 Serverless functions can be a game changer for devs building applications who want to get into production fast and elastically scale with usage. Today, developers primarily use serverless functions on platforms like Vercel to build synchronous APIs, but what do you do if you need to run critical business logic on top of serverless functions?

--- a/content/blog/your-agent-needs-a-harness-not-a-framework.mdx
+++ b/content/blog/your-agent-needs-a-harness-not-a-framework.mdx
@@ -5,6 +5,7 @@ image: /assets/blog/your-agent-needs-a-harness-not-a-framework/featured-image.pn
 date: 2026-03-03
 author: Dan Farrelly
 category: engineering
+primaryCTA: "report2026"
 ---
 
 In every engineering discipline, a harness is the same thing: the layer that connects, protects, and orchestrates components — without doing the work itself. A wiring harness routes signals between an engine, sensors, and dashboard. A test harness provides the scaffolding that makes code repeatable and observable. A safety harness catches you when you fall.

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -297,9 +297,45 @@ function CTAs({
   primary = "docs",
   ctaRef = "",
 }: {
-  primary: "docs" | "sales" | "signUp";
+  primary: "docs" | "sales" | "signUp" | "report2026";
   ctaRef: string;
 }) {
+  if (primary === "report2026") {
+    return (
+      <aside className="m-auto max-w-[70ch] border-t-[2px] border-stone-700 pt-8">
+        <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:gap-8">
+          <div className="flex flex-col items-start">
+            <h2 className="mt-0 text-xl font-medium text-basis">
+              AI in Production: The 2026 Benchmark Report
+            </h2>
+            <p className="mb-6 mt-2 text-sm text-subtle">
+              We surveyed 130 backend, full-stack, and AI engineers to find out
+              how teams are actually running AI in production, and what's
+              holding them back.
+            </p>
+            <Button
+              variant="primary"
+              size="sm"
+              href={`https://www.inngest.com/content/ai-in-production-report-2026?ref=${ctaRef}`}
+              arrow="right"
+            >
+              View Key Findings
+            </Button>
+          </div>
+          <div className="flex-shrink-0">
+            <Image
+              src="/assets/blog/ai-in-production-report-2026-card/featured-image/featured-image.png"
+              alt="AI in Production: The 2026 Benchmark Report"
+              width={220}
+              height={165}
+              className="rounded-lg"
+            />
+          </div>
+        </div>
+      </aside>
+    );
+  }
+
   const ctas = {
     sales: {
       title: "Chat with a solutions expert",


### PR DESCRIPTION
**Add AI in Production 2026 Report CTA to blog posts**
Replaces the "Get Started with Inngest" and "Chat with a solutions expert" CTAs at the bottom of 13 AI/agent-focused blog posts with a single CTA block promoting the AI in Production: The 2026 Benchmark Report.

**What changed**
pages/blog/[slug].tsx — Added a new report2026 CTA variant. When a post has primaryCTA: "report2026" in its frontmatter, the standard two-column CTA is replaced with a horizontal card featuring the report thumbnail (right), title, descriptor copy, and a "View Key Findings" button linking to /content/ai-in-production-report-2026.

The following 13 posts had primaryCTA: "report2026" added to their frontmatter:
/blog/build-self-learning-agent
/blog/hanging-promises-for-control-flow
/blog/your-agent-needs-a-harness-not-a-framework
/blog/ai-agents-inngest-durable-steps
/blog/after-the-agent-signs-in
/blog/context-engineering-in-practice
/blog/how-to-build-a-production-ai-image-generation-pipeline-with-fal-ai-and-inngest
/blog/durable-execution-key-to-harnessing-ai-agents
/blog/background-agents-are-here-your-orchestration-isnt-ready
/blog/three-patterns-you-need-for-agentic-systems
/blog/principles-of-durable-execution
/blog/vercel-long-running-background-functions
/blog/building-durable-agents