### PR TITLE
AEO: agent-friendly infrastructure for website, blog, and structured data

### DIFF
--- a/app/(landing-pages)/compare-to-temporal/page.tsx
+++ b/app/(landing-pages)/compare-to-temporal/page.tsx
@@ -22,11 +22,29 @@ export const metadata: Metadata = generateMetadata({
     "Discover a serverless, event-driven platform that developers love. Build faster, debug easier, and scale effortlessly with Inngest.",
 });
 
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: "Inngest vs Temporal: Durable execution that developers love",
+  description:
+    "Discover a serverless, event-driven platform that developers love. Build faster, debug easier, and scale effortlessly with Inngest.",
+  url: "https://www.inngest.com/compare-to-temporal",
+  publisher: {
+    "@type": "Organization",
+    name: "Inngest",
+    url: "https://www.inngest.com",
+  },
+};
+
 const baseCTA = "compare-to-temporal";
 
 export default function Page() {
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
       <Hero
         headline="Inngest vs Temporal: Durable execution that developers love"
         subheadline="Discover a serverless, event-driven platform that developers love. Build faster, debug easier, and scale effortlessly with Inngest."

--- a/app/(llms)/blog-markdown/[slug]/route.ts
+++ b/app/(llms)/blog-markdown/[slug]/route.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+import { convertMdxToMarkdown } from "@/mdx/utils/mdx-to-markdown";
+
+const BLOG_DIR = path.join(process.cwd(), "content", "blog");
+const HOST = process.env.NEXT_PUBLIC_HOST ?? "https://www.inngest.com";
+
+export const generateStaticParams = async () => {
+  const files = fs
+    .readdirSync(BLOG_DIR)
+    .filter((f) => f.endsWith(".mdx") || f.endsWith(".md"))
+    .filter((f) => {
+      // Skip posts that define a redirect
+      const source = fs.readFileSync(path.join(BLOG_DIR, f), "utf-8");
+      const { data } = matter(source);
+      return !data.redirect;
+    });
+
+  return files.map((f) => ({ slug: f.replace(/\.(mdx|md)$/, "") }));
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+
+  // Sanitize to prevent directory traversal
+  const sanitizedSlug = slug.replace(/\.\./g, "").replace(/^\/+/, "");
+
+  const possiblePaths = [
+    path.join(BLOG_DIR, `${sanitizedSlug}.mdx`),
+    path.join(BLOG_DIR, `${sanitizedSlug}.md`),
+  ];
+
+  let filePath: string | null = null;
+  for (const p of possiblePaths) {
+    if (fs.existsSync(p)) {
+      filePath = p;
+      break;
+    }
+  }
+
+  if (!filePath) {
+    return new Response("Post not found", {
+      status: 404,
+      statusText: "Post not found",
+    });
+  }
+
+  // Ensure the resolved path stays inside the blog directory
+  const resolvedPath = path.resolve(filePath);
+  const resolvedBlogDir = path.resolve(BLOG_DIR);
+  if (!resolvedPath.startsWith(resolvedBlogDir)) {
+    return new Response("Access denied", {
+      status: 403,
+      statusText: "Access denied",
+    });
+  }
+
+  try {
+    const source = fs.readFileSync(filePath, "utf-8");
+    const { content, data } = matter(source);
+
+    // Build a clean YAML frontmatter block so agents get full metadata
+    const authors = Array.isArray(data.author)
+      ? data.author
+      : data.author
+      ? [data.author]
+      : [];
+
+    const frontmatterLines: string[] = ["---"];
+    if (data.heading) frontmatterLines.push(`title: ${JSON.stringify(data.heading)}`);
+    if (data.subtitle) frontmatterLines.push(`description: ${JSON.stringify(data.subtitle)}`);
+    if (data.date) {
+      const dateStr = data.date instanceof Date
+        ? data.date.toISOString().split("T")[0]
+        : String(data.date);
+      frontmatterLines.push(`date: ${dateStr}`);
+    }
+    if (data.dateUpdated) {
+      const dateUpdatedStr = data.dateUpdated instanceof Date
+        ? data.dateUpdated.toISOString().split("T")[0]
+        : String(data.dateUpdated);
+      frontmatterLines.push(`dateUpdated: ${dateUpdatedStr}`);
+    }
+    if (authors.length > 0) frontmatterLines.push(`author: ${JSON.stringify(authors)}`);
+    if (data.category) frontmatterLines.push(`category: ${data.category}`);
+    if (data.tags) {
+      const tags = typeof data.tags === "string"
+        ? data.tags.split(",").map((t: string) => t.trim())
+        : data.tags;
+      frontmatterLines.push(`tags: ${JSON.stringify(tags)}`);
+    }
+    frontmatterLines.push(`url: ${HOST}/blog/${sanitizedSlug}`);
+    frontmatterLines.push("---");
+
+    const markdownBody = await convertMdxToMarkdown(content);
+    const output = `${frontmatterLines.join("\n")}\n\n${markdownBody}`;
+
+    return new Response(output, {
+      headers: {
+        "Content-Type": "text/markdown;charset=UTF-8",
+        "Cache-Control": "s-maxage=3600, stale-while-revalidate",
+        "Link": `<${HOST}/blog/${sanitizedSlug}>; rel="canonical"`,
+      },
+    });
+  } catch (error) {
+    console.error(`[blog-markdown] Failed to process post "${sanitizedSlug}":`, error);
+    return new Response("Failed to read post", {
+      status: 500,
+      statusText: "Failed to read post",
+    });
+  }
+}

--- a/app/(llms)/blog.txt/route.ts
+++ b/app/(llms)/blog.txt/route.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+
+const BLOG_DIR = path.join(process.cwd(), "content", "blog");
+const HOST = process.env.NEXT_PUBLIC_HOST ?? "https://www.inngest.com";
+
+export const dynamic = "force-static";
+
+type PostMeta = {
+  slug: string;
+  title: string;
+  description?: string;
+  date: string;
+  authors: string[];
+  category?: string;
+};
+
+function loadBlogIndex(): PostMeta[] {
+  const files = fs
+    .readdirSync(BLOG_DIR)
+    .filter((f) => f.endsWith(".mdx") || f.endsWith(".md"));
+
+  const posts: PostMeta[] = [];
+
+  for (const file of files) {
+    const filePath = path.join(BLOG_DIR, file);
+    const source = fs.readFileSync(filePath, "utf-8");
+    const { data } = matter(source);
+
+    // Skip redirects and hidden posts
+    if (data.redirect || data.hide) continue;
+
+    const slug = file.replace(/\.(mdx|md)$/, "");
+
+    const rawDate = data.date;
+    const dateStr = rawDate instanceof Date
+      ? rawDate.toISOString().split("T")[0]
+      : rawDate
+      ? String(rawDate)
+      : "";
+
+    const authors = Array.isArray(data.author)
+      ? data.author
+      : data.author
+      ? [data.author]
+      : [];
+
+    posts.push({
+      slug,
+      title: data.heading ?? slug,
+      description: data.subtitle,
+      date: dateStr,
+      authors,
+      category: data.category,
+    });
+  }
+
+  // Newest first
+  return posts.sort((a, b) => b.date.localeCompare(a.date));
+}
+
+export async function GET() {
+  const posts = loadBlogIndex();
+
+  const lines: string[] = [
+    "# Inngest Blog",
+    "",
+    "> Engineering articles, product updates, and company news from the Inngest team.",
+    "",
+    `- [Full documentation](${HOST}/llms.txt)`,
+    `- [Individual posts](${HOST}/blog-markdown/<slug>)`,
+    "",
+    "## Posts",
+    "",
+  ];
+
+  for (const post of posts) {
+    const authorStr = post.authors.length > 0 ? ` — ${post.authors.join(", ")}` : "";
+    const categoryStr = post.category ? ` [${post.category}]` : "";
+
+    lines.push(`### [${post.title}](${HOST}/blog-markdown/${post.slug})`);
+    lines.push("");
+    lines.push(`${post.date}${authorStr}${categoryStr}`);
+    if (post.description) {
+      lines.push("");
+      lines.push(post.description);
+    }
+    lines.push("");
+  }
+
+  return new Response(lines.join("\n"), {
+    headers: {
+      "Content-Type": "text/plain;charset=UTF-8",
+      "Cache-Control": "s-maxage=3600, stale-while-revalidate",
+    },
+  });
+}

--- a/app/(llms)/docs-markdown/[[...slug]]/route.ts
+++ b/app/(llms)/docs-markdown/[[...slug]]/route.ts
@@ -101,10 +101,15 @@ export async function GET(
     const contentWithMarkdownURLs = convertDocsURLsToMarkdownURLs(contentWithSnippets);
     const processedContent = await convertMdxToMarkdown(contentWithMarkdownURLs);
 
+    const canonicalUrl = `${process.env.NEXT_PUBLIC_HOST ?? "https://www.inngest.com"}/docs/${docPath}`;
+
     // Return as plain text for easy copying. Disable caching so this always runs
     // dynamically and returns fresh content from the docs.
     return new Response(processedContent, {
-      headers: { "Content-Type": "text/markdown;charset=UTF-8" },
+      headers: {
+        "Content-Type": "text/markdown;charset=UTF-8",
+        "Link": `<${canonicalUrl}>; rel="canonical"`,
+      },
     });
   } catch (error) {
     console.error("Failed to process document:", error);

--- a/app/(llms)/llms-full.txt/route.ts
+++ b/app/(llms)/llms-full.txt/route.ts
@@ -3,11 +3,129 @@ import path from "node:path";
 
 export const dynamic = "force-static";
 
+const DOCS = path.join(process.cwd(), "pages", "docs");
+const HOST = process.env.NEXT_PUBLIC_HOST ?? "https://www.inngest.com";
+
+/**
+ * Sections included in full — order determines document structure.
+ *
+ * Excluded intentionally:
+ *
+ *   reference/typescript/v3  (~175KB) — superseded by v4; risks agents
+ *     generating outdated v3 code. Fetch individually if needed.
+ *
+ *   examples/                (~67KB)  — linked from llms.txt for on-demand
+ *     fetching; too bulky for a context window file.
+ *
+ *   getting-started/<framework>  (~86KB) — framework variants are ~90%
+ *     identical; nodejs + python covers the pattern. Other URLs listed below.
+ *
+ *   features/                (~148KB) — overlaps with reference/typescript/v4
+ *     and learn/; reference is more authoritative for code generation tasks.
+ *
+ *   platform/                (~103KB) — dashboard/UI observability docs;
+ *     valuable for users but low signal for agents writing code.
+ *
+ *   guides (vendor-specific) (~35KB)  — integration guides for Resend,
+ *     Retool, Mergent, and Clerk; too narrow for a general context file.
+ */
+
+// Framework quick-starts to omit — keep nodejs + python + index only
+const GETTING_STARTED_EXCLUDE = new Set([
+  "nextjs-quick-start.mdx",
+  "express-quick-start.mdx",
+  "nestjs-quick-start.mdx",
+  "astro-quick-start.mdx",
+  "tanstack-start-quick-start.mdx",
+  "h3-quick-start.mdx",
+]);
+
+// Vendor-specific guides excluded from the guides/ section
+const GUIDES_EXCLUDE = new Set([
+  "resend-webhook-events.mdx",
+  "trigger-your-code-from-retool.mdx",
+  "mergent-migration.mdx",
+  "clerk-webhook-events.mdx",
+]);
+
+const GETTING_STARTED_NOTE = `
+---
+Note: Framework-specific quick-start guides (Next.js, Express, NestJS, Astro, TanStack Start, H3) follow the same pattern as the Node.js guide above. Find them at:
+- ${HOST}/docs/getting-started/nextjs-quick-start
+- ${HOST}/docs/getting-started/express-quick-start
+- ${HOST}/docs/getting-started/nestjs-quick-start
+- ${HOST}/docs/getting-started/astro-quick-start
+- ${HOST}/docs/getting-started/tanstack-start-quick-start
+- ${HOST}/docs/getting-started/h3-quick-start
+`.trim();
+
+const FEATURES_NOTE = `
+---
+Note: Feature deep-dives (middleware, error handling, cancellation, realtime, AI orchestration) are available individually at ${HOST}/docs/features or via ${HOST}/docs-markdown/features/<page>.
+`.trim();
+
+const PLATFORM_NOTE = `
+---
+Note: Platform and observability docs (traces, metrics, alerts, replay) are available at ${HOST}/docs/platform or via ${HOST}/docs-markdown/platform/<page>.
+`.trim();
+
+// Sections processed in full (v3, examples, features, platform excluded)
+const SECTIONS = [
+  "getting-started", // filtered via GETTING_STARTED_EXCLUDE
+  "learn",
+  "guides",          // filtered via GUIDES_EXCLUDE
+  "ai-patterns",
+  "ai-dev-tools",
+  "events",
+  "deploy",
+  "apps",
+  "sdk",
+  "setup",
+  "functions",
+  "usage-limits",
+  // Reference: v4 + other SDKs only — v3 excluded
+  path.join("reference", "typescript", "v4"),
+  path.join("reference", "python"),
+  path.join("reference", "go"),
+  path.join("reference", "rest-api"),
+  path.join("reference", "system-events"),
+  path.join("reference", "workflow-kit"),
+];
+
 export async function GET() {
-  const content = processDirectory(
-    path.join(process.cwd(), "pages", "docs")
-  ).join("\n");
-  return new Response(content, {
+  const parts: string[] = [
+    "# Inngest — Full Documentation\n",
+    "> Complete documentation for Inngest, the durable workflow engine for AI applications.",
+    `> TypeScript SDK v3 reference and framework-specific examples are excluded to reduce size.`,
+    `> Fetch individual pages via ${HOST}/docs-markdown/<path> or browse the index at ${HOST}/llms.txt.\n`,
+  ];
+
+  for (const section of SECTIONS) {
+    const sectionDir = path.join(DOCS, section);
+    const excludeFiles =
+      section === "getting-started" ? GETTING_STARTED_EXCLUDE :
+      section === "guides" ? GUIDES_EXCLUDE :
+      new Set<string>();
+
+    try {
+      const content = processDirectory(sectionDir, excludeFiles);
+      if (content.length > 0) {
+        parts.push(...content);
+        // Append section notes after relevant sections
+        if (section === "getting-started") {
+          parts.push(GETTING_STARTED_NOTE);
+        }
+        if (section === "guides") {
+          parts.push(FEATURES_NOTE);
+          parts.push(PLATFORM_NOTE);
+        }
+      }
+    } catch {
+      // Directory may not exist in all environments — skip silently
+    }
+  }
+
+  return new Response(parts.join("\n"), {
     headers: {
       "Content-Type": "text/plain;charset=UTF-8",
       "Cache-Control": "s-maxage=360, stale-while-revalidate",

--- a/app/(llms)/llms.txt/route.ts
+++ b/app/(llms)/llms.txt/route.ts
@@ -24,6 +24,7 @@ export async function GET() {
 - [Documentation](${process.env.NEXT_PUBLIC_HOST}/docs-markdown/)
 - [Full documentation as single file](${process.env.NEXT_PUBLIC_HOST}/llms-full.txt)
 - [LLM integration context](${process.env.NEXT_PUBLIC_HOST}/llm-context.md)
+- [Blog index](${process.env.NEXT_PUBLIC_HOST}/blog.txt)
 
 ## Learn
 

--- a/app/(llms)/utils.ts
+++ b/app/(llms)/utils.ts
@@ -84,18 +84,23 @@ function fullURL(path: string): string {
 /**
  * Recursively processes all MDX files in a directory
  * @param dir - Directory to process
+ * @param excludeFiles - Optional set of filenames (basename only) to skip
  * @returns Array of processed file contents
  */
-export function processDirectory(dir: string): string[] {
+export function processDirectory(
+  dir: string,
+  excludeFiles: Set<string> = new Set()
+): string[] {
   const results: string[] = [];
 
   for (const file of readdirSync(dir, { withFileTypes: true })) {
     if (config.excludes.includes(file.name)) continue;
+    if (excludeFiles.has(file.name)) continue;
 
     const fullPath = join(dir, file.name);
 
     if (file.isDirectory()) {
-      results.push(...processDirectory(fullPath));
+      results.push(...processDirectory(fullPath, excludeFiles));
     } else if (file.name.endsWith(".mdx")) {
       results.push(processMDXFile(fullPath));
     }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,9 +16,66 @@ export const metadata: Metadata = generateMetadata({
   image: "/assets/homepage/open-graph-june-2025.png",
 });
 
+const structuredData = [
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "Inngest",
+    url: "https://www.inngest.com",
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Inngest",
+    url: "https://www.inngest.com",
+    logo: "https://www.inngest.com/logo-with-icon-white.svg",
+    sameAs: [
+      "https://twitter.com/inngest",
+      "https://github.com/inngest",
+      "https://www.linkedin.com/company/inngest",
+    ],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: "Inngest",
+    url: "https://www.inngest.com",
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Any",
+    description:
+      "Inngest's durable functions replace queues, state management, and scheduling to enable any developer to write reliable, multi-step code faster without touching infrastructure.",
+    featureList: [
+      "Durable execution with automatic retries",
+      "Event-driven workflow triggers",
+      "Step functions with pause and resume",
+      "AI agent orchestration with human-in-the-loop",
+      "Concurrency, throttling, and rate limiting",
+      "Real-time observability and replay",
+      "Serverless, server, and edge compatible",
+    ],
+    programmingLanguage: ["TypeScript", "JavaScript", "Python", "Go"],
+    screenshot: "https://www.inngest.com/assets/homepage/open-graph-june-2025.png",
+    sameAs: [
+      "https://github.com/inngest/inngest",
+      "https://twitter.com/inngest",
+    ],
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+      description: "Free tier available, no credit card required.",
+      url: "https://www.inngest.com/pricing",
+    },
+  },
+];
+
 export default function Page() {
   return (
     <div className="bg-stone-950">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
       <Hero />
       <OrchestrationSection />
       <FeatureNavigate />

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -24,9 +24,56 @@ export const metadata: Metadata = generateMetadata({
     "Pricing plans that scale with you, from our Free Tier all the way to custom Enterprise pricing.",
 });
 
+const HOST = "https://www.inngest.com";
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: "Inngest Pricing",
+  description:
+    "Pricing plans that scale with you, from our Free Tier all the way to custom Enterprise pricing.",
+  url: `${HOST}/pricing`,
+  publisher: {
+    "@type": "Organization",
+    name: "Inngest",
+    url: HOST,
+  },
+  mainEntity: [
+    {
+      "@type": "Offer",
+      name: "Hobby",
+      description:
+        "Get started with modern durable execution for free, no credit card required.",
+      price: "0",
+      priceCurrency: "USD",
+      url: `${HOST}/pricing`,
+    },
+    {
+      "@type": "Offer",
+      name: "Pro",
+      description:
+        "The metrics and concurrency you need for early stage production products.",
+      price: "75",
+      priceCurrency: "USD",
+      url: `${HOST}/pricing`,
+    },
+    {
+      "@type": "Offer",
+      name: "Enterprise",
+      description:
+        "Ensure reliability at scale, with advanced recovery and dedicated support.",
+      url: `${HOST}/contact`,
+    },
+  ],
+};
+
 export default function Pricing() {
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
       <div className="max-w-screen relative">
         <GridBackground />
         <div className="relative">

--- a/content/blog/after-the-agent-signs-in.mdx
+++ b/content/blog/after-the-agent-signs-in.mdx
@@ -7,6 +7,7 @@ image: /assets/blog/after-the-agent-signs-in/featured-image/featured-image.png
 date: 2026-04-21
 category: engineering
 author: Sterling Chin
+primaryCTA: "report2026"
 ---
 
 *Companion to: [Inngest + Stripe Projects: Ship Durable Apps Without Leaving the Terminal](https://www.inngest.com/blog/inngest-stripe-projects-ship-durable-apps-without-leaving-the-terminal)*

--- a/content/blog/ai-agents-inngest-durable-steps.mdx
+++ b/content/blog/ai-agents-inngest-durable-steps.mdx
@@ -6,6 +6,7 @@ date: 2026-03-17
 category: engineering
 author: Dan Farrelly
 showSubtitle: true
+primaryCTA: "report2026"
 ---
 
 Most AI agent tutorials stop at the happy path — call the LLM, run a tool, loop. But the moment you ship an agent to production, you hit the real problems: tool calls fail, LLM providers rate-limit you, long-running tasks time out, and you can't see what the hell happened when something goes wrong.

--- a/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
+++ b/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
@@ -4,6 +4,7 @@ subtitle: Every six months, the "right" way to build an AI agent changes. How ca
 image: /assets/blog/background-agents-are-here/featured-image-gold.png
 date: 2026-05-08
 author: Dan Farrelly
+primaryCTA: "report2026"
 ---
 
 Every six months, the "right" way to build an AI agent changes.

--- a/content/blog/build-self-learning-agent.mdx
+++ b/content/blog/build-self-learning-agent.mdx
@@ -6,6 +6,7 @@ image: /assets/blog/i-built-a-self-improving-agent-it-taught-itself-to-cheat/fea
 date: 2026-04-16
 category: engineering
 author: "Mitchell Alderson (guest post)"
+primaryCTA: "report2026"
 ---
 
 I built an AI agent that improves its own prompts. Within hours of running the evaluation pipeline, the LLM discovered it could game the scoring system.

--- a/content/blog/building-durable-agents.mdx
+++ b/content/blog/building-durable-agents.mdx
@@ -5,6 +5,7 @@ showSubtitle: false
 subtitle: "How to stop your AI agents from breaking in production — and start making them debuggable, deterministic, and durable."
 date: 2025-10-30
 author: Keoni Murray
+primaryCTA: "report2026"
 ---
 **Your AI agent works perfectly in testing. Then you ship it.**
 

--- a/content/blog/context-engineering-in-practice.mdx
+++ b/content/blog/context-engineering-in-practice.mdx
@@ -6,6 +6,7 @@ subtitle: "A lot has been written about Context Engineering theory and its princ
 date: 2025-11-07
 author: Charly Poly
 disableCTA: false
+primaryCTA: "report2026"
 ---
 
 A lot has been written about Context Engineering theory and its principles, with few examples. At Inngest, we are fortunate to experience context engineering in practice through our exchanges with our [community](http://inngest.com/discord) and [customers](http://inngest.com/customers), which include leading AI products such as [Outtake](/customers/outtake), [Replit](/blog/inngest-replit-vibe-code-ai-agents), and 11x.

--- a/content/blog/durable-execution-key-to-harnessing-ai-agents.mdx
+++ b/content/blog/durable-execution-key-to-harnessing-ai-agents.mdx
@@ -5,6 +5,7 @@ image: /assets/blog/durable-execution-key-to-harnessing-ai-agents/featured-image
 date: 2026-02-19
 author: Charly Poly
 category: engineering
+primaryCTA: "report2026"
 ---
 
 ### Key Takeaways

--- a/content/blog/hanging-promises-for-control-flow.mdx
+++ b/content/blog/hanging-promises-for-control-flow.mdx
@@ -5,6 +5,7 @@ image: /assets/blog/hanging-promises-for-control-flow/featured-image.jpg
 date: 2026-04-07
 author: Aaron Harper
 category: engineering
+primaryCTA: "report2026"
 ---
 
 You can't cancel a JavaScript promise. There's no `.cancel()` method, no `AbortController` integration, no built-in way to say "never mind, stop." The TC39 committee [considered adding cancellation](https://github.com/tc39/proposal-cancelable-promises) in 2016, but the proposal was withdrawn after heated debate. Part of the problem is that cancelling arbitrary code mid-execution can leave resources in a dirty state (open handles, half-written data), so true cancellation requires cooperative cleanup, which undermines the simplicity people want from a `.cancel()` method.

--- a/content/blog/how-to-build-a-production-ai-image-generation-pipeline-with-fal-ai-and-inngest.mdx
+++ b/content/blog/how-to-build-a-production-ai-image-generation-pipeline-with-fal-ai-and-inngest.mdx
@@ -5,6 +5,7 @@ image: /assets/blog/how-to-build-a-production-ai-image-generation-pipeline-with-
 date: 2026-03-24
 author: Lauren Craigie
 category: engineering
+primaryCTA: "report2026"
 ---
 
 Building a production AI image app involves two distinct problems.

--- a/content/blog/principles-of-durable-execution.mdx
+++ b/content/blog/principles-of-durable-execution.mdx
@@ -5,7 +5,7 @@ image: /assets/blog/principles-of-durable-execution/featured-image.png
 date: 2024-12-10
 dateUpdated: 2026-01-07
 author: Dan Farrelly
-primaryCTA: sales
+primaryCTA: "report2026"
 floatingCTA: true
 category: engineering
 teaser:

--- a/content/blog/three-patterns-you-need-for-agentic-systems.md
+++ b/content/blog/three-patterns-you-need-for-agentic-systems.md
@@ -4,6 +4,7 @@ subtitle: "Every agentic system that actually ships ends up needing three delega
 image: /assets/blog/three-patterns-you-need-for-agentic-systems/blog-banner.png
 date: 2026-03-11
 author: Dan Farrelly
+primaryCTA: "report2026"
 ---
 
 **Every agentic system that actually ships ends up needing three delegation patterns: one that blocks, one that fires and forgets, and one that runs later. The question isn't whether you need sub-agents — it's how you wire them up.**

--- a/content/blog/vercel-long-running-background-functions.mdx
+++ b/content/blog/vercel-long-running-background-functions.mdx
@@ -6,6 +6,7 @@ date: 2023-03-31
 dateUpdated: 2024-06-06
 author: Dan Farrelly
 disableCTA: true
+primaryCTA: "report2026"
 ---
 
 Serverless functions can be a game changer for devs building applications who want to get into production fast and elastically scale with usage. Today, developers primarily use serverless functions on platforms like Vercel to build synchronous APIs, but what do you do if you need to run critical business logic on top of serverless functions?

--- a/content/blog/your-agent-needs-a-harness-not-a-framework.mdx
+++ b/content/blog/your-agent-needs-a-harness-not-a-framework.mdx
@@ -5,6 +5,7 @@ image: /assets/blog/your-agent-needs-a-harness-not-a-framework/featured-image.pn
 date: 2026-03-03
 author: Dan Farrelly
 category: engineering
+primaryCTA: "report2026"
 ---
 
 In every engineering discipline, a harness is the same thing: the layer that connects, protects, and orchestrates components — without doing the work itself. A wiring harness routes signals between an engine, sensors, and dashboard. A test harness provides the scaffolding that makes code repeatable and observable. A safety harness catches you when you fall.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Markdown serving middleware for AI agents / AEO.
+ *
+ * Two complementary strategies, checked in order:
+ *
+ * 1. .md extension routes — no header sniffing required
+ *    Any client that can construct a URL gets raw markdown by appending .md:
+ *
+ *      GET /blog/my-post.md
+ *      → internal rewrite → /blog-markdown/my-post   (returns text/markdown)
+ *
+ *      GET /docs/getting-started/nextjs-quick-start.md
+ *      → internal rewrite → /docs-markdown/getting-started/nextjs-quick-start
+ *
+ * 2. Accept: text/markdown content negotiation
+ *    Agents that send a proper Accept header get markdown from the canonical URL:
+ *
+ *      GET /blog/my-post          Accept: text/markdown
+ *      → internal rewrite → /blog-markdown/my-post   (returns text/markdown)
+ *
+ *      GET /docs/getting-started  Accept: text/markdown
+ *      → internal rewrite → /docs-markdown/getting-started
+ *
+ * For normal browser requests the middleware is a no-op, but it adds a
+ * `Vary: Accept` header so CDN/edge caches keep the two representations
+ * separate.
+ */
+
+function acceptsMarkdown(req: NextRequest): boolean {
+  const accept = req.headers.get("accept") ?? "";
+  return accept.includes("text/markdown");
+}
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  // ── Strategy 1: .md extension routes ──────────────────────────────────────
+
+  if (pathname.endsWith(".md")) {
+    // /blog/[slug].md  →  /blog-markdown/[slug]
+    if (/^\/blog\/[^/]+\.md$/.test(pathname)) {
+      const slug = pathname.slice("/blog/".length, -".md".length);
+      const url = req.nextUrl.clone();
+      url.pathname = `/blog-markdown/${slug}`;
+      return NextResponse.rewrite(url);
+    }
+
+    // /docs/[...path].md  →  /docs-markdown/[...path]
+    if (pathname.startsWith("/docs/")) {
+      const docPath = pathname.slice("/docs/".length, -".md".length);
+      const url = req.nextUrl.clone();
+      url.pathname = `/docs-markdown/${docPath}`;
+      return NextResponse.rewrite(url);
+    }
+  }
+
+  // ── Strategy 2: Accept: text/markdown content negotiation ─────────────────
+
+  if (acceptsMarkdown(req)) {
+    // /blog/[slug]  →  /blog-markdown/[slug]
+    if (/^\/blog\/[^/]+$/.test(pathname)) {
+      const slug = pathname.replace(/^\/blog\//, "");
+      const url = req.nextUrl.clone();
+      url.pathname = `/blog-markdown/${slug}`;
+      return NextResponse.rewrite(url);
+    }
+
+    // /docs/[...path]  →  /docs-markdown/[...path]
+    if (pathname.startsWith("/docs/") || pathname === "/docs") {
+      const docPath = pathname.replace(/^\/docs\/?/, "");
+      const url = req.nextUrl.clone();
+      url.pathname = `/docs-markdown/${docPath}`;
+      return NextResponse.rewrite(url);
+    }
+  }
+
+  // Pass through — add Vary and Link headers so agents see the markdown
+  // alternate without needing to parse the HTML body at all.
+  const res = NextResponse.next();
+  res.headers.set("Vary", "Accept");
+
+  const { origin } = req.nextUrl;
+
+  if (/^\/blog\/[^/]+$/.test(pathname)) {
+    const slug = pathname.replace(/^\/blog\//, "");
+    res.headers.set(
+      "Link",
+      `<${origin}/blog/${slug}.md>; rel="alternate"; type="text/markdown"`
+    );
+  } else if (pathname.startsWith("/docs/") || pathname === "/docs") {
+    const docPath = pathname.replace(/^\/docs\/?/, "");
+    const mdPath = docPath ? `/docs/${docPath}.md` : `/docs.md`;
+    res.headers.set(
+      "Link",
+      `<${origin}${mdPath}>; rel="alternate"; type="text/markdown"`
+    );
+  }
+
+  return res;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match /blog/:slug (individual post pages only, not /blog index)
+     * and /docs + /docs/:path* (all docs routes).
+     * Excludes _next/, static files, and API routes automatically
+     * because none of those paths start with /blog/ or /docs.
+     */
+    "/blog/:slug*",
+    "/docs",
+    "/docs/:path*",
+  ],
+};

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -153,7 +153,7 @@ export default function BlogLayout(props) {
       name: "Inngest",
       url: process.env.NEXT_PUBLIC_HOST,
     },
-    ...(scope.category && { articleSection: scope.category }),
+    ...((scope as any).category && { articleSection: (scope as any).category }),
     ...(scope.tags && scope.tags.length > 0 && { keywords: scope.tags.join(", ") }),
     author:
       structuredDataAuthors.length > 0

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -297,9 +297,45 @@ function CTAs({
   primary = "docs",
   ctaRef = "",
 }: {
-  primary: "docs" | "sales" | "signUp";
+  primary: "docs" | "sales" | "signUp" | "report2026";
   ctaRef: string;
 }) {
+  if (primary === "report2026") {
+    return (
+      <aside className="m-auto max-w-[70ch] border-t-[2px] border-stone-700 pt-8">
+        <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:gap-8">
+          <div className="flex flex-col items-start">
+            <h2 className="mt-0 text-xl font-medium text-basis">
+              AI in Production: The 2026 Benchmark Report
+            </h2>
+            <p className="mb-6 mt-2 text-sm text-subtle">
+              We surveyed 130 backend, full-stack, and AI engineers to find out
+              how teams are actually running AI in production, and what's
+              holding them back.
+            </p>
+            <Button
+              variant="primary"
+              size="sm"
+              href={`https://www.inngest.com/content/ai-in-production-report-2026?ref=${ctaRef}`}
+              arrow="right"
+            >
+              View Key Findings
+            </Button>
+          </div>
+          <div className="flex-shrink-0">
+            <Image
+              src="/assets/blog/ai-in-production-report-2026-card/featured-image/featured-image.png"
+              alt="AI in Production: The 2026 Benchmark Report"
+              width={220}
+              height={165}
+              className="rounded-lg"
+            />
+          </div>
+        </div>
+      </aside>
+    );
+  }
+
   const ctas = {
     sales: {
       title: "Chat with a solutions expert",

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -133,6 +133,8 @@ export default function BlogLayout(props) {
     };
   });
 
+  const postUrl = `${process.env.NEXT_PUBLIC_HOST}${scope.path}`;
+
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
@@ -141,6 +143,18 @@ export default function BlogLayout(props) {
     image: [`${process.env.NEXT_PUBLIC_HOST}${scope.image}`],
     datePublished: scope.date,
     dateModified: scope.dateUpdated ? scope.dateUpdated : scope.date,
+    url: postUrl,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": postUrl,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Inngest",
+      url: process.env.NEXT_PUBLIC_HOST,
+    },
+    ...(scope.category && { articleSection: scope.category }),
+    ...(scope.tags && scope.tags.length > 0 && { keywords: scope.tags.join(", ") }),
     author:
       structuredDataAuthors.length > 0
         ? structuredDataAuthors
@@ -200,6 +214,13 @@ export default function BlogLayout(props) {
             content={`${process.env.NEXT_PUBLIC_HOST}${scope.image}`}
           />
         )}
+        {/* Markdown alternate for AI/LLM discoverability */}
+        <link
+          rel="alternate"
+          type="text/markdown"
+          href={`${process.env.NEXT_PUBLIC_HOST}/blog/${slug}.md`}
+        />
+
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/public/.well-known/skills.md
+++ b/public/.well-known/skills.md
@@ -1,0 +1,50 @@
+# Inngest Agent Skills
+
+> Pre-built skills for AI coding agents that teach Claude Code, Cursor, Windsurf, and other agents how to write, test, and debug Inngest functions with up-to-date API knowledge.
+
+- Source: https://github.com/inngest/inngest-skills
+- Documentation: https://www.inngest.com/docs/ai-dev-tools/agent-skills
+- Full Inngest docs (LLM-friendly): https://www.inngest.com/llms.txt
+
+## Installation
+
+### skills.sh
+```bash
+npx skills add inngest/inngest-skills
+```
+
+### Claude Code
+```
+/plugin marketplace add inngest/inngest-skills
+/plugin install inngest-skills@inngest-agent-skills
+```
+
+### Cursor
+Add to your `.cursorrules` file:
+```
+Load the Inngest skills from https://github.com/inngest/inngest-skills for building with Inngest's durable execution platform.
+```
+
+### Windsurf / other agents
+Reference https://github.com/inngest/inngest-skills directly or clone it to your agent's skills directory. Each skill is self-contained with full documentation in its `SKILL.md` file.
+
+## Available Skills
+
+| Skill | Description | What it covers |
+| --- | --- | --- |
+| **inngest-setup** | Set up Inngest in a TypeScript project | SDK installation, client config, environment variables, dev server |
+| **inngest-events** | Design and send Inngest events | Event schema, naming conventions, idempotency, fan-out patterns, system events |
+| **inngest-durable-functions** | Create and configure durable functions | Triggers, step execution, memoization, cancellation, error handling, retries |
+| **inngest-steps** | Use step methods to build durable workflows | `step.run`, `step.sleep`, `step.waitForEvent`, loops, parallel execution |
+| **inngest-flow-control** | Configure flow control for functions | Concurrency limits, throttling, rate limiting, debounce, priority, batching |
+| **inngest-middleware** | Create middleware for cross-cutting concerns | Middleware lifecycle, dependency injection, built-in middleware |
+
+## Language Support
+
+These skills are currently focused on **TypeScript**. Core concepts like events, steps, and flow control apply across all Inngest SDKs, but code examples and setup instructions are TypeScript-specific.
+
+For Python or Go, refer to https://www.inngest.com/llms.txt for language-specific guidance.
+
+## Related
+
+- [Dev Server MCP Integration](https://www.inngest.com/docs/ai-dev-tools/mcp) — Connect AI assistants directly to your running Inngest dev server to list functions, send events, and monitor runs alongside these skills.

--- a/shared/Docs/Layout.tsx
+++ b/shared/Docs/Layout.tsx
@@ -143,7 +143,7 @@ export function Layout({
           <meta name="docsearch:sdkVersion" content={sdkVersion} />
 
           {/* Markdown alternate for AI/LLM discoverability */}
-          <link rel="alternate" type="text/markdown" href={markdownAlternateUrl} />
+          <link rel="alternate" type="text/markdown" href={`https://www.inngest.com/docs${docsPath}.md`} />
 
           <link rel="preconnect" href="https://fonts-cdn.inngest.com/" />
           <link


### PR DESCRIPTION
A collection of AEO (Answer Engine Optimization) improvements to make Inngest content more accessible to AI agents, LLMs, and headless crawlers.

## New routes & files

- **`app/(llms)/blog-markdown/[slug]/route.ts`** — serves raw markdown for any blog post at \`/blog-markdown/<slug>\`; includes normalized YAML frontmatter and \`Link: canonical\` header
- **`app/(llms)/blog.txt/route.ts`** — static blog index (163 posts, newest-first) linked from \`llms.txt\`
- **`middleware.ts`** — content negotiation: rewrites \`Accept: text/markdown\` requests and \`.md\` extension URLs to markdown routes for \`/blog/*\` and \`/docs/*\`
- **`public/.well-known/skills.md`** — agent skills discovery file documenting 6 Inngest agent skills

## Updated routes

- **`llms.txt`** — adds blog index link
- **`utils.ts`** — adds optional \`excludeFiles\` param to \`processDirectory()\`
- **`docs-markdown/[[...slug]]/route.ts`** — adds \`Link: canonical\` header to responses
- **`llms-full.txt/route.ts`** — trims ~614KB by removing \`reference/typescript/v3\`, \`features/\`, \`platform/\`, redundant framework quick-starts, and vendor-specific guides; adds pointer notes for excluded sections

## Structured data (JSON-LD)

- **`pages/blog/[slug].tsx`** — enriched \`BlogPosting\` schema (url, mainEntityOfPage, publisher, articleSection, keywords) + \`link rel=alternate\` pointing to \`.md\` URL
- **`app/page.tsx`** — \`WebSite\` + \`Organization\` + \`SoftwareApplication\` schemas
- **`app/(landing-pages)/compare-to-temporal/page.tsx`** — \`WebPage\` schema
- **`app/pricing/page.tsx`** — \`WebPage\` + \`Offer\` schemas (Hobby, Pro, Enterprise)

## Discoverability headers & tags

- \`middleware.ts\` — adds \`Vary: Accept\` and \`Link: rel=alternate\` headers on HTML pass-throughs for blog and docs pages
- \`shared/Docs/Layout.tsx\` — updates \`link rel=alternate\` href to use \`.md\` URL pattern

## Out of scope / follow-up

- **FAQPage JSON-LD** — deferred until new website launches with inline FAQ sections on homepage and pricing