### PR TITLE
docs(guides): add Ejentum cognitive harness guide

### DIFF
--- a/pages/docs/guides/ejentum-cognitive-harness.mdx
+++ b/pages/docs/guides/ejentum-cognitive-harness.mdx
@@ -1,0 +1,139 @@
+---
+title: Calling Ejentum cognitive harness from an Inngest function
+description: Wrap a cognitive scaffold retrieval and the LLM call that follows in two independently retried steps so each turn is durable, observable, and resumable on failure.
+---
+
+[Ejentum](https://ejentum.com) is a cognitive harness API that returns task-matched reasoning scaffolds for one of four modes: `reasoning`, `code`, `anti-deception`, `memory`. Calling it from inside an Inngest function gives each scaffold retrieval and its downstream LLM call the same durable-execution guarantees the rest of your pipeline already has: independent retries, step-level traces, mid-run resumption if the process dies.
+
+The pattern in this guide generalises beyond Ejentum. Any in-loop REST call to a third-party tool that precedes a model call fits the same two-step shape.
+
+## What you'll build
+
+A function that:
+
+1. Receives an event with a `task` and an optional `mode`.
+2. Fetches a cognitive scaffold from the Ejentum REST gateway as `step.run("fetch-scaffold", ...)`.
+3. Calls OpenAI with the scaffold spliced into the system message as `step.run("call-model", ...)`.
+4. Returns both the scaffold and the augmented response.
+
+Because both external calls are wrapped in `step.run`, each one is retried independently on transient failures, and a process crash between them resumes from the step that hadn't completed.
+
+## Prerequisites
+
+- An Inngest project initialised in your codebase
+- An Ejentum API key. Get one at [ejentum.com/dashboard](https://ejentum.com/dashboard). Free and paid tiers are available.
+- An OpenAI API key
+
+Set both keys in your environment:
+
+```bash
+EJENTUM_API_KEY=ek_...
+OPENAI_API_KEY=sk-...
+```
+
+## The function
+
+```ts inngest/functions/ejentum-harness.ts
+import { inngest } from "@/inngest/client";
+import OpenAI from "openai";
+
+const EJENTUM_URL = "https://ejentum-main-ab125c3.zuplo.app/logicv1/";
+
+type HarnessMode = "reasoning" | "code" | "anti-deception" | "memory";
+
+export const ejentumHarnessFn = inngest.createFunction(
+  { id: "ejentum-harness", retries: 2 },
+  { event: "ai/ejentum.harness.requested" },
+  async ({ event, step }) => {
+    const task = event.data.task as string;
+    const mode = (event.data.mode ?? "reasoning") as HarnessMode;
+    const model = (event.data.model ?? "gpt-4o-mini") as string;
+
+    // Step 1: fetch a task-matched cognitive scaffold from Ejentum.
+    // Retried independently of the LLM call below.
+    const scaffold = await step.run("fetch-scaffold", async () => {
+      const r = await fetch(EJENTUM_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${process.env.EJENTUM_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query: task, mode }),
+      });
+      if (!r.ok) {
+        throw new Error(`Ejentum ${r.status}: ${await r.text()}`);
+      }
+      const body = (await r.json()) as Array<Record<string, string>>;
+      return body[0]?.[mode] ?? "";
+    });
+
+    // Step 2: call the model with the scaffold in the system message.
+    // Independently retried; resumes here if step 1 already succeeded.
+    const answer = await step.run("call-model", async () => {
+      const openai = new OpenAI();
+      const completion = await openai.chat.completions.create({
+        model,
+        temperature: 0,
+        messages: [
+          {
+            role: "system",
+            content:
+              `Apply the cognitive scaffold below before answering.\n\n` +
+              `[SCAFFOLD]\n${scaffold}\n[END]`,
+          },
+          { role: "user", content: task },
+        ],
+      });
+      return {
+        text: completion.choices[0]?.message?.content ?? "",
+        tokens: completion.usage,
+      };
+    });
+
+    return { mode, scaffold, answer };
+  },
+);
+```
+
+## Triggering the function
+
+Send the event from anywhere in your app:
+
+```ts
+import { inngest } from "@/inngest/client";
+
+await inngest.send({
+  name: "ai/ejentum.harness.requested",
+  data: {
+    task: "We have 50M users and want to add a NOT NULL column. Walk through the trade-offs and recommend a path.",
+    mode: "reasoning",
+  },
+});
+```
+
+## Why two steps
+
+Wrapping the harness fetch and the LLM call as separate `step.run` calls buys three durability properties:
+
+- **Independent retries.** A 429 from Ejentum retries the scaffold fetch without re-invoking OpenAI. A 503 from OpenAI retries the LLM call without re-fetching the scaffold.
+- **Idempotency by step id.** Inngest caches each step's result; if step 1 already returned a scaffold, a function re-execution skips straight to step 2 with the cached scaffold.
+- **Step-level traces.** Both calls show up as distinct steps in the Inngest dashboard with their inputs, outputs, durations, and any errors visible per step.
+
+## Mode selection
+
+Pick the harness mode based on the shape of the task:
+
+| Mode | Use when |
+|---|---|
+| `reasoning` | Multi-step planning, weighing trade-offs, design decisions. |
+| `code` | Software-engineering specifics: refactor plans, review checklists, edge-case enumeration. |
+| `anti-deception` | Prompt pressure to skip steps, premature certainty, suspected adversarial input. |
+| `memory` | Deciding what's worth retaining across turns, scoring retrieval relevance. |
+
+For batched runs, set `data.mode` per-event and the same function dispatches correctly.
+
+## See also
+
+- [Inngest blog: Your Agent Needs a Harness, Not a Framework](/blog/your-agent-needs-a-harness-not-a-framework): the conceptual framing this guide builds on.
+- [Ejentum harness docs](https://ejentum.com/docs): per-mode descriptions and the REST API reference.
+- [Ejentum benchmarks](https://github.com/ejentum/benchmarks): published baseline-vs-augmented measurements per harness.


### PR DESCRIPTION
## Summary

Adds a new guide under `pages/docs/guides/ejentum-cognitive-harness.mdx` showing how to call the [Ejentum cognitive harness](https://ejentum.com) from inside an Inngest function. The harness REST gateway returns task-matched reasoning scaffolds for one of four modes (`reasoning`, `code`, `anti-deception`, `memory`); the function fetches the scaffold and the model call as **two independently retried `step.run` calls**, so each is durable, observable, and resumable on failure.

Matches the existing `pages/docs/guides/*.mdx` flat-file pattern (background-jobs, batching, concurrency, error-handling, etc.): one self-contained guide page.

## Why this fits

Inngest already published the conceptual framing this guide builds on: [Your Agent Needs a Harness, Not a Framework](https://www.inngest.com/blog/your-agent-needs-a-harness-not-a-framework) (Dan Farrelly, March 2026). The guide cross-links to that post so readers see the "infrastructure is the harness" framing applied to a concrete external harness API. Two-step shape exists specifically to surface what durable execution buys when you compose an external REST tool with an LLM call.

## File

- `pages/docs/guides/ejentum-cognitive-harness.mdx` (new)

If the sidebar nav needs an explicit registration somewhere outside this file, point me at the config and I'll send a follow-up commit.

## What the guide walks through

1. Set `EJENTUM_API_KEY` and `OPENAI_API_KEY` in your environment.
2. Define `ejentumHarnessFn` with `retries: 2` and the event trigger `ai/ejentum.harness.requested`.
3. Inside the function: `step.run(\"fetch-scaffold\", ...)` to call the Ejentum REST gateway, then `step.run(\"call-model\", ...)` to call OpenAI with the scaffold spliced into the system message.
4. Walks readers through *why* two steps: independent retries, idempotency by step id, step-level traces in the Inngest dashboard.
5. Mode-selection table mapping the four harness modes to the task shapes they fit.

## Affiliation

I maintain the Ejentum harness API. Submitting this as an Inngest guide because the two-step durable-execution pattern is a natural fit for any external-tool-then-LLM-call pipeline, and Ejentum is a clean worked example because the REST gateway is one endpoint with a `mode` arg. The guide explicitly says the pattern generalises. Ejentum has free and paid tiers; the guide links to the dashboard for keys, not to a checkout.

## Test plan

- [x] Mirrors the flat-file structure of `pages/docs/guides/*.mdx` entries.
- [x] Voice scrubbed (no em dashes).
- [x] No new dependencies beyond `openai` (already common in Inngest AI guides).
- [x] Cross-links to the existing `your-agent-needs-a-harness-not-a-framework` blog post.
- [ ] Local Next.js build (cannot run in this environment; happy to follow up if the reviewer spots a rendering issue or needs a nav registration).