### PR TITLE
Update observability-metrics intro for paid search landing

### DIFF
--- a/pages/docs/platform/monitor/observability-metrics.mdx
+++ b/pages/docs/platform/monitor/observability-metrics.mdx
@@ -4,9 +4,11 @@ export const description = "Monitor function runs, event throughput, and step ex
 
 # Observability & Metrics
 
-Durable execution means your code runs across multiple steps, retries, and time boundaries. A single function might sleep for hours, fan out across hundreds of jobs, or chain LLM calls with tool execution loops. When something fails at step 14 of a 20-step workflow, or an agent's fifth inference call times out, you need to see exactly where it broke and why.
+Durable execution runs your code across steps, retries, and time boundaries. Each step is retried and persisted independently. When something fails, you need to see where.
 
-Inngest automatically captures this execution data for every function run. You get metrics, traces, event logs, and per-step timing without adding any instrumentation to your code. This page covers the metrics dashboard. For step-level execution detail, see [Traces](/docs/platform/monitor/traces). For querying raw event and run data with SQL, see [Insights](/docs/platform/monitor/insights).
+Inngest captures execution data for every function run. You get metrics, traces, event logs, and per-step timing without instrumenting your code.
+
+This page covers the metrics dashboard. For step-level execution detail, see [Traces](/docs/platform/monitor/traces). For querying raw event and run data with SQL, see [Insights](/docs/platform/monitor/insights).
 
 ## Function runs observability
 

--- a/pages/docs/platform/monitor/observability-metrics.mdx
+++ b/pages/docs/platform/monitor/observability-metrics.mdx
@@ -1,11 +1,12 @@
 import { Callout, Col, Row } from "src/shared/Docs/mdx";
 
+export const description = "Monitor function runs, event throughput, and step execution across your durable workflows and AI pipelines with built-in observability.";
+
 # Observability & Metrics
 
+Durable execution means your code runs across multiple steps, retries, and time boundaries. A single function might sleep for hours, fan out across hundreds of jobs, or chain LLM calls with tool execution loops. When something fails at step 14 of a 20-step workflow, or an agent's fifth inference call times out, you need to see exactly where it broke and why.
 
-With hundreds to thousands of events going through your Inngest Apps, triggering multiple Function runs, getting a clear view of what is happening at any time is crucial.
-
-The Inngest Platform provides observability features for both Events and Function runs, coupled with Event logs and [a detailed Function Run details to inspect arguments and steps timings](/docs/platform/monitor/inspecting-function-runs).
+Inngest automatically captures this execution data for every function run. You get metrics, traces, event logs, and per-step timing without adding any instrumentation to your code. This page covers the metrics dashboard. For step-level execution detail, see [Traces](/docs/platform/monitor/traces). For querying raw event and run data with SQL, see [Insights](/docs/platform/monitor/insights).
 
 ## Function runs observability
 


### PR DESCRIPTION
Rewrites the intro on the observability-metrics page to frame observability in the context of durable execution and AI workflows. Adds SEO description meta and cross-links to Traces and Insights. Existing chart content untouched.

Landing page for Patt's paid search campaign going live this week.

Resolves DEV-341