### PR TITLE
[codex] Add AI coding agent plugins and skills docs

### DIFF
--- a/pages/docs/ai-dev-tools/agent-skills.mdx
+++ b/pages/docs/ai-dev-tools/agent-skills.mdx
@@ -17,8 +17,8 @@ Inngest provides official plugins and [agent skills](https://agentskills.io) for
 
 | AI tool | Recommended install | What it includes |
 | --- | --- | --- |
-| **Claude Code** | Inngest Claude Code plugin | Seven Inngest skills, MCP config for the local dev server, and an eval harness |
-| **Codex** | Inngest Codex plugin bundle | 11 Codex skills, Codex plugin metadata, MCP config, copyable examples, local marketplace metadata, and an eval harness |
+| **Claude Code** | Inngest Claude Code plugin | Core Inngest skills, MCP config for the local dev server, and an eval harness |
+| **Codex** | Inngest Codex plugin bundle | Codex skills, Codex plugin metadata, MCP config, copyable examples, local marketplace metadata, and an eval harness |
 | **Cursor, Windsurf, and other agents** | Standalone `inngest-skills` repository | The core skill content in a portable format |
 
 ## Why use Inngest plugins?

--- a/pages/docs/ai-dev-tools/agent-skills.mdx
+++ b/pages/docs/ai-dev-tools/agent-skills.mdx
@@ -1,38 +1,51 @@
 import { ResourceGrid, Resource } from "shared/Docs/Resources";
 import { Callout, CodeGroup } from "shared/Docs/mdx";
 
-import { BookOpenIcon, CodeBracketIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
+import { CodeBracketIcon, ComputerDesktopIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 
-export const description = "Pre-built agent skills that teach AI coding agents like Claude Code and Cursor how to write, test, and debug Inngest functions."
+export const description = "Install Inngest plugins and skills for Claude Code, Codex, Cursor, and other AI coding agents so they can write, test, and debug durable functions."
 
-# Agent Skills
+# AI Coding Agent Plugins and Skills
 
-Inngest Skills provides pre-built [agent skills](https://agentskills.io) for AI coding agents like Claude Code, Cursor, and Windsurf. They give your coding agent comprehensive, up-to-date guidance on building reliable applications with Inngest — from initial setup to advanced flow control.
+Inngest provides official plugins and [agent skills](https://agentskills.io) for AI coding agents like Claude Code, Codex, Cursor, and Windsurf. They give your agent current guidance for building reliable applications with Inngest — from initial setup to advanced flow control and realtime updates.
 
 <Callout>
-  Inngest Skills is open source at [github.com/inngest/inngest-skills](https://github.com/inngest/inngest-skills).
+  Use the Claude Code or Codex plugin for the best experience. Each plugin packages Inngest skills with local dev server MCP wiring so your agent can write code and inspect running functions in one loop.
 </Callout>
 
-## Why use agent skills?
+## What to install
 
-Instead of relying on an AI model's training data (which may be outdated or incomplete), agent skills provide:
+| AI tool | Recommended install | What it includes |
+| --- | --- | --- |
+| **Claude Code** | Inngest Claude Code plugin | Seven Inngest skills, MCP config for the local dev server, and an eval harness |
+| **Codex** | Inngest Codex plugin bundle | Seven Codex skills, Codex plugin metadata, MCP config, and local marketplace metadata |
+| **Cursor, Windsurf, and other agents** | Standalone `inngest-skills` repository | The same skill content in a portable format |
+
+## Why use Inngest plugins?
+
+Instead of relying on an AI model's training data, which may be outdated or incomplete, Inngest plugins provide:
 
 - **Current API knowledge** — Accurate function signatures, configuration options, and best practices
 - **Step-by-step guidance** — Structured instructions for common Inngest patterns
-- **Workflow templates** — Proven patterns for background jobs, scheduled tasks, and event-driven workflows
+- **Workflow templates** — Proven patterns for background jobs, scheduled tasks, webhook handlers, and event-driven workflows
+- **Local feedback loops** — MCP access to your running dev server so agents can list functions, send events, and inspect runs
 
-## Installation
+## Install
 
 <CodeGroup>
 
-```bash {{ title: "Skills.sh" }}
-npx skills add inngest/inngest-skills
+```bash {{ title: "Claude Code" }}
+/plugin marketplace add inngest/inngest-claude-code-plugin
+/plugin install inngest@inngest-claude-code-plugin
 ```
 
+```bash {{ title: "Codex" }}
+# From a checkout of the Inngest Codex plugin repository:
+/plugin install /path/to/inngest-codex-plugin/plugins/inngest
+```
 
-```bash {{ title: "Claude Code" }}
-/plugin marketplace add inngest/inngest-skills
-/plugin install inngest-skills@inngest-agent-skills
+```bash {{ title: "Skills.sh" }}
+npx skills add inngest/inngest-skills
 ```
 
 ```text {{ title: "Cursor" }}
@@ -42,7 +55,7 @@ Load the Inngest skills from https://github.com/inngest/inngest-skills for build
 
 </CodeGroup>
 
-For other agents, reference the [repository](https://github.com/inngest/inngest-skills) directly or clone it to your agent's skills directory. Each skill is self-contained with full documentation in its `SKILL.md` file.
+For other agents, reference the [standalone skills repository](https://github.com/inngest/inngest-skills) directly or clone it to your agent's skills directory. Each skill is self-contained with full documentation in its `SKILL.md` file.
 
 ## Available skills
 
@@ -54,10 +67,11 @@ For other agents, reference the [repository](https://github.com/inngest/inngest-
 | **inngest-steps** | Use step methods to build durable workflows | `step.run`, `step.sleep`, `step.waitForEvent`, loops, parallel execution |
 | **inngest-flow-control** | Configure flow control for functions | Concurrency limits, throttling, rate limiting, debounce, priority, batching |
 | **inngest-middleware** | Create middleware for cross-cutting concerns | Middleware lifecycle, dependency injection, built-in middleware |
+| **inngest-realtime** | Stream workflow updates to users | Realtime channels, subscription tokens, React hooks, SSE consumers |
 
 ## Language support
 
-These skills are currently focused on **TypeScript**. Core concepts like events, steps, and flow control apply across all Inngest SDKs, but code examples and setup instructions are TypeScript-specific.
+These plugins and skills are currently focused on **TypeScript**. Core concepts like events, steps, flow control, and realtime updates apply across all Inngest SDKs, but code examples and setup instructions are TypeScript-specific.
 
 For Python or Go, refer to the [Inngest documentation](/docs) and [llms.txt](https://www.inngest.com/llms.txt) for language-specific guidance.
 
@@ -70,15 +84,27 @@ For the best AI development experience, use agent skills alongside the [Inngest 
 
 This enables a complete write, test, and debug loop powered by your coding agent.
 
+## Repositories
+
+The plugin repositories mirror their skills from [`inngest/inngest-skills`](https://github.com/inngest/inngest-skills) so Claude Code, Codex, and portable skills installs stay aligned.
+
 ## Resources
 
-<ResourceGrid cols={2}>
+<ResourceGrid cols={3}>
+
+<Resource resource={{
+  href: "https://github.com/inngest/inngest-claude-code-plugin",
+  name: "Claude Code plugin",
+  icon: ComputerDesktopIcon,
+  description: "Official Inngest plugin for Claude Code with skills and dev-server MCP wiring.",
+  pattern: 1,
+}}/>
 
 <Resource resource={{
   href: "https://github.com/inngest/inngest-skills",
   name: "inngest-skills on GitHub",
   icon: CodeBracketIcon,
-  description: "Source code, installation instructions, and contribution guide.",
+  description: "Portable skills source of truth for coding agents that support skill directories.",
   pattern: 1,
 }}/>
 

--- a/pages/docs/ai-dev-tools/agent-skills.mdx
+++ b/pages/docs/ai-dev-tools/agent-skills.mdx
@@ -18,8 +18,8 @@ Inngest provides official plugins and [agent skills](https://agentskills.io) for
 | AI tool | Recommended install | What it includes |
 | --- | --- | --- |
 | **Claude Code** | Inngest Claude Code plugin | Seven Inngest skills, MCP config for the local dev server, and an eval harness |
-| **Codex** | Inngest Codex plugin bundle | Seven Codex skills, Codex plugin metadata, MCP config, and local marketplace metadata |
-| **Cursor, Windsurf, and other agents** | Standalone `inngest-skills` repository | The same skill content in a portable format |
+| **Codex** | Inngest Codex plugin bundle | 11 Codex skills, Codex plugin metadata, MCP config, copyable examples, local marketplace metadata, and an eval harness |
+| **Cursor, Windsurf, and other agents** | Standalone `inngest-skills` repository | The core skill content in a portable format |
 
 ## Why use Inngest plugins?
 
@@ -28,6 +28,8 @@ Instead of relying on an AI model's training data, which may be outdated or inco
 - **Current API knowledge** — Accurate function signatures, configuration options, and best practices
 - **Step-by-step guidance** — Structured instructions for common Inngest patterns
 - **Workflow templates** — Proven patterns for background jobs, scheduled tasks, webhook handlers, and event-driven workflows
+- **Repository audits** — Agent-first guidance for finding durability gaps before making code changes
+- **Durable agent patterns** — Guidance for AgentKit workflows, tool calls, human approval, realtime progress, and provider flow control
 - **Local feedback loops** — MCP access to your running dev server so agents can list functions, send events, and inspect runs
 
 ## Install
@@ -39,9 +41,11 @@ Instead of relying on an AI model's training data, which may be outdated or inco
 /plugin install inngest@inngest-claude-code-plugin
 ```
 
-```bash {{ title: "Codex" }}
-# From a checkout of the Inngest Codex plugin repository:
-/plugin install /path/to/inngest-codex-plugin/plugins/inngest
+```text {{ title: "Codex" }}
+git clone https://github.com/inngest/inngest-codex-plugin.git
+
+# In Codex:
+/plugin install /absolute/path/to/inngest-codex-plugin/plugins/inngest
 ```
 
 ```bash {{ title: "Skills.sh" }}
@@ -57,7 +61,7 @@ Load the Inngest skills from https://github.com/inngest/inngest-skills for build
 
 For other agents, reference the [standalone skills repository](https://github.com/inngest/inngest-skills) directly or clone it to your agent's skills directory. Each skill is self-contained with full documentation in its `SKILL.md` file.
 
-## Available skills
+## Core skills
 
 | Skill | Description | What it covers |
 | --- | --- | --- |
@@ -68,6 +72,17 @@ For other agents, reference the [standalone skills repository](https://github.co
 | **inngest-flow-control** | Configure flow control for functions | Concurrency limits, throttling, rate limiting, debounce, priority, batching |
 | **inngest-middleware** | Create middleware for cross-cutting concerns | Middleware lifecycle, dependency injection, built-in middleware |
 | **inngest-realtime** | Stream workflow updates to users | Realtime channels, subscription tokens, React hooks, SSE consumers |
+
+## Additional Codex plugin skills
+
+The Codex plugin adds skills that are tuned for repository-scale agent work:
+
+| Skill | Description | What it covers |
+| --- | --- | --- |
+| **inngest-brownfield-audit** | Audit an existing codebase before changing it | Framework detection, existing Inngest usage, webhooks, cron jobs, queues, long-running routes, polling loops, AI agents, and safe first integration slices |
+| **inngest-agents** | Build durable AI agents with Inngest and AgentKit | Model calls, tool calls, human approval, realtime progress, retries, and provider flow control |
+| **inngest-v3-v4-migration** | Upgrade TypeScript SDK v3 projects to v4 | Trigger syntax, typed events, serve options, `step.invoke`, native realtime, local dev mode, and mixed v3/v4 cleanup |
+| **inngest-api** | Operate Inngest through the alpha API CLI | Account, environment, webhook, app sync, function invocation, run, and trace operations |
 
 ## Language support
 
@@ -86,7 +101,7 @@ This enables a complete write, test, and debug loop powered by your coding agent
 
 ## Repositories
 
-The plugin repositories mirror their skills from [`inngest/inngest-skills`](https://github.com/inngest/inngest-skills) so Claude Code, Codex, and portable skills installs stay aligned.
+The plugin repositories share core skills from [`inngest/inngest-skills`](https://github.com/inngest/inngest-skills) so Claude Code, Codex, and portable skills installs stay aligned. The Codex plugin also includes Codex-specific skills, examples, and eval fixtures for agent-first codebase audits and durable agent workflows.
 
 ## Resources
 
@@ -97,6 +112,14 @@ The plugin repositories mirror their skills from [`inngest/inngest-skills`](http
   name: "Claude Code plugin",
   icon: ComputerDesktopIcon,
   description: "Official Inngest plugin for Claude Code with skills and dev-server MCP wiring.",
+  pattern: 1,
+}}/>
+
+<Resource resource={{
+  href: "https://github.com/inngest/inngest-codex-plugin",
+  name: "Codex plugin",
+  icon: ComputerDesktopIcon,
+  description: "Official Inngest plugin for Codex with skills, examples, evals, and dev-server MCP wiring.",
   pattern: 1,
 }}/>
 

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -71,11 +71,11 @@ Write functions in TypeScript, Python or Go to power background and scheduled jo
 <CardGroup cols={3}>
   <Card
     href={"/docs/ai-dev-tools/agent-skills"}
-    title={"Agent Skills"}
+    title={"Agent Plugins and Skills"}
     icon={<SkillsMDIcon square={false} className="text-basis h-16 w-32"/>}
     iconPlacement="top"
   >
-    Pre-built skills that teach coding agents how to write, test, and debug Inngest functions.
+    Official plugins and skills that teach coding agents how to write, test, and debug Inngest functions.
   </Card>
 
   <Card

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -1159,6 +1159,10 @@ const sectionLearn: (NavGroup | NavLink)[] = [
     title: "AI",
     links: [
       {
+        title: "Agent Plugins and Skills",
+        href: "/docs/ai-dev-tools/agent-skills",
+      },
+      {
         title: "Dev Server MCP",
         href: "/docs/ai-dev-tools/mcp",
       },


### PR DESCRIPTION
## Summary

- Renames the Agent Skills docs page to "AI Coding Agent Plugins and Skills"
- Adds Claude Code, Codex, and standalone skills install guidance based on the plugin repos
- Updates the Codex plugin copy for the now-public `inngest/inngest-codex-plugin` repo, 11 Codex skills, copyable examples, brownfield audits, durable agents, v3-to-v4 migration, and API CLI coverage
- Adds `inngest-realtime` to the core available skills table and adds a Codex-specific skills table
- Adds a Codex plugin resource card
- Surfaces the page in the AI docs nav and updates the docs homepage card copy

## Validation

- `./node_modules/.bin/prettier --check pages/docs/ai-dev-tools/agent-skills.mdx pages/docs/index.mdx shared/Docs/navigationStructure.ts`
- `git diff --check`
- Local render previously verified at `/docs/ai-dev-tools/agent-skills`

## Notes

- `./node_modules/.bin/next build` currently fails before compiling this page because of an existing redirect config issue: `destination` is missing for route `{ "source": "/sign-up", "permanent": true }`.
