### PR TITLE
Add Branch vs Custom Environments concept page

### DIFF
--- a/pages/docs/platform/branch-vs-custom-environments.mdx
+++ b/pages/docs/platform/branch-vs-custom-environments.mdx
@@ -1,0 +1,61 @@
+import { Callout } from "src/shared/Docs/mdx";
+
+export const description = "Understand the difference between Branch Environments and Custom Environments in Inngest."
+
+# Branch vs Custom Environments
+
+Inngest has two types of non-production environments. They serve different purposes and behave differently. Confusing them is one of the most common setup issues.
+
+---
+
+## Branch Environments
+
+Branch environments are created automatically when you deploy a branch to your hosting provider (like Vercel preview deployments). Each git branch gets its own isolated Inngest environment with its own functions, events, and runs.
+
+Branch environments are temporary. They're tied to the lifecycle of your git branch and Vercel preview deployment.
+
+When you use the [Vercel integration](/docs/deploy/vercel), branch environments are created and synced automatically on every push. No manual setup required.
+
+<Callout variant="info">
+  Branch environments use the same signing key as your production environment. The Vercel integration handles this automatically.
+</Callout>
+
+---
+
+## Custom Environments
+
+Custom environments are manually created in the [Inngest dashboard](/docs/platform/environments#custom-environments). They're for persistent, named environments like staging, QA, or testing.
+
+Custom environments have their own signing keys and event keys. You set these as environment variables in your hosting provider.
+
+Custom environments are permanent. They persist until you delete them.
+
+---
+
+## The common mistake
+
+Your preview deployments target a Custom Environment instead of Branch Environments. This happens when your `INNGEST_SIGNING_KEY` environment variable in Vercel's preview/development settings points to a custom environment's signing key instead of letting the Vercel integration handle it automatically.
+
+**Symptoms:**
+
+Functions from your preview branches appear in a custom environment (like "staging") instead of creating their own branch environment. Multiple branches overwrite each other's functions in the same environment.
+
+**Fix:**
+
+Remove any manually set `INNGEST_SIGNING_KEY` from Vercel's preview environment variable settings. Let the Vercel integration manage the keys for preview deployments. Only set keys manually for custom environments you've explicitly created.
+
+---
+
+## When to use which
+
+Use **Branch Environments** for PR previews and feature branch testing. These are automatic and ephemeral.
+
+Use **Custom Environments** for persistent non-production environments like staging, QA, or load testing. These require manual key setup but give you a stable, long-lived environment.
+
+---
+
+## Related
+
+- [Environments overview](/docs/platform/environments)
+- [Vercel deployment guide](/docs/deploy/vercel)
+- [Setting up a staging environment](/docs/deploy/vercel#setting-up-a-staging-environment)

--- a/pages/docs/platform/branch-vs-custom-environments.mdx
+++ b/pages/docs/platform/branch-vs-custom-environments.mdx
@@ -2,55 +2,47 @@ import { Callout } from "src/shared/Docs/mdx";
 
 export const description = "Understand the difference between Branch Environments and Custom Environments in Inngest."
 
-# Branch vs Custom Environments
+# Branch Environments vs Custom Environments
 
-Inngest has two types of non-production environments. They serve different purposes and behave differently. Confusing them is one of the most common setup issues.
+Inngest has two types of non-production environments. They serve different purposes and behave differently.
 
 ---
 
 ## Branch Environments
 
-Branch environments are created automatically when you deploy a branch to your hosting provider (like Vercel preview deployments). Each git branch gets its own isolated Inngest environment with its own functions, events, and runs.
+Branch environments are automatic and temporary. When you deploy a branch to your hosting provider, Inngest creates an isolated environment for that branch with its own functions, events, and runs.
 
-Branch environments are temporary. They're tied to the lifecycle of your git branch and Vercel preview deployment.
+The [Vercel integration](/docs/deploy/vercel) handles this on every push. No manual setup required.
 
-When you use the [Vercel integration](/docs/deploy/vercel), branch environments are created and synced automatically on every push. No manual setup required.
-
-<Callout variant="info">
-  Branch environments use the same signing key as your production environment. The Vercel integration handles this automatically.
-</Callout>
+Branch environments share the production signing key. The integration manages this for you. When the branch is deleted or the preview deployment expires, the environment goes away.
 
 ---
 
 ## Custom Environments
 
-Custom environments are manually created in the [Inngest dashboard](/docs/platform/environments#custom-environments). They're for persistent, named environments like staging, QA, or testing.
+Custom environments are manual and permanent. You create them in the [Inngest dashboard](/docs/platform/environments#custom-environments) for persistent non-production use: staging, QA, load testing.
 
-Custom environments have their own signing keys and event keys. You set these as environment variables in your hosting provider.
-
-Custom environments are permanent. They persist until you delete them.
+Each custom environment has its own signing key and event key. You set these as environment variables in your hosting provider. The environment persists until you delete it.
 
 ---
 
-## The common mistake
+## How they differ
 
-Your preview deployments target a Custom Environment instead of Branch Environments. This happens when your `INNGEST_SIGNING_KEY` environment variable in Vercel's preview/development settings points to a custom environment's signing key instead of letting the Vercel integration handle it automatically.
+Branch environments exist for the lifecycle of a git branch. Custom environments exist until you remove them.
 
-**Symptoms:**
+Branch environments inherit the production signing key. Custom environments have their own keys.
 
-Functions from your preview branches appear in a custom environment (like "staging") instead of creating their own branch environment. Multiple branches overwrite each other's functions in the same environment.
-
-**Fix:**
-
-Remove any manually set `INNGEST_SIGNING_KEY` from Vercel's preview environment variable settings. Let the Vercel integration manage the keys for preview deployments. Only set keys manually for custom environments you've explicitly created.
+Branch environments are created automatically by the Vercel integration. Custom environments require manual setup in the dashboard and manual key configuration in your hosting provider.
 
 ---
 
-## When to use which
+## A common source of confusion
 
-Use **Branch Environments** for PR previews and feature branch testing. These are automatic and ephemeral.
+Preview deployments can accidentally target a custom environment instead of creating branch environments. This happens when `INNGEST_SIGNING_KEY` in your Vercel preview settings points to a custom environment's key instead of letting the integration manage it.
 
-Use **Custom Environments** for persistent non-production environments like staging, QA, or load testing. These require manual key setup but give you a stable, long-lived environment.
+The result: functions from multiple branches overwrite each other in the same custom environment. Each branch should have its own isolated environment, but they all land in one.
+
+For the fix, see [Vercel integration troubleshooting](/docs/deploy/vercel-troubleshooting).
 
 ---
 
@@ -58,4 +50,4 @@ Use **Custom Environments** for persistent non-production environments like stag
 
 - [Environments overview](/docs/platform/environments)
 - [Vercel deployment guide](/docs/deploy/vercel)
-- [Setting up a staging environment](/docs/deploy/vercel#setting-up-a-staging-environment)
+- [Vercel integration troubleshooting](/docs/deploy/vercel-troubleshooting)


### PR DESCRIPTION
## Summary

Concept page explaining the difference between Branch Environments and Custom Environments. Confusing the two is one of the most common setup issues from support.

Covers: what each type is, the common mistake (preview deployments targeting a custom env instead of branch envs), when to use which.

Source: Dan's support inbox scan (T-7550). Support team's reply was near-verbatim the article.

Resolves DEV-338