### PR TITLE
Send canonical URL header for markdown pages

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -91,10 +91,16 @@ export function middleware(req: NextRequest) {
   const res = NextResponse.next({ request: { headers: requestHeaders } });
   res.headers.set("Vary", "Accept");
 
-  // Canonical: always the clean pathname with no query params.
+  // Canonical: always the clean pathname with no query params. For the
+  // markdown mirrors (/docs-markdown, /blog-markdown), canonicalize to the
+  // corresponding HTML page so crawlers don't index the raw markdown as a
+  // duplicate.
+  const canonicalPathname = pathname
+    .replace(/^\/docs-markdown(\/|$)/, "/docs$1")
+    .replace(/^\/blog-markdown(\/|$)/, "/blog$1");
   res.headers.set(
     "Link",
-    `<${SITE_ORIGIN}${pathname}>; rel="canonical"`
+    `<${SITE_ORIGIN}${canonicalPathname}>; rel="canonical"`
   );
 
   // Markdown alternate link for blog/docs so agents can discover raw content.


### PR DESCRIPTION
Build on #1621 to ensure that all markdown pages, which are duplictes have canonicals.