### PR TITLE
Optimize image for resource popover

### DIFF
--- a/components/RedesignedLanding/Header/ResourcePopover.tsx
+++ b/components/RedesignedLanding/Header/ResourcePopover.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChevronDownIcon } from "@heroicons/react/20/solid";
+import Image from "next/image";
 import Link from "next/link";
 import { useState, useRef } from "react";
 import {
@@ -173,10 +174,15 @@ export default function ResourcePopover() {
                       <div className="flex w-full flex-col">
                         <div className="aspect-[2/1] w-full overflow-hidden rounded-md bg-stone-800">
                           <div className="flex h-full w-full items-center justify-center">
-                            <img
-                              alt=""
-                              src={featuredBlogPost.image}
+                            {/* <img alt="" src={featuredBlogPost.image} /> */}
+                            <Image
                               className="max-h-full max-w-full object-contain object-center"
+                              src={featuredBlogPost.image}
+                              alt={`Featured image for ${featuredBlogPost.title}`}
+                              width={372}
+                              height={198}
+                              quality={85}
+                              // loading="eager"
                             />
                           </div>
                         </div>

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -154,7 +154,8 @@ export default function BlogLayout(props) {
       url: process.env.NEXT_PUBLIC_HOST,
     },
     ...((scope as any).category && { articleSection: (scope as any).category }),
-    ...(scope.tags && scope.tags.length > 0 && { keywords: scope.tags.join(", ") }),
+    ...(scope.tags &&
+      scope.tags.length > 0 && { keywords: scope.tags.join(", ") }),
     author:
       structuredDataAuthors.length > 0
         ? structuredDataAuthors
@@ -239,7 +240,7 @@ export default function BlogLayout(props) {
               {scope.image && (
                 <figure className="mx-auto flex max-w-[768px] flex-col items-end">
                   <Image
-                    className="rounded-lg shadow-lg"
+                    className="rounded-lg"
                     src={scope.image}
                     alt={`Featured image for ${scope.heading} blog post`}
                     width={768}


### PR DESCRIPTION
Previously, the popover was loading a 1MB image. This uses the image optimization URLs