### PR TITLE
Publish 2026 AI in Production benchmark report as a "blog."

### DIFF
--- a/app/content/ai-in-production-report-2026/graphs.ts
+++ b/app/content/ai-in-production-report-2026/graphs.ts
@@ -5,6 +5,10 @@ export type ReportGraph = {
   shareText: string;
 };
 
+/** Native dimensions of OG share-card chart PNGs — used for next/image. */
+export const REPORT_GRAPH_WIDTH = 3600;
+export const REPORT_GRAPH_HEIGHT = 1890;
+
 export const REPORT_PATH =
   "/assets/reports/2026-benchmark/2026-durable-execution-benchmark-report.pdf";
 

--- a/app/content/ai-in-production-report-2026/page.tsx
+++ b/app/content/ai-in-production-report-2026/page.tsx
@@ -24,6 +24,9 @@ export const metadata: Metadata = {
     image: "/assets/reports/2026-benchmark/og/landing.png",
   }),
   robots: { index: false, follow: false },
+  alternates: {
+    canonical: "https://www.inngest.com/blog/ai-in-production-report-2026",
+  },
 };
 
 const KEY_FINDINGS = [

--- a/app/content/ai-in-production-report-2026/page.tsx
+++ b/app/content/ai-in-production-report-2026/page.tsx
@@ -17,11 +17,14 @@ const PAGE_TITLE = "AI in Production: The 2026 Benchmark Report";
 const PAGE_DESCRIPTION =
   "We surveyed 130 backend, full-stack, and AI engineers about what it takes to run reliable AI workflows in production. Explore the patterns that predict scaling confidence.";
 
-export const metadata: Metadata = buildMetadata({
-  title: PAGE_TITLE,
-  description: PAGE_DESCRIPTION,
-  image: "/assets/reports/2026-benchmark/og/landing.png",
-});
+export const metadata: Metadata = {
+  ...buildMetadata({
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    image: "/assets/reports/2026-benchmark/og/landing.png",
+  }),
+  robots: { index: false, follow: false },
+};
 
 const KEY_FINDINGS = [
   {

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -38,7 +38,7 @@ const Banner: React.FC<Props> = ({ href, children, className }) => (
 
 export default function AnnouncementBanner() {
   return (
-    <Banner href="https://www.inngest.com/content/ai-in-production-report-2026?ref=site-banner">
+    <Banner href="/blog/ai-in-production-report-2026?ref=site-banner">
       What are the most confident teams using to build AI? →{" "}
       <strong className="underline underline-offset-2">
         2026 Benchmark Report

--- a/components/Blog/Report/ReportChart.tsx
+++ b/components/Blog/Report/ReportChart.tsx
@@ -1,0 +1,80 @@
+import {
+  RiDownload2Line,
+  RiFilePdf2Line,
+  RiLinkedinBoxFill,
+  RiTwitterXFill,
+} from "@remixicon/react";
+import {
+  getReportGraph,
+  REPORT_LANDING_PATH,
+  REPORT_PATH,
+  type ReportGraphId,
+} from "app/content/ai-in-production-report-2026/graphs";
+import { getFullURL } from "src/utils/social";
+import { REPORT_COLUMN_BLEED } from "./constants";
+
+type Props = {
+  graphId: ReportGraphId;
+  /** Tighter vertical rhythm when charts stack as a set */
+  tight?: boolean;
+};
+
+export function ReportChart({ graphId, tight = false }: Props) {
+  const graph = getReportGraph(graphId);
+  if (!graph) return null;
+
+  const shareUrl = getFullURL(`${REPORT_LANDING_PATH}/share/${graphId}`);
+  const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(graph.shareText)}&url=${encodeURIComponent(shareUrl)}`;
+  const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`;
+  const downloadUrl = `/api/report-graph-download/${graphId}`;
+
+  return (
+    <figure
+      className={`${REPORT_COLUMN_BLEED} not-prose ${tight ? "my-6" : "my-10"}`}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={graph.image}
+        alt={graph.title}
+        loading="lazy"
+        decoding="async"
+        className="block h-auto w-full max-w-full rounded-lg"
+      />
+      <figcaption className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-white/10 pt-3">
+        <span className="sr-only">Share or download this chart</span>
+        <a
+          href={tweetUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-sm text-subtle transition-colors hover:text-basis"
+        >
+          <RiTwitterXFill className="h-4 w-4" aria-hidden="true" />
+          Post to X
+        </a>
+        <a
+          href={linkedInUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-sm text-subtle transition-colors hover:text-basis"
+        >
+          <RiLinkedinBoxFill className="h-4 w-4" aria-hidden="true" />
+          Post to LinkedIn
+        </a>
+        <a
+          href={downloadUrl}
+          className="inline-flex items-center gap-1.5 text-sm text-subtle transition-colors hover:text-basis"
+        >
+          <RiDownload2Line className="h-4 w-4" aria-hidden="true" />
+          Download image
+        </a>
+        <a
+          href={REPORT_PATH}
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--color-matcha-400))] transition-colors hover:text-[rgb(var(--color-matcha-300))]"
+        >
+          <RiFilePdf2Line className="h-4 w-4" aria-hidden="true" />
+          See PDF for full breakdown
+        </a>
+      </figcaption>
+    </figure>
+  );
+}

--- a/components/Blog/Report/ReportChart.tsx
+++ b/components/Blog/Report/ReportChart.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import {
   RiDownload2Line,
   RiFilePdf2Line,
@@ -6,18 +7,26 @@ import {
 } from "@remixicon/react";
 import {
   getReportGraph,
+  REPORT_GRAPH_HEIGHT,
+  REPORT_GRAPH_WIDTH,
   REPORT_LANDING_PATH,
   REPORT_PATH,
   type ReportGraphId,
 } from "app/content/ai-in-production-report-2026/graphs";
 import { getFullURL } from "src/utils/social";
-import { REPORT_COLUMN_BLEED } from "./constants";
 
 type Props = {
   graphId: ReportGraphId;
   /** Tighter vertical rhythm when charts stack as a set */
   tight?: boolean;
 };
+
+/** Display width cap — matches `.report-prose` (75ch). Native PNG is 3600px. */
+const CHART_DISPLAY_WIDTH = 1200;
+const CHART_DISPLAY_HEIGHT = Math.round(
+  (CHART_DISPLAY_WIDTH * REPORT_GRAPH_HEIGHT) / REPORT_GRAPH_WIDTH
+);
+const CHART_SIZES = "(min-width: 768px) 75ch, 100vw";
 
 export function ReportChart({ graphId, tight = false }: Props) {
   const graph = getReportGraph(graphId);
@@ -30,15 +39,19 @@ export function ReportChart({ graphId, tight = false }: Props) {
 
   return (
     <figure
-      className={`${REPORT_COLUMN_BLEED} not-prose ${tight ? "my-6" : "my-10"}`}
+      className={`report-chart not-prose ${tight ? "my-6" : "my-10"}`}
+      style={{ maxWidth: "75ch", width: "100%" }}
     >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
+      <Image
         src={graph.image}
         alt={graph.title}
+        width={CHART_DISPLAY_WIDTH}
+        height={CHART_DISPLAY_HEIGHT}
+        sizes={CHART_SIZES}
+        quality={75}
         loading="lazy"
-        decoding="async"
-        className="block h-auto w-full max-w-full rounded-lg"
+        className="h-auto w-full rounded-lg"
+        style={{ width: "100%", height: "auto" }}
       />
       <figcaption className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-white/10 pt-3">
         <span className="sr-only">Share or download this chart</span>

--- a/components/Blog/Report/ReportExecSummary.tsx
+++ b/components/Blog/Report/ReportExecSummary.tsx
@@ -1,4 +1,4 @@
-import { REPORT_COLUMN_BLEED } from "./constants";
+import { REPORT_FULL_BLEED } from "./constants";
 
 type Finding = {
   number: number;
@@ -14,7 +14,7 @@ type Props = {
 
 export function ReportExecSummary({ id = "executive-summary", intro, findings }: Props) {
   return (
-    <div id={id} className={`${REPORT_COLUMN_BLEED} scroll-mt-28 mb-14`}>
+    <div id={id} className={`${REPORT_FULL_BLEED} scroll-mt-28 mb-14`}>
       <div className="grid md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
         {/* Sidebar label — mirrors PDF left column */}
         <div

--- a/components/Blog/Report/ReportExecSummary.tsx
+++ b/components/Blog/Report/ReportExecSummary.tsx
@@ -45,7 +45,7 @@ export function ReportExecSummary({ id = "executive-summary", intro, findings }:
           </p>
           <ol className="mt-6 flex flex-col gap-8">
             {findings.map((finding) => (
-              <li key={finding.number} className="flex items-start gap-5">
+              <li key={finding.number} className="flex gap-5">
                 <span
                   className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full font-whyteInktrap text-lg font-bold text-[#0c1f10]"
                   style={{ backgroundColor: "#a8ef3c" }}

--- a/components/Blog/Report/ReportExecSummary.tsx
+++ b/components/Blog/Report/ReportExecSummary.tsx
@@ -45,7 +45,7 @@ export function ReportExecSummary({ id = "executive-summary", intro, findings }:
           </p>
           <ol className="mt-6 flex flex-col gap-8">
             {findings.map((finding) => (
-              <li key={finding.number} className="flex gap-5">
+              <li key={finding.number} className="flex items-start gap-5">
                 <span
                   className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full font-whyteInktrap text-lg font-bold text-[#0c1f10]"
                   style={{ backgroundColor: "#a8ef3c" }}

--- a/components/Blog/Report/ReportExecSummary.tsx
+++ b/components/Blog/Report/ReportExecSummary.tsx
@@ -1,0 +1,68 @@
+import { REPORT_COLUMN_BLEED } from "./constants";
+
+type Finding = {
+  number: number;
+  title: string;
+  body: string;
+};
+
+type Props = {
+  id?: string;
+  intro: string;
+  findings: Finding[];
+};
+
+export function ReportExecSummary({ id = "executive-summary", intro, findings }: Props) {
+  return (
+    <div id={id} className={`${REPORT_COLUMN_BLEED} scroll-mt-28 mb-14`}>
+      <div className="grid md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+        {/* Sidebar label — mirrors PDF left column */}
+        <div
+          className="flex items-center justify-center px-6 py-10 md:min-h-[320px] md:py-16"
+          style={{
+            background:
+              "linear-gradient(180deg, #3a3a3a 0%, #212121 50%, #1a1a1a 100%)",
+          }}
+        >
+          <p className="font-whyteInktrap text-2xl font-black uppercase leading-tight tracking-tight text-white md:text-3xl lg:text-4xl">
+            Executive
+            <br />
+            Summary
+          </p>
+        </div>
+
+        {/* Body */}
+        <div className="bg-black px-6 py-10 md:px-10 md:py-14">
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-[rgb(var(--color-matcha-400))]">
+            Executive summary
+          </p>
+          <p className="mt-4 text-base leading-relaxed text-subtle md:text-lg">
+            {intro}
+          </p>
+
+          <p className="mt-8 font-mono text-xs uppercase tracking-[0.2em] text-white/50">
+            Three key findings
+          </p>
+          <ol className="mt-6 flex flex-col gap-8">
+            {findings.map((finding) => (
+              <li key={finding.number} className="flex gap-5">
+                <span
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full font-whyteInktrap text-lg font-bold text-[#0c1f10]"
+                  style={{ backgroundColor: "#a8ef3c" }}
+                >
+                  {finding.number}
+                </span>
+                <div>
+                  <p className="font-semibold text-basis">{finding.title}</p>
+                  <p className="mt-2 text-sm leading-relaxed text-subtle md:text-base">
+                    {finding.body}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Blog/Report/ReportHero.tsx
+++ b/components/Blog/Report/ReportHero.tsx
@@ -24,7 +24,7 @@ export function ReportHero({ author, date, readingTime }: Props = {}) {
         aria-hidden
         fill
         sizes="100vw"
-        quality={75}
+        quality={40}
         priority
         className="pointer-events-none object-cover opacity-[0.12] mix-blend-soft-light"
       />

--- a/components/Blog/Report/ReportHero.tsx
+++ b/components/Blog/Report/ReportHero.tsx
@@ -1,0 +1,114 @@
+import Link from "next/link";
+import Logo from "src/shared/Icons/Logo";
+import { REPORT_COLUMN_BLEED, REPORT_LOGOS } from "./constants";
+
+type Props = {
+  author?: string[];
+  date?: string;
+  readingTime?: string;
+};
+
+export function ReportHero({ author, date, readingTime }: Props = {}) {
+  return (
+    <div
+      className={`${REPORT_COLUMN_BLEED} relative mb-14 overflow-hidden rounded-lg`}
+      style={{
+        background:
+          "linear-gradient(145deg, #FB5536 0%, #e84a2e 35%, #d43d24 70%, #c23520 100%)",
+      }}
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-[0.12]"
+        style={{
+          backgroundImage: "url('/assets/report-assets/report_texture.png')",
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          mixBlendMode: "soft-light",
+        }}
+      />
+
+      <div className="relative mx-auto max-w-5xl px-6 py-12 md:px-10 md:py-16 lg:py-20">
+        <Link
+          href="/"
+          className="mb-10 inline-block transition-opacity hover:opacity-70"
+          aria-label="Inngest homepage"
+        >
+          <Logo width={120} fill="#ffffff" />
+        </Link>
+
+        <div className="max-w-3xl">
+          <p className="font-mono text-xs uppercase tracking-[0.25em] text-white/80">
+            Benchmark report · 2026
+          </p>
+          <h2 className="mt-4 font-whyteInktrap text-4xl font-black leading-[1.05] text-white sm:text-5xl md:text-6xl">
+            AI in Production:
+            <br />
+            The 2026 Benchmark Report
+          </h2>
+          <p className="mt-6 max-w-2xl text-base leading-relaxed text-white/90 md:text-lg">
+            We surveyed 130 backend, full-stack, and AI engineers about what it
+            takes to run reliable AI workflows in production—and which
+            infrastructure choices actually reduce the burden of reliability.
+          </p>
+          <p className="mt-4">
+            <a
+              href="/assets/reports/2026-benchmark/2026-durable-execution-benchmark-report.pdf"
+              className="inline-flex items-center gap-2 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-[#c23520] transition hover:bg-white/90"
+            >
+              Download PDF
+            </a>
+          </p>
+        </div>
+
+        <div className="mt-14 border-t border-white/20 pt-10">
+          <p className="mb-6 font-mono text-xs uppercase tracking-[0.2em] text-white/70">
+            With participation from engineers at
+          </p>
+          <div className="grid grid-cols-3 items-center justify-items-center gap-x-8 gap-y-6 sm:grid-cols-5">
+            {REPORT_LOGOS.map((logo) => (
+              <div
+                key={logo.name}
+                className={`flex items-center justify-center${logo.name === "Remitly" ? " hidden sm:flex" : ""}`}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={logo.src}
+                  alt={logo.name}
+                  style={{
+                    maxHeight: logo.h,
+                    maxWidth: "100%",
+                    height: "auto",
+                    width: "auto",
+                    display: "block",
+                    filter: "brightness(0) invert(1)",
+                    opacity: 0.95,
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {(author?.length || date || readingTime) && (
+          <p className="mt-10 flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-white/20 pt-8 text-sm text-white/70">
+            {author?.map((name, idx) => (
+              <span key={name}>
+                {name}
+                {idx < author.length - 1 ? ", " : ""}
+              </span>
+            ))}
+            {author?.length && date && <span>·</span>}
+            {date && <span>{date}</span>}
+            {readingTime && (
+              <>
+                <span>·</span>
+                <span>{readingTime}</span>
+              </>
+            )}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/Blog/Report/ReportHero.tsx
+++ b/components/Blog/Report/ReportHero.tsx
@@ -1,6 +1,7 @@
+import Image from "next/image";
 import Link from "next/link";
 import Logo from "src/shared/Icons/Logo";
-import { REPORT_COLUMN_BLEED, REPORT_LOGOS } from "./constants";
+import { REPORT_FULL_BLEED, REPORT_LOGOS, REPORT_TEXTURE } from "./constants";
 
 type Props = {
   author?: string[];
@@ -11,21 +12,21 @@ type Props = {
 export function ReportHero({ author, date, readingTime }: Props = {}) {
   return (
     <div
-      className={`${REPORT_COLUMN_BLEED} relative mb-14 overflow-hidden rounded-lg`}
+      className={`${REPORT_FULL_BLEED} relative mb-14 overflow-hidden rounded-lg`}
       style={{
         background:
           "linear-gradient(145deg, #FB5536 0%, #e84a2e 35%, #d43d24 70%, #c23520 100%)",
       }}
     >
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-[0.12]"
-        style={{
-          backgroundImage: "url('/assets/report-assets/report_texture.png')",
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-          mixBlendMode: "soft-light",
-        }}
+      <Image
+        src={REPORT_TEXTURE}
+        alt=""
+        aria-hidden
+        fill
+        sizes="100vw"
+        quality={75}
+        priority
+        className="pointer-events-none object-cover opacity-[0.12] mix-blend-soft-light"
       />
 
       <div className="relative mx-auto max-w-5xl px-6 py-12 md:px-10 md:py-16 lg:py-20">
@@ -71,19 +72,13 @@ export function ReportHero({ author, date, readingTime }: Props = {}) {
                 key={logo.name}
                 className={`flex items-center justify-center${logo.name === "Remitly" ? " hidden sm:flex" : ""}`}
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
+                <Image
                   src={logo.src}
                   alt={logo.name}
-                  style={{
-                    maxHeight: logo.h,
-                    maxWidth: "100%",
-                    height: "auto",
-                    width: "auto",
-                    display: "block",
-                    filter: "brightness(0) invert(1)",
-                    opacity: 0.95,
-                  }}
+                  width={logo.width}
+                  height={logo.height}
+                  className="block h-auto w-auto max-w-full opacity-95 brightness-0 invert"
+                  style={{ maxHeight: logo.h }}
                 />
               </div>
             ))}

--- a/components/Blog/Report/ReportLayoutShell.tsx
+++ b/components/Blog/Report/ReportLayoutShell.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  toc: ReactNode;
+  children: ReactNode;
+};
+
+/**
+ * Two-column report layout: dedicated left rail for the TOC, content on the right.
+ * The aside column is reserved for the full scroll height so nothing overlaps the nav.
+ */
+export function ReportLayoutShell({ toc, children }: Props) {
+  return (
+    <div className="xl:grid xl:grid-cols-[13rem_minmax(0,1fr)] xl:gap-x-10 2xl:gap-x-12">
+      <aside
+        aria-label="Report navigation"
+        className="relative hidden xl:block border-r border-white/[0.06] pr-8"
+      >
+        {/* Aside stretches to full row height; inner wrapper sticks while scrolling. */}
+        <div className="sticky top-28 z-20 max-h-[calc(100vh-7rem)] overflow-y-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {toc}
+        </div>
+      </aside>
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}

--- a/components/Blog/Report/ReportSectionBreak.tsx
+++ b/components/Blog/Report/ReportSectionBreak.tsx
@@ -81,7 +81,7 @@ export function ReportSectionBreak({
           aria-hidden
           fill
           sizes="(min-width: 1280px) 900px, 100vw"
-          quality={75}
+          quality={40}
           className="pointer-events-none object-cover opacity-[0.12] mix-blend-soft-light"
         />
       )}

--- a/components/Blog/Report/ReportSectionBreak.tsx
+++ b/components/Blog/Report/ReportSectionBreak.tsx
@@ -1,4 +1,5 @@
-import { REPORT_COLUMN_BLEED } from "./constants";
+import Image from "next/image";
+import { REPORT_FULL_BLEED, REPORT_SHAPE, REPORT_TEXTURE } from "./constants";
 
 type Stat = {
   value: string;
@@ -61,29 +62,27 @@ export function ReportSectionBreak({
   return (
     <div
       id={id}
-      className={`${REPORT_COLUMN_BLEED} relative my-14 scroll-mt-28 overflow-hidden rounded-lg`}
+      className={`${REPORT_FULL_BLEED} relative my-14 scroll-mt-28 overflow-hidden rounded-lg`}
       style={{ background: theme.background }}
     >
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-[0.08]"
-        style={{
-          backgroundImage: "url('/assets/report-assets/report_shape.png')",
-          backgroundSize: "contain",
-          backgroundPosition: "left top",
-          backgroundRepeat: "no-repeat",
-        }}
+      <Image
+        src={REPORT_SHAPE}
+        alt=""
+        aria-hidden
+        fill
+        sizes="(min-width: 1280px) 900px, 100vw"
+        quality={75}
+        className="pointer-events-none object-contain object-left-top opacity-[0.08]"
       />
       {variant === "blue" && (
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-0 opacity-[0.12]"
-          style={{
-            backgroundImage: "url('/assets/report-assets/report_texture.png')",
-            backgroundSize: "cover",
-            backgroundPosition: "center",
-            mixBlendMode: "soft-light",
-          }}
+        <Image
+          src={REPORT_TEXTURE}
+          alt=""
+          aria-hidden
+          fill
+          sizes="(min-width: 1280px) 900px, 100vw"
+          quality={75}
+          className="pointer-events-none object-cover opacity-[0.12] mix-blend-soft-light"
         />
       )}
 

--- a/components/Blog/Report/ReportSectionBreak.tsx
+++ b/components/Blog/Report/ReportSectionBreak.tsx
@@ -1,0 +1,186 @@
+import { REPORT_COLUMN_BLEED } from "./constants";
+
+type Stat = {
+  value: string;
+  label: string;
+};
+
+type StatGroup = {
+  intro: string;
+  stats: Stat[];
+};
+
+type Props = {
+  id: string;
+  section: number;
+  title: string;
+  /** Lead-in copy before headline stats (section 5 in the PDF). */
+  intro?: string;
+  /** Single headline stats (sections 1–3, 5–6). */
+  stats?: Stat[];
+  /** Paired comparison blocks (section 4 in the PDF). */
+  statGroups?: StatGroup[];
+  variant?: "green" | "orange" | "blue";
+};
+
+const VARIANTS = {
+  green: {
+    background:
+      "linear-gradient(135deg, #2C9B63 0%, #79D617 22%, #a8ef3c 50%, #79D617 78%, #2C9B63 100%)",
+    text: "#0c1f10",
+    divider: "rgba(12, 31, 16, 0.25)",
+    label: "rgba(12, 31, 16, 0.65)",
+  },
+  orange: {
+    background:
+      "linear-gradient(145deg, #FB5536 0%, #e84a2e 50%, #d43d24 100%)",
+    text: "#ffffff",
+    divider: "rgba(255, 255, 255, 0.25)",
+    label: "rgba(255, 255, 255, 0.85)",
+  },
+  blue: {
+    background:
+      "linear-gradient(135deg, #0b44bd 0%, #1364D6 38%, #1e73cf 68%, #2d7ede 100%)",
+    text: "#ffffff",
+    divider: "rgba(255, 255, 255, 0.3)",
+    label: "rgba(255, 255, 255, 0.92)",
+  },
+} as const;
+
+export function ReportSectionBreak({
+  id,
+  section,
+  title,
+  intro,
+  stats = [],
+  statGroups,
+  variant = "green",
+}: Props) {
+  const theme = VARIANTS[variant];
+
+  return (
+    <div
+      id={id}
+      className={`${REPORT_COLUMN_BLEED} relative my-14 scroll-mt-28 overflow-hidden rounded-lg`}
+      style={{ background: theme.background }}
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-[0.08]"
+        style={{
+          backgroundImage: "url('/assets/report-assets/report_shape.png')",
+          backgroundSize: "contain",
+          backgroundPosition: "left top",
+          backgroundRepeat: "no-repeat",
+        }}
+      />
+      {variant === "blue" && (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 opacity-[0.12]"
+          style={{
+            backgroundImage: "url('/assets/report-assets/report_texture.png')",
+            backgroundSize: "cover",
+            backgroundPosition: "center",
+            mixBlendMode: "soft-light",
+          }}
+        />
+      )}
+
+      <div className="relative mx-auto max-w-5xl px-6 py-12 md:px-10 md:py-16">
+        <p
+          className="font-mono text-xs uppercase tracking-[0.25em]"
+          style={{ color: theme.label }}
+        >
+          Section {section}
+        </p>
+        <h2
+          className="mt-3 max-w-4xl font-whyteInktrap text-3xl font-black uppercase leading-tight tracking-tight md:text-4xl lg:text-5xl"
+          style={{ color: theme.text }}
+        >
+          {title}
+        </h2>
+
+        <div
+          className="my-8 h-px w-full max-w-2xl"
+          style={{ backgroundColor: theme.divider }}
+        />
+
+        {statGroups ? (
+          <div className="flex max-w-4xl flex-col gap-10">
+            {statGroups.map((group, i) => (
+              <div key={i}>
+                {i > 0 && (
+                  <div
+                    className="mb-10 h-px w-full max-w-xl"
+                    style={{ backgroundColor: theme.divider }}
+                  />
+                )}
+                <p
+                  className="max-w-3xl border-l-2 pl-4 text-base leading-relaxed underline decoration-1 underline-offset-4 md:text-lg"
+                  style={{
+                    color: theme.text,
+                    borderColor: theme.divider,
+                  }}
+                >
+                  {group.intro}
+                </p>
+                <div className="mt-6 grid gap-8 sm:grid-cols-2">
+                  {group.stats.map((stat, j) => (
+                    <div key={j}>
+                      <p
+                        className="font-whyteInktrap text-6xl font-black leading-none md:text-7xl"
+                        style={{ color: theme.text }}
+                      >
+                        {stat.value}
+                      </p>
+                      <p
+                        className="mt-2 text-base leading-relaxed md:text-lg"
+                        style={{ color: theme.label }}
+                      >
+                        {stat.label}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex max-w-3xl flex-col gap-8">
+            {intro && (
+              <p
+                className="max-w-3xl text-base leading-relaxed md:text-lg"
+                style={{ color: theme.label }}
+              >
+                {intro}
+              </p>
+            )}
+            {stats.map((stat, i) => (
+              <div key={i}>
+                {i > 0 && (
+                  <div
+                    className="mb-8 h-px w-full max-w-xl"
+                    style={{ backgroundColor: theme.divider }}
+                  />
+                )}
+                <p
+                  className="font-whyteInktrap text-6xl font-black leading-none md:text-7xl lg:text-8xl"
+                  style={{ color: theme.text }}
+                >
+                  {stat.value}
+                </p>
+                <p
+                  className="mt-3 max-w-xl text-base leading-relaxed md:text-lg"
+                  style={{ color: theme.label }}
+                >
+                  {stat.label}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/Blog/Report/ReportTableOfContents.tsx
+++ b/components/Blog/Report/ReportTableOfContents.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { REPORT_TOC_ITEMS } from "./constants";
+
+/** Site header + breathing room for scroll targets and sticky TOC. */
+const HEADER_OFFSET = 112;
+
+function getSectionElements() {
+  return REPORT_TOC_ITEMS.map(({ id }) => ({
+    id,
+    el: document.getElementById(id),
+  })).filter((s): s is { id: string; el: HTMLElement } => !!s.el);
+}
+
+function computeActiveSection(
+  elements: { id: string; el: HTMLElement }[]
+): string {
+  if (elements.length === 0) return REPORT_TOC_ITEMS[0]?.id ?? "";
+
+  const nearBottom =
+    window.innerHeight + window.scrollY >=
+    document.documentElement.scrollHeight - 48;
+
+  if (nearBottom) {
+    return elements[elements.length - 1].id;
+  }
+
+  const scrollPos = window.scrollY + HEADER_OFFSET + 32;
+  let current = elements[0].id;
+
+  for (const { id, el } of elements) {
+    if (el.offsetTop <= scrollPos) {
+      current = id;
+    }
+  }
+
+  return current;
+}
+
+function useActiveSection() {
+  const [activeId, setActiveId] = useState(REPORT_TOC_ITEMS[0]?.id ?? "");
+
+  useEffect(() => {
+    let raf = 0;
+
+    const update = () => {
+      const elements = getSectionElements();
+      if (elements.length === 0) return;
+      setActiveId(computeActiveSection(elements));
+    };
+
+    const onScroll = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(update);
+    };
+
+    // Run on mount and after MDX hydrates section anchors.
+    update();
+    const hydrateTimer = window.setTimeout(update, 150);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", update);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.clearTimeout(hydrateTimer);
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+
+  return activeId;
+}
+
+function useScrollToSection() {
+  return useCallback((id: string) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const top = el.offsetTop - HEADER_OFFSET;
+    window.scrollTo({ top, behavior: "smooth" });
+  }, []);
+}
+
+type Props = {
+  className?: string;
+};
+
+/** TOC for the dedicated left rail — desktop (xl+). Sticky wrapper lives in ReportLayoutShell. */
+export function ReportTableOfContents({ className = "" }: Props) {
+  const activeId = useActiveSection();
+  const scrollTo = useScrollToSection();
+
+  return (
+    <nav aria-label="Table of contents" className={`w-full ${className}`}>
+      <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/40">
+        Contents
+      </p>
+      <ol className="mt-4 flex flex-col gap-1">
+        {REPORT_TOC_ITEMS.map((item, index) => {
+          const isActive = activeId === item.id;
+          return (
+            <li
+              key={item.id}
+              className={`border-l-2 transition-colors duration-200 ${
+                isActive ? "border-[#a8ef3c]" : "border-transparent"
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => scrollTo(item.id)}
+                aria-current={isActive ? "true" : undefined}
+                className={`flex w-full items-start gap-2.5 py-1.5 pl-3 text-left text-[13px] leading-snug transition-colors duration-200 ${
+                  isActive
+                    ? "font-medium text-[#a8ef3c]"
+                    : "text-subtle hover:text-basis"
+                }`}
+              >
+                <span
+                  className={`mt-0.5 shrink-0 font-mono text-[10px] tracking-wider transition-colors duration-200 ${
+                    isActive ? "text-[#a8ef3c]" : "text-white/30"
+                  }`}
+                >
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span>{item.label}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+      <a
+        href="/assets/reports/2026-benchmark/2026-durable-execution-benchmark-report.pdf"
+        className="mt-6 inline-flex items-center rounded-full bg-white px-4 py-2 font-mono text-[11px] uppercase tracking-[0.12em] text-[#0c1f10] transition hover:bg-white/90"
+      >
+        Download PDF ↓
+      </a>
+    </nav>
+  );
+}
+
+/** Sticky horizontal TOC — tablet and mobile. */
+export function ReportMobileContentsBar() {
+  const activeId = useActiveSection();
+  const scrollTo = useScrollToSection();
+
+  return (
+    <nav
+      aria-label="Table of contents"
+      className="sticky top-16 z-20 -mx-6 mb-8 border-b border-white/10 bg-stone-950/90 px-6 py-3 backdrop-blur-md xl:hidden"
+    >
+      <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-white/40">
+        Contents
+      </p>
+      <ol className="flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {REPORT_TOC_ITEMS.map((item, index) => {
+          const isActive = activeId === item.id;
+          return (
+            <li key={item.id} className="shrink-0">
+              <button
+                type="button"
+                onClick={() => scrollTo(item.id)}
+                aria-current={isActive ? "true" : undefined}
+                className={`whitespace-nowrap rounded-full px-3 py-1.5 font-mono text-xs transition-colors duration-200 ${
+                  isActive
+                    ? "bg-[#a8ef3c] font-medium text-[#0c1f10]"
+                    : "bg-white/5 text-subtle hover:bg-white/10 hover:text-basis"
+                }`}
+              >
+                {String(index + 1).padStart(2, "0")}{" "}
+                <span className="hidden sm:inline">{item.label}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/components/Blog/Report/ReportWhatWeAsked.tsx
+++ b/components/Blog/Report/ReportWhatWeAsked.tsx
@@ -1,3 +1,5 @@
+import { REPORT_TEXT_WIDTH } from "./constants";
+
 type Props = {
   questions: string[];
 };
@@ -5,7 +7,7 @@ type Props = {
 /** Survey questions block — matches the PDF "What we asked" sections. */
 export function ReportWhatWeAsked({ questions }: Props) {
   return (
-    <div className="not-prose my-8 max-w-[75ch]">
+    <div className={`not-prose my-8 ${REPORT_TEXT_WIDTH}`}>
       <p className="font-semibold text-basis">What we asked</p>
       <ol className="mt-3 list-decimal space-y-2 pl-5 text-subtle marker:text-muted">
         {questions.map((question) => (

--- a/components/Blog/Report/ReportWhatWeAsked.tsx
+++ b/components/Blog/Report/ReportWhatWeAsked.tsx
@@ -1,0 +1,19 @@
+type Props = {
+  questions: string[];
+};
+
+/** Survey questions block — matches the PDF "What we asked" sections. */
+export function ReportWhatWeAsked({ questions }: Props) {
+  return (
+    <div className="not-prose my-8 max-w-[75ch]">
+      <p className="font-semibold text-basis">What we asked</p>
+      <ol className="mt-3 list-decimal space-y-2 pl-5 text-subtle marker:text-muted">
+        {questions.map((question) => (
+          <li key={question} className="pl-1 leading-relaxed">
+            {question}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/components/Blog/Report/constants.ts
+++ b/components/Blog/Report/constants.ts
@@ -1,0 +1,38 @@
+/** Company logos shown on the report cover — shared with the microsite. */
+export const REPORT_LOGOS = [
+  { name: "Cohere", src: "/assets/report-assets/logos/Cohere.png", h: 24 },
+  { name: "11x", src: "/assets/report-assets/logos/11x.png", h: 28 },
+  { name: "LiveKit", src: "/assets/report-assets/logos/Livekit.png", h: 22 },
+  { name: "mintlify", src: "/assets/report-assets/logos/Mintlify.png", h: 22 },
+  { name: "BÆRSkin", src: "/assets/report-assets/logos/Bearskin.png", h: 32 },
+  { name: "Stuut Technologies", src: "/assets/report-assets/logos/Stuut.png", h: 28 },
+  { name: "Mercury", src: "/assets/report-assets/logos/Mercury.png", h: 36 },
+  { name: "Wealthfront", src: "/assets/report-assets/logos/Wealthfront.png", h: 20 },
+  { name: "Gnosis Freight", src: "/assets/report-assets/logos/Gnosis.png", h: 28 },
+  { name: "Remitly", src: "/assets/report-assets/logos/Remintly.png", h: 28 },
+] as const;
+
+export type ReportTocItem = {
+  id: string;
+  label: string;
+  section?: number;
+};
+
+export const REPORT_TOC_ITEMS: ReportTocItem[] = [
+  { id: "executive-summary", label: "Executive summary" },
+  { id: "confidence-in-scaling-ai", label: "Confidence in scaling AI", section: 1 },
+  { id: "durable-execution", label: "Durable execution", section: 2 },
+  { id: "reliability-tax", label: "The reliability tax", section: 3 },
+  { id: "observability-edge", label: "The observability edge", section: 4 },
+  { id: "ai-frameworks-and-evals", label: "AI frameworks and evals", section: 5 },
+  { id: "whats-still-unsolved", label: "What's still unsolved", section: 6 },
+  { id: "conclusion", label: "Conclusion" },
+];
+
+/** OG share-card chart images — used on the blog with share/download actions. */
+export const REPORT_OG_PATH = "/assets/reports/2026-benchmark/og";
+export const REPORT_BLEED =
+  "not-prose relative left-1/2 w-screen max-w-[100vw] -translate-x-1/2";
+
+/** Full width within the report content column — never crosses into the TOC rail. */
+export const REPORT_COLUMN_BLEED = "not-prose w-full max-w-none";

--- a/components/Blog/Report/constants.ts
+++ b/components/Blog/Report/constants.ts
@@ -38,7 +38,7 @@ export const REPORT_BLEED =
   "not-prose relative left-1/2 w-screen max-w-[100vw] -translate-x-1/2";
 
 /** Full-bleed within the report content column (section breaks, exec summary). */
-export const REPORT_FULL_BLEED = "report-full-bleed w-full";
+export const REPORT_FULL_BLEED = "not-prose report-full-bleed w-full";
 
 /** @deprecated Use REPORT_FULL_BLEED */
 export const REPORT_COLUMN_BLEED = REPORT_FULL_BLEED;

--- a/components/Blog/Report/constants.ts
+++ b/components/Blog/Report/constants.ts
@@ -1,15 +1,18 @@
+export const REPORT_TEXTURE = "/assets/report-assets/report_texture.png";
+export const REPORT_SHAPE = "/assets/report-assets/report_shape.png";
+
 /** Company logos shown on the report cover — shared with the microsite. */
 export const REPORT_LOGOS = [
-  { name: "Cohere", src: "/assets/report-assets/logos/Cohere.png", h: 24 },
-  { name: "11x", src: "/assets/report-assets/logos/11x.png", h: 28 },
-  { name: "LiveKit", src: "/assets/report-assets/logos/Livekit.png", h: 22 },
-  { name: "mintlify", src: "/assets/report-assets/logos/Mintlify.png", h: 22 },
-  { name: "BÆRSkin", src: "/assets/report-assets/logos/Bearskin.png", h: 32 },
-  { name: "Stuut Technologies", src: "/assets/report-assets/logos/Stuut.png", h: 28 },
-  { name: "Mercury", src: "/assets/report-assets/logos/Mercury.png", h: 36 },
-  { name: "Wealthfront", src: "/assets/report-assets/logos/Wealthfront.png", h: 20 },
-  { name: "Gnosis Freight", src: "/assets/report-assets/logos/Gnosis.png", h: 28 },
-  { name: "Remitly", src: "/assets/report-assets/logos/Remintly.png", h: 28 },
+  { name: "Cohere", src: "/assets/report-assets/logos/Cohere.png", width: 505, height: 85, h: 24 },
+  { name: "11x", src: "/assets/report-assets/logos/11x.png", width: 305, height: 108, h: 28 },
+  { name: "LiveKit", src: "/assets/report-assets/logos/Livekit.png", width: 372, height: 85, h: 22 },
+  { name: "mintlify", src: "/assets/report-assets/logos/Mintlify.png", width: 414, height: 96, h: 22 },
+  { name: "BÆRSkin", src: "/assets/report-assets/logos/Bearskin.png", width: 475, height: 85, h: 32 },
+  { name: "Stuut Technologies", src: "/assets/report-assets/logos/Stuut.png", width: 542, height: 77, h: 28 },
+  { name: "Mercury", src: "/assets/report-assets/logos/Mercury.png", width: 346, height: 114, h: 36 },
+  { name: "Wealthfront", src: "/assets/report-assets/logos/Wealthfront.png", width: 434, height: 84, h: 20 },
+  { name: "Gnosis Freight", src: "/assets/report-assets/logos/Gnosis.png", width: 369, height: 103, h: 28 },
+  { name: "Remitly", src: "/assets/report-assets/logos/Remintly.png", width: 416, height: 104, h: 28 },
 ] as const;
 
 export type ReportTocItem = {
@@ -34,5 +37,11 @@ export const REPORT_OG_PATH = "/assets/reports/2026-benchmark/og";
 export const REPORT_BLEED =
   "not-prose relative left-1/2 w-screen max-w-[100vw] -translate-x-1/2";
 
-/** Full width within the report content column — never crosses into the TOC rail. */
-export const REPORT_COLUMN_BLEED = "not-prose w-full max-w-none";
+/** Full-bleed within the report content column (section breaks, exec summary). */
+export const REPORT_FULL_BLEED = "report-full-bleed w-full";
+
+/** @deprecated Use REPORT_FULL_BLEED */
+export const REPORT_COLUMN_BLEED = REPORT_FULL_BLEED;
+
+/** Explicit prose-width marker — default `.report-prose > *` already applies 75ch. */
+export const REPORT_TEXT_WIDTH = "report-text-width w-full";

--- a/components/Blog/Report/index.ts
+++ b/components/Blog/Report/index.ts
@@ -1,0 +1,8 @@
+export { ReportHero } from "./ReportHero";
+export { ReportExecSummary } from "./ReportExecSummary";
+export { ReportSectionBreak } from "./ReportSectionBreak";
+export { ReportTableOfContents, ReportMobileContentsBar } from "./ReportTableOfContents";
+export { ReportLayoutShell } from "./ReportLayoutShell";
+export { ReportChart } from "./ReportChart";
+export { ReportWhatWeAsked } from "./ReportWhatWeAsked";
+export { REPORT_TOC_ITEMS } from "./constants";

--- a/components/Blog/index.ts
+++ b/components/Blog/index.ts
@@ -28,6 +28,8 @@ export type BlogPost = {
   focusCta?: string;
   // When hidden, the post will be available on at the URL, but not in any blog feed of RSS
   hide?: boolean;
+  /** Hides default hero image/title; use Report* MDX components instead. */
+  reportLayout?: boolean;
   // When featured is false, post will be hidden from main feed, but available on category pages
   featured?: boolean;
   // When included, the post will be included on the category feed

--- a/components/RedesignedLanding/Header/Header.tsx
+++ b/components/RedesignedLanding/Header/Header.tsx
@@ -310,11 +310,11 @@ export default function Header() {
                         Featured report
                       </h3>
                       <article className="relative isolate flex flex-row gap-y-3 pb-2">
-                        <div className="relative flex h-16 w-[7.5rem] flex-none items-center justify-center overflow-hidden rounded-lg bg-stone-800">
+                        <div className="relative h-16 w-[7.5rem] flex-none overflow-hidden rounded-lg bg-stone-800">
                           <img
                             alt=""
                             src={featuredBlogPost.image}
-                            className="max-h-full max-w-full object-contain object-center"
+                            className="h-full w-full origin-bottom scale-[1.1] object-cover object-bottom"
                           />
                           <div className="pointer-events-none absolute inset-0 rounded-lg ring-1 ring-inset ring-stone-600/40" />
                         </div>

--- a/components/RedesignedLanding/Header/ResourcePopover.tsx
+++ b/components/RedesignedLanding/Header/ResourcePopover.tsx
@@ -174,7 +174,6 @@ export default function ResourcePopover() {
                       <div className="flex w-full flex-col">
                         <div className="aspect-[2/1] w-full overflow-hidden rounded-md bg-stone-800">
                           <div className="flex h-full w-full items-center justify-center">
-                            {/* <img alt="" src={featuredBlogPost.image} /> */}
                             <Image
                               className="max-h-full max-w-full object-contain object-center"
                               src={featuredBlogPost.image}

--- a/components/RedesignedLanding/Header/helpers.ts
+++ b/components/RedesignedLanding/Header/helpers.ts
@@ -4,5 +4,5 @@ export const featuredBlogPost = {
     "/assets/blog/ai-in-production-report-2026-card/featured-image/featured-image.png",
   description:
     "We surveyed 130 backend, full-stack, and AI engineers about what it takes to run reliable AI workflows in production—and which choices actually reduce the burden of reliability.",
-  href: "/content/ai-in-production-report-2026?ref=nav-resources-featured",
+  href: "/blog/ai-in-production-report-2026?ref=nav-resources-featured",
 };

--- a/content/blog/ai-in-production-managing-capacity-with-flow-control.mdx
+++ b/content/blog/ai-in-production-managing-capacity-with-flow-control.mdx
@@ -9,7 +9,7 @@ dateUpdated: 2026-01-07
 author: Dan Farrelly
 ---
 
-Whether it's a core part of your functionality or a behind-the-scenes helper, if you're building right now, you're probably building with AI. AI offers so much functionality to your product that it has become almost expected.
+Whether it's a core part of your functionality or a behind-the-scenes helper, if you're building right now, you're probably building with AI. AI offers so much functionality to your product that it has become almost expected. In our [2026 benchmark survey](/blog/ai-in-production-report-2026?ref=blog-manage-capacity-ai), 68% of teams running async workflows in production reported building AI workflows—and only 19% were very confident their stack could handle 2–3× scale.
 
 But like any API, once it is integrated into your product, you must manage it. AI APIs are constantly under load, and AI services have responded to that by locking them down with rate limits and high costs. You must carefully monitor and manage your AI usage to avoid exceeding limits or incurring unexpectedly high bills.
 

--- a/content/blog/ai-in-production-report-2026-card.mdx
+++ b/content/blog/ai-in-production-report-2026-card.mdx
@@ -1,5 +1,6 @@
 ---
-redirect: "/content/ai-in-production-report-2026?ref=blog-ai-in-production-report-2026"
+redirect: "/blog/ai-in-production-report-2026?ref=blog-ai-in-production-report-2026"
+hide: true
 heading: "AI in Production: The 2026 Benchmark Report"
 subtitle: "We surveyed 130 backend, full-stack, and AI engineers about what it takes to run reliable AI workflows in production. We wanted to know what's causing failures, and which infrastructure choices—across orchestration, observability, evals, and agent frameworks—actually reduce the burden of reliability. Explore the patterns that predict scaling confidence."
 focusCta: "Read the report"

--- a/content/blog/ai-in-production-report-2026.mdx
+++ b/content/blog/ai-in-production-report-2026.mdx
@@ -1,0 +1,389 @@
+---
+heading: "AI in Production: The 2026 Benchmark Report"
+subtitle: "We surveyed 130 backend, full-stack, and AI engineers about what it takes to run reliable AI workflows in production. We wanted to know what's causing failures, and which infrastructure choices—across orchestration, observability, evals, and agent frameworks—actually reduce the burden of reliability."
+showSubtitle: true
+focus: true
+focusCta: "Read the report"
+reportLayout: true
+image: /assets/blog/ai-in-production-report-2026-card/featured-image/featured-image.png
+date: "2026-05-05"
+category: company-news
+author: Lauren Craigie
+---
+
+<ReportExecSummary
+  intro="We surveyed 130 backend, full-stack, and AI engineers across companies of all sizes about what they're building, and how they keep it reliable. We specifically focused on how these teams run asynchronous work in production. Some findings were expected: 68% of respondents are building AI workflows in production. Others were less so: only 19% of those teams are very confident their infrastructure can handle 2–3× current scale—and at organizations with 500+ engineers, that number is 0%. That confidence gap is the story of this report."
+  findings={[
+    {
+      number: 1,
+      title: "The reliability burden is growing for teams expanding into AI use cases.",
+      body: "20% of teams building AI in production spend up to half their time on reliability work, with a clear split in burden expansion or reduction based on durability tool in use.",
+    },
+    {
+      number: 2,
+      title: "Observability is the #1 problem engineers believe still hasn't been solved.",
+      body: "Even respondents using a mix of third-party and homegrown solutions were just as likely to cite a persistent gap in observability across their workflow.",
+    },
+    {
+      number: 3,
+      title: "Confident teams use observable, composable stacks.",
+      body: "The strongest three-factor predictor of confidence is using orchestration tools with built-in observability, running AI evals, and diagnosing failures fast. These teams are 3× more likely to report confidence in their stack.",
+    },
+  ]}
+/>
+
+<ReportSectionBreak
+  id="confidence-in-scaling-ai"
+  section={1}
+  title="Confidence in scaling AI"
+  variant="green"
+  stats={[
+    {
+      value: "19%",
+      label: "of teams running AI workflows in production said they were very confident in their stack's ability to handle 2–3× their current scale",
+    },
+    {
+      value: "0%",
+      label: "of teams with over 500 engineers reported any confidence",
+    },
+  ]}
+/>
+
+We asked survey participants several questions about the tooling in their stack that supports how they run asynchronous workflows in production. While confidence in the ability to scale AI systems is relatively low, we see an important correlation to combinations of solutions in play.
+
+<ReportWhatWeAsked
+  questions={[
+    "What kinds of AI workflows are you running in production?",
+    "How confident are you in your setup's ability to handle AI workloads reliably at 2-3x your current scale?",
+  ]}
+/>
+
+Smaller teams, with limited resource to handle scale, reported being more confident than larger teams in the ability to handle 2–3× the load. This could be because these teams rate their use cases to be relatively simple—already designed for 2–3× scale by nature of the stage they're at.
+
+In an attempt to add more dimension to this result, we looked at how stack choices might correlate with overall reported confidence. We found a few statistically significant trends worth noting.
+
+### What separates confident teams
+
+We started by asking about the tooling used to build workflows and observe failures. We also asked about agent evals and frameworks. These aren't the only layers of a production stack, but they are some of the more emergent—and in some cases, contentious.
+
+The strongest statistically significant predictors are **production evals** and the **ability to diagnose failures fast**—both clearing p&lt;0.05 independently, and together reaching p&lt;0.01. Teams that can diagnose in minutes and have production evals are the most concentrated in the confident group; not one unconfident team has both.
+
+The combination of using a [durable execution](/docs/learn/inngest-steps?ref=blog-ai-in-production-report-2026) solution as well as structured evals is the most actionable three-factor predictor (p=0.011), with 49% of confident teams having all three versus 13% of unconfident teams.
+
+On the negative side, the **absence of evals** is the clearest anti-pattern in the dataset (p=0.038). Teams missing both evals and orchestration-native observability show the sharpest gap (p=0.008).
+
+<ReportChart graphId="confidence-in-scaling-ai-workflows-by-team-size" />
+
+<ReportChart graphId="most-statistically-significant-signals-for-confidence-in-scaling-ai" />
+
+<ReportSectionBreak
+  id="durable-execution"
+  section={2}
+  title="Durable execution: Mapping use cases and tools"
+  variant="orange"
+  stats={[
+    {
+      value: "56%",
+      label: "of respondents use more than one tool for durable execution, often pairing a custom-built solution with a third-party platform. Inngest is favored by growth-stage teams; users also report the widest variety of use cases served.",
+    },
+  ]}
+/>
+
+[Durable execution](/uses/durable-workflows?ref=blog-ai-in-production-report-2026) is a fault-tolerant approach to running code that ensures functions complete—no matter what. These platforms persist state, handle failures, pause and retry when needed, and provide deep observability for quick troubleshooting and recovery. They are the full-context infrastructure layer that modern production systems are being built on top of.
+
+While the survey showed that types of workflows and jobs run in production are fairly uniform across companies of all sizes, we saw quite a range in what folks were using to ensure durable execution at scale.
+
+<ReportWhatWeAsked
+  questions={[
+    "What types of workflows or jobs are you running in production?",
+    "What are you using to ensure reliable execution of those workflows and jobs?",
+  ]}
+/>
+
+### Top use cases for durable execution
+
+Background jobs and event-driven workflows are near-universal use cases for anyone building asynchronous workflows in production. These run at companies of every size, regardless of what teams are building. Long-running workflows and AI/LLM workflows are tied at **68%**—AI is now as common a production use case as long-running workflows. Data pipelines follow closely at 63%.
+
+| Workflow type | Share of respondents |
+| --- | --- |
+| Background jobs or scheduled tasks | 87% |
+| Event-driven automation or webhook processing | 93% |
+| Long-running workflows (minutes to days) | 68% |
+| AI / LLM workflows | 68% |
+| Data pipelines (ETL, embedding, enrichment) | 63% |
+
+### Orchestration platforms by team and use case
+
+What teams are building correlates strongly with which orchestration solution they use (or build themselves). 56% of respondents use more than one tool, often pairing a custom-built solution with a third-party platform.
+
+For example, 100% of Temporal users surveyed have another durable execution or orchestration solution running alongside to handle edge cases. Inngest is the platform most often run alone (56%), with 22% of those teams also running something custom-built.
+
+This loyalty may be a function of scale: Inngest is popular among growing teams who want low-friction adoption that scales with them. But it's also a reflection of capability breadth. Among statistically meaningful solo-tool cohorts, Inngest serves the widest variety of use cases.
+
+<ReportChart graphId="orchestration-platform-by-team-size" />
+
+Among reportable solo-tool cohorts, Inngest serves the widest variety of use cases at 75% average. AWS/Vercel/Cloudflare and BullMQ/Celery/Sidekiq are the most specialized—AWS/Vercel/CF drops sharply on long-running (43%) and AI (29%); BullMQ on data pipelines (17%).
+
+<ReportSectionBreak
+  id="reliability-tax"
+  section={3}
+  title="The reliability tax: What's driving a change in time spent on reliability?"
+  variant="green"
+  stats={[
+    {
+      value: "20%",
+      label: "of teams building AI in production spend twice the time on reliability work than those running traditional workflows. Users of Inngest and homegrown solutions report a net reduction in burden over the last 12 months.",
+    },
+  ]}
+/>
+
+Building AI in production carries different challenges from building traditional software—higher throughput, non-deterministic models, opaque evaluations. The question this section tries to answer is: is it the use case, the team size, or the tooling that makes the biggest difference in how much time engineers spend on reliability? And critically—can anything reduce that time?
+
+<ReportWhatWeAsked
+  questions={[
+    "Roughly what share of your team's engineering time goes to reliability work?",
+    "Has that percentage gone up or down in the last 12 months? If up, what do you think is driving that increase?",
+  ]}
+/>
+
+### Time spent on reliability: AI vs non-AI use cases
+
+Teams building AI in production spend more time on reliability work. 20% of AI teams are in the 26–50% band—spending up to half their engineering capacity just keeping things running. That's twice the rate of non-AI teams (10%).
+
+Nearly half of teams building AI (48%) are in the 10–25% band. That's a significant but not catastrophic spend—the kind of number that likely prevents the team from shipping as fast as it wants to.
+
+<ReportChart graphId="time-spent-on-reliability-work-teams-building-ai-vs-traditional-software" />
+
+### How has time spent on reliability changed over time?
+
+While the survey showed that larger teams generally spend more of their time on reliability toil, the net change in time spent on reliability over the last year is relatively uniform across teams of all sizes. Change over time also appears to be relatively similar between AI and non-AI use cases.
+
+The more revealing split is by orchestration tool.
+
+Teams building AI workflows with Inngest (−10pp) and custom-built orchestration tools (−9pp) correlate with declining reliability burden over the last year. Temporal (+22pp) and AWS/Vercel/CF (+9pp) users correlate with increasing burden. BullMQ/Celery/Sidekiq sits in the middle (−5pp).
+
+<ReportChart graphId="reliability-burden-change-by-ai-orchestration-tool" />
+
+### What causes reliability toil to increase?
+
+For the 31% who reported their burden increasing, the top two drivers were equal in citation: **higher traffic and scale (61%)** and **technical debt (61%)**. However, when splitting results by AI and non-AI use cases, we see higher traffic & scale take a slight lead for teams building AI at 62%, and technical debt take the lead for those not building AI in production at a significantly higher margin of 86%.
+
+Multi-service architectures, faster shipping pressure, and AI workloads with new failure modes follow closely. Non-deterministic outputs requiring more validation logic is last.
+
+<ReportChart graphId="whats-driving-reliability-burden-up" />
+
+<Blockquote
+  text="I think the biggest unsolved problem is making workflows truly reliable when things go wrong in production. Retries, duplicate events, partial failures, long-running jobs, and out-of-order execution can all break logic in subtle ways. It's still hard to build systems that are easy to debug, resume safely, and trust at scale."
+  attribution={{
+    name: "E-commerce Engineering Leader",
+    title: "Engineering Leader",
+    company: "1,000+ person org",
+  }}
+/>
+
+<Callout>
+  **Key insight:** Orchestration tooling should help teams handle rapid or lumpy scale, as well as fit into their existing stack in order to reduce friction cited here.
+</Callout>
+
+<ReportSectionBreak
+  id="observability-edge"
+  section={4}
+  title="The observability edge: How tooling choices correlate with recovery time in customer-facing incidents"
+  variant="blue"
+  statGroups={[
+    {
+      intro:
+        "Engineers using observability dashboards built into their orchestration layer report the fastest path to understanding crashes when they occur:",
+      stats: [
+        { value: "40%", label: "diagnose in minutes." },
+        { value: "1%", label: "note lengthy delays." },
+      ],
+    },
+    {
+      intro: "Teams using only APM tools,",
+      stats: [
+        { value: "29%", label: "diagnose in minutes." },
+        { value: "11%", label: "note lengthy delays." },
+      ],
+    },
+  ]}
+/>
+
+In this survey we asked one free-text question: "What is the biggest unsolved problem in building reliable workflows, agents, and endpoints?" One theme dominated the responses: **observability**.
+
+While not exclusively an AI problem, observability was cited more frequently by teams building AI in production. Most observability tools were built on the premise that the same inputs produce the same outputs. AI systems break that assumption. When a workflow fails because an LLM returned a malformed response at step three of five, the error surfaces as a downstream consequence in a system that had no reason to expect it.
+
+<ReportWhatWeAsked
+  questions={[
+    "How do you observe workflow runs?",
+    "When a workflow fails in production, how long does it typically take to understand what went wrong?",
+    "In the past 90 days, has a workflow or background job failure caused a customer-visible incident?",
+    "What are the most common causes of failures (pick up to 3).",
+  ]}
+/>
+
+### Observability platforms and diagnostic speed
+
+38% of teams can diagnose a production failure in minutes. Another 54% get there in under an hour but require active investigation. 9% take hours or can't fully explain what happened at all.
+
+The gap between these cohorts is almost entirely explained by observability tooling. Platform-native dashboards — where observability is built into the orchestration layer — deliver the best outcomes: 40% diagnose in minutes, with only 1% in the slow-or-blind band.
+
+Teams using only APM tools without an orchestration dashboard: 29% fast, 11% slow or blind. That's an 11x difference in worst-case outcomes.
+
+<Callout>
+  **Key insight:** Orchestration tools that provide granular observability are the best shot teams have to find what went wrong, quickly, when workflows fail.
+</Callout>
+
+<ReportChart graphId="time-to-understand-pipeline-failures-by-observability-method" />
+
+Orchestration platform dashboards lead on fast diagnosis (40%) and have the lowest combined slow/can't-explain rate (5%). Sentry, Datadog, and New Relic have the highest "hours" rate (7%) despite being the most widely used tools, broad adoption doesn't mean fast resolution. Teams with no structured observability (n=7, not shown) split sharply: 43% diagnose in minutes but 29% can't explain at all, either the failure is immediately obvious or you're completely in the dark.
+
+### Rate and cause of incidents in AI vs non-AI use cases
+
+74% of AI teams building AI in production experienced at least one customer-visible incident in the past 90 days—vs 62% of non-AI teams. One in five AI teams had three or more, while teams larger than 500 engineers rarely accumulate 3+.
+
+Infrastructure crashes are a top cause of workflow failure for both AI and non-AI use cases, though LLM/external API failures invert the top slot for those building with AI.
+
+<ReportChart graphId="what-breaks-teams-building-ai-vs-traditional-software" />
+
+<ReportSectionBreak
+  id="ai-frameworks-and-evals"
+  section={5}
+  title="AI frameworks and evals — harnessing unpredictable models"
+  variant="green"
+  intro="While evals are closely tied to confidence in scale, we're still early. 28% of respondents believe it's hard to write evals that matter,"
+  stats={[
+    {
+      value: "35%",
+      label: "aren't using evals at all, and most who are, have built their own pipeline.",
+    },
+  ]}
+/>
+
+AI frameworks and evals exist in the layer of building AI where non-determinism becomes harder to manage through better infrastructure alone.
+
+**Evals** aim to measure whether AI outputs are correct, safe, and within acceptable variance.
+
+**Agent frameworks** are the libraries that sit between application code and the model—structuring calls, managing context, handling tool use.
+
+Both categories barely existed two years ago and have grown fast. And both may share a common achilles heel: they were built as standalone layers, without a native connection to the orchestration layer that knows what actually ran.
+
+<ReportWhatWeAsked
+  questions={[
+    "What are you using to evaluate AI outputs in production?",
+    "What do you believe are the biggest limitations, if any, of modern AI eval solutions?",
+    "What, if anything, are you using for an agent framework?",
+    "What do you believe are the biggest limitations, if any, of modern agent frameworks?",
+  ]}
+/>
+
+### Using evals to improve AI quality in production
+
+Maybe the most surprising finding in this survey is that **35%** of respondents building AI in production are not doing AI evals at all. Of the 65% who are, most have built their own pipeline.
+
+Tool selection spread seems to hold across all team sizes, though as with orchestration solutions, teams begin to default to building their own solution when they're small enough that complexity is low, or big enough that bespoke solutions seem like the only answer.
+
+Growth-phase teams (11–50 engineers) exhibit the highest rate of "not doing evals" at 44%. This may simply be because these teams are moving fast, shipping fast, and deferring infrastructure investments until something breaks.
+
+<ReportChart graphId="eval-approach-by-team-size" />
+
+### Perceived gaps in eval solutions
+
+Regardless of whether teams invested in, built, or deferred eval solutions, they also answered what gaps they perceived to exist in the category.
+
+While the top two reasons cited pertain exclusively to the ergonomics of eval solutions, three are failures of context: results in a separate system (20%), no way to act on a failed eval (13%), we don't have enough coverage to trust our output (12%), evals offline and disconnected from production behavior (10%). Nearly half of all AI teams (47%) cite at least one of these three. Each describes the same structural absence: eval state and orchestration state that can't see each other.
+
+<ReportChart graphId="perceived-gaps-in-eval-solutions" />
+
+<Blockquote
+  text="Deeply integrated infrastructure, data sources, evaluations, and data migrations based on evaluation results—that's what's still missing."
+  attribution={{
+    name: "Head of Machine Learning",
+    title: "Head of Machine Learning",
+    company: "200+ person org",
+  }}
+/>
+
+### Using agent frameworks to guide AI agent production
+
+**69%** of respondents building AI in production are not using third-party agent frameworks, instead choosing to call LLM APIs directly, or build their own abstractions. Observability-related fears top the list of perceived gaps, with 26% saying abstractions make failures harder to trace.
+
+Given the popularity of frameworks like LangChain, it might be surprising that 69% of respondents building AI just call LLM APIs directly, or have built their own abstractions.
+
+The remaining 31% are split between Vercel AI SDK (30%), LangChain/LangGraph (20%), and smaller tools. LangChain/LangGraph adoption skews towards larger teams—45% at 500+ engineers.
+
+<ReportChart graphId="agent-framework-adoption-by-team-size" />
+
+### Perceived gaps in agent frameworks
+
+The predominant gaps cited are that agent framework abstractions make failures harder to trace (26%), and there's poor support for long-running or stateful workflows (19%).
+
+However, it should be noted that time to diagnose workflow failures is nearly identical between those using frameworks, and those calling LLMs directly without a framework.
+
+<ReportChart graphId="perceived-gaps-in-agent-frameworks" />
+
+<ReportSectionBreak
+  id="whats-still-unsolved"
+  section={6}
+  title="What engineers say is still unsolved"
+  variant="orange"
+  stats={[
+    {
+      value: "19%",
+      label: "of responses name observability as the core unsolved problem—the highest of any theme, and equal across AI (18%) and non-AI (21%) teams",
+    },
+  ]}
+/>
+
+Our final question in the survey was open-ended: "What do you think is the biggest unsolved problem in building reliable workflows, agents, and endpoints?" The responses tell us a lot about universal problems, and problems of scale.
+
+<ReportChart graphId="whats-unsolved-by-team-size" />
+
+### Observability: the named gap
+
+19% of responses name observability as the core unsolved problem—the highest of any theme, and the only one that appears equally among AI (18%) and non-AI (21%) teams.
+
+<Blockquote
+  text="Observability is, I would say, still very unsolved. A lot of the workflows that we run, we are able to monitor, but it is not at the same level and requires a lot more instrumentation than we would like. Often the issues that are found are outside of the observability metrics that we have built, so they get missed."
+  attribution={{
+    name: "Head of Machine Learning & Data Science",
+    title: "Head of Machine Learning & Data Science",
+    company: "11–50 eng team",
+  }}
+/>
+
+<Blockquote
+  text="Observability gaps — When something breaks, it's hard to trace why an agent made a decision or reproduce it. Debugging feels more like forensics than engineering."
+  attribution={{
+    name: "Engineer",
+    title: "Engineer",
+    company: "2–10 eng team",
+  }}
+/>
+
+### Context: the unnamed gap
+
+Survey responses point to observability as a felt gap, but the survey data reveals another related issue: the importance of **shared context**, in a layer that makes every other component in the stack actually effective. Three signals support this finding:
+
+1. **Platform-native observability outperforms bolted-on observability.** Teams relying only on APM tools like Sentry or Datadog are more likely to end up slow or blind when a failure hits—11% take hours or can't explain what happened at all, vs. 1% for teams using insights native to their orchestration platform.
+
+2. **Three of five major complaints of eval platforms are integration problems.** The five most-cited eval limitations split into two types: two are intrinsic to evaluation (31% cite hard-to-write evals, 25% cite LLM-as-judge cost), while three are integration failures—results in a separate system (20%), no way to act on a failed eval (13%), evals offline and disconnected from production (10%).
+
+3. **Framework composability is the missing link.** 69% of AI teams call LLM APIs directly or built their own abstractions rather than using a framework—and 20% of them still cite poor composability with job orchestration as a top limitation, comparable to the rate among LangChain and Vercel AI SDK users.
+
+<Blockquote
+  text="From my experience, the biggest unsolved problem is ensuring deterministic reliability in non-deterministic systems—especially when LLM-driven agents interact across multi-step workflows and external APIs. I often see failures in state management, error propagation, and tool orchestration, where edge cases break silently and are hard to trace or reproduce."
+  attribution={{
+    name: "Director, Enterprise Architecture",
+    title: "Director, Enterprise Architecture",
+    company: "501–1000 eng team",
+  }}
+/>
+
+<h2 id="conclusion" className="scroll-mt-28">Conclusion</h2>
+
+The data in this report paints a pretty clear picture about missing context—about the lack of an AI stack where state is shared across layers—where a failed eval can see the execution that produced it, where an observability dashboard can trace inside the workflow, where an agent framework composes naturally with the infrastructure running beneath it.
+
+The 19% of AI teams who are very confident in their ability to scale aren't using fundamentally different tools. They're using tools that are more tightly connected: purpose-built orchestration with native observability, eval approaches that integrate with where failures actually live, frameworks that compose with the job layer rather than sitting above it.
+
+The ask that runs through open-text responses is simple: show me what ran, show me why it stopped, show me whether it's safe to resume, and what happens after it does. Most importantly, bring all of that information, into one place.

--- a/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
+++ b/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
@@ -81,7 +81,7 @@ When you have `step.run()`, `step.invoke()`, `step.waitForEvent()`, and `step.sl
 
 Patterns change faster than ever. They're all compositions. Frameworks struggle to adapt for these things as they encode a fixed topology. Composable primitives don't have that same issue.
 
-There's another angle here that's easy to miss: [teams with strong orchestration and observability iterate faster](/content/ai-in-production-report-2026?ref=blog-background-agents-are-here). When you can see every step of every agent run (structured, not just logs) you can identify what's working and swap what isn't. **The composability gap is really an observability problem.** You can't recompose what you can't see.
+There's another angle here that's easy to miss: [teams with strong orchestration and observability iterate faster](/blog/ai-in-production-report-2026?ref=blog-background-agents-are-here). When you can see every step of every agent run (structured, not just logs) you can identify what's working and swap what isn't. **The composability gap is really an observability problem.** You can't recompose what you can't see.
 
 ## What this looks like in practice
 

--- a/content/blog/principles-of-production-ai.mdx
+++ b/content/blog/principles-of-production-ai.mdx
@@ -12,7 +12,7 @@ One main observation can be made as we approach the end of 2024: AI Engineering 
 
 Prompting iterations now rely on evaluations, or “Evals,” a technique inspired by classical Software Engineering's unit testing. AI Engineering also merges with software engineering architecture to support the orchestration of the **increasing need for more tools and the use of mixture-of-models in agentic workflows**.
 
-This article covers the three pillars used in AI Engineering to fulfill its mission of providing users with a safe and reliable AI experience at scale: **LLM Evaluation**, **Guardrails**, and **better orchestration**.
+This article covers the three pillars used in AI Engineering to fulfill its mission of providing users with a safe and reliable AI experience at scale: **LLM Evaluation**, **Guardrails**, and **better orchestration**. Our [2026 benchmark survey](/blog/ai-in-production-report-2026?ref=blog-principles-of-production-ai) of 130 engineers found that teams running production evals alongside durable orchestration are among the most confident in their ability to scale AI workloads.
 
 ## LLM Evaluation: from unit testing to monitoring
 

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -24,6 +24,16 @@ import YouTube from "react-youtube-embed";
 import remarkGfm from "remark-gfm";
 import { SectionProvider } from "src/shared/Docs/SectionProvider";
 import FloatingCTA from "src/components/Blog/FloatingCTA";
+import {
+  ReportExecSummary,
+  ReportHero,
+  ReportSectionBreak,
+  ReportTableOfContents,
+  ReportMobileContentsBar,
+  ReportLayoutShell,
+  ReportChart,
+  ReportWhatWeAsked,
+} from "src/components/Blog/Report";
 import { formatShortLocaleDate } from "src/utils/date";
 
 // @ts-ignore
@@ -52,6 +62,11 @@ const components: MDXComponents = {
   WorkflowKitProductOfTheDay: ProductHunt,
   Col,
   Row,
+  ReportHero,
+  ReportExecSummary,
+  ReportSectionBreak,
+  ReportChart,
+  ReportWhatWeAsked,
 };
 
 type Props = {
@@ -88,6 +103,9 @@ type Scope = {
 
   primaryCTA?: "sales" | "docs" | "signUp";
   floatingCTA?: boolean;
+
+  /** When true, hides the featured image and uses report-style MDX blocks for the hero. */
+  reportLayout?: boolean;
 
   reading: {
     text: string;
@@ -236,8 +254,10 @@ export default function BlogLayout(props) {
         <Header />
         <Container>
           <article>
-            <main className="relative m-auto max-w-3xl py-16">
-              {scope.image && (
+            <main
+              className={`relative py-16 ${scope.reportLayout ? "w-full max-w-none" : "m-auto max-w-3xl"}`}
+            >
+              {scope.image && !scope.reportLayout && (
                 <figure className="mx-auto flex max-w-[768px] flex-col items-end">
                   <Image
                     className="rounded-lg"
@@ -257,55 +277,81 @@ export default function BlogLayout(props) {
                   )}
                 </figure>
               )}
-              <div className="lg:pt-18 m-auto max-w-[76ch] pt-12">
-                <header className="">
-                  <h1 className="mb-2 text-2xl font-medium tracking-tighter text-basis md:mb-4 md:text-4xl lg:leading-loose xl:text-5xl">
-                    {scope.heading}
-                  </h1>
-                  {scope.showSubtitle && (
-                    <p className="mb-6 flex items-center gap-1 text-lg font-bold text-subtle">
-                      {scope.subtitle}
-                    </p>
-                  )}
-                  <p className="mt-2 flex items-center gap-2 text-sm text-subtle">
-                    {authors.map((author, idx, arr) => (
-                      <span key={idx}>
-                        {authorURLs[author] ? (
-                          <a
-                            href={authorURLs[author]}
-                            target="_blank"
-                            className="text-subtle hover:underline"
-                          >
-                            {author}
-                          </a>
-                        ) : (
-                          <>{author}</>
-                        )}
-                        {idx < arr.length - 1 && ", "}
-                      </span>
-                    ))}
-                    {authors.length > 0 && <>&middot; </>}
-                    <span className="flex items-center gap-1">
-                      <RiCalendarLine className="mr-px h-3 w-3" />{" "}
-                      {scope.humanDate}{" "}
-                      {!!dateUpdated && <> (Updated: {dateUpdated})</>}
-                    </span>{" "}
-                    &middot; <span>{scope.reading.text}</span>
-                    <Tags tags={scope.tags} />
-                  </p>
-                </header>
-                <SectionProvider sections={[]}>
-                  <div className="prose-invert blog-content prose mb-20 mt-12 text-basis prose-a:font-medium prose-a:no-underline prose-a:transition-all hover:prose-a:underline prose-code:tracking-tight prose-pre:border prose-pre:border-subtle prose-img:rounded-lg">
-                    {/* @ts-ignore */}
-                    <MDXRemote
-                      compiledSource={props.post.compiledSource}
-                      scope={scope}
-                      components={components}
+              {scope.reportLayout ? (
+                <ReportLayoutShell toc={<ReportTableOfContents />}>
+                  <>
+                    <ReportHero
+                      author={authors}
+                      date={scope.humanDate}
+                      readingTime={scope.reading.text}
                     />
-                  </div>
-                </SectionProvider>
-                <CTAs primary={primaryCTA} ctaRef={`blog-${slug}`} />
-              </div>
+                    <div className="w-full pt-0">
+                    <ReportMobileContentsBar />
+                    <SectionProvider sections={[]}>
+                      <div className="report-prose prose-invert blog-content prose mb-20 mt-0 max-w-none text-basis prose-a:font-medium prose-a:no-underline prose-a:transition-all hover:prose-a:underline prose-code:tracking-tight prose-pre:border prose-pre:border-subtle [&_h2]:scroll-mt-28">
+                        {/* @ts-ignore */}
+                        <MDXRemote
+                          compiledSource={props.post.compiledSource}
+                          scope={scope}
+                          components={components}
+                        />
+                      </div>
+                    </SectionProvider>
+                    <CTAs primary={primaryCTA} ctaRef={`blog-${slug}`} />
+                    </div>
+                  </>
+                </ReportLayoutShell>
+              ) : (
+                <div className="m-auto max-w-[76ch] pt-12 lg:pt-18">
+                  <header className="">
+                    <h1 className="mb-2 text-2xl font-medium tracking-tighter text-basis md:mb-4 md:text-4xl lg:leading-loose xl:text-5xl">
+                      {scope.heading}
+                    </h1>
+                    {scope.showSubtitle && (
+                      <p className="mb-6 flex items-center gap-1 text-lg font-bold text-subtle">
+                        {scope.subtitle}
+                      </p>
+                    )}
+                    <p className="mt-2 flex items-center gap-2 text-sm text-subtle">
+                      {authors.map((author, idx, arr) => (
+                        <span key={idx}>
+                          {authorURLs[author] ? (
+                            <a
+                              href={authorURLs[author]}
+                              target="_blank"
+                              className="text-subtle hover:underline"
+                            >
+                              {author}
+                            </a>
+                          ) : (
+                            <>{author}</>
+                          )}
+                          {idx < arr.length - 1 && ", "}
+                        </span>
+                      ))}
+                      {authors.length > 0 && <>&middot; </>}
+                      <span className="flex items-center gap-1">
+                        <RiCalendarLine className="mr-px h-3 w-3" />{" "}
+                        {scope.humanDate}{" "}
+                        {!!dateUpdated && <> (Updated: {dateUpdated})</>}
+                      </span>{" "}
+                      &middot; <span>{scope.reading.text}</span>
+                      <Tags tags={scope.tags} />
+                    </p>
+                  </header>
+                  <SectionProvider sections={[]}>
+                    <div className="prose-invert blog-content prose mb-20 mt-12 text-basis prose-a:font-medium prose-a:no-underline prose-a:transition-all hover:prose-a:underline prose-code:tracking-tight prose-pre:border prose-pre:border-subtle prose-img:rounded-lg">
+                      {/* @ts-ignore */}
+                      <MDXRemote
+                        compiledSource={props.post.compiledSource}
+                        scope={scope}
+                        components={components}
+                      />
+                    </div>
+                  </SectionProvider>
+                  <CTAs primary={primaryCTA} ctaRef={`blog-${slug}`} />
+                </div>
+              )}
               {scope.floatingCTA && <FloatingCTA ctaRef={`blog-${slug}`} />}
             </main>
           </article>
@@ -339,10 +385,10 @@ function CTAs({
             <Button
               variant="primary"
               size="sm"
-              href={`https://www.inngest.com/content/ai-in-production-report-2026?ref=${ctaRef}`}
+              href={`/blog/ai-in-production-report-2026?ref=${ctaRef}`}
               arrow="right"
             >
-              View Key Findings
+              Read the report
             </Button>
           </div>
           <div className="flex-shrink-0">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -767,7 +767,7 @@ ul.check li {
 }
 
 .report-prose > .report-full-bleed {
-  max-width: 75ch;
+  max-width: none;
   width: 100%;
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -755,6 +755,62 @@ ul.check li {
   margin: 0 0.25rem 0 0;
 }
 
+/**
+ * Report blog posts (reportLayout: true): override default prose column
+ * constraints so charts fill the content column while body copy stays readable.
+ */
+.report-prose > * {
+  max-width: none;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.report-prose > p,
+.report-prose > h2,
+.report-prose > h3,
+.report-prose > h4,
+.report-prose > ul,
+.report-prose > ol {
+  max-width: 75ch;
+}
+
+.report-prose h2 {
+  font-family: "Whyte Inktrap", Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 1.875rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin-top: 3rem;
+}
+
+.report-prose h3 {
+  font-family: "Whyte Inktrap", Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 1.625rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin-top: 2.5rem;
+}
+
+@media (min-width: 768px) {
+  .report-prose h2 {
+    font-size: 2.25rem;
+  }
+
+  .report-prose h3 {
+    font-size: 1.875rem;
+  }
+}
+
+.report-prose > p:has(> img) {
+  max-width: none;
+}
+
+.report-prose table {
+  max-width: none;
+  width: 100%;
+}
+
 .blog-image-container\:2 {
   display: grid;
   gap: 1rem;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -756,13 +756,35 @@ ul.check li {
 }
 
 /**
- * Report blog posts (reportLayout: true): override default prose column
- * constraints so charts fill the content column while body copy stays readable.
+ * Report blog posts (reportLayout: true): body copy, charts, and blockquotes
+ * share a 75ch measure. Section breaks and exec summary opt into full bleed.
  */
 .report-prose > * {
-  max-width: none;
+  max-width: 75ch;
+  width: 100%;
   margin-left: 0;
   margin-right: 0;
+}
+
+.report-prose > .report-full-bleed {
+  max-width: none;
+  width: 100%;
+}
+
+.report-prose > figure.report-chart {
+  max-width: 75ch !important;
+  width: 100%;
+}
+
+.report-prose > figure {
+  display: block;
+}
+
+.report-prose > figure img,
+.report-prose > figure span {
+  max-width: 100% !important;
+  width: 100% !important;
+  height: auto !important;
 }
 
 .report-prose > p,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -767,7 +767,7 @@ ul.check li {
 }
 
 .report-prose > .report-full-bleed {
-  max-width: none;
+  max-width: 75ch;
   width: 100%;
 }
 


### PR DESCRIPTION
Adds PDF-aligned report layout, section breaks, charts, and TOC so the survey findings are readable on the site without leaving the blog.

Itll start as a 'blog' but I think we can re-label it as a report in the resources center later on.