### PR TITLE
Deferred Functions: reference docs, changelog, and nav entry

### DIFF
--- a/content/changelog/2026-06-05-deferred-functions.mdx
+++ b/content/changelog/2026-06-05-deferred-functions.mdx
@@ -1,0 +1,15 @@
+export const title = "Deferred Functions: fire-and-forget background work with typed payloads";
+export const date = "2026-06-05";
+
+Deferred Functions are a new way to launch independent background work from inside an Inngest function. Call `defer("some-id", { function, data })` and the parent run keeps executing — the deferred run is fully independent, with its own retries, concurrency, step state, and typed payload.
+
+Reach for them when work should happen *because of* a run, not *as part of* it: scoring an agent's output, sending a notification, logging a side effect, or queueing follow-up work.
+
+- **Fire-and-forget** — `defer(...)` is synchronous and returns `void`. The parent doesn't block and never sees a result.
+- **Typed payloads** — Define a [Standard Schema](https://standardschema.dev/?ref=inngest) on the deferred function and `data` is validated on both the caller and receiver side, then typed in the handler.
+- **Fully independent runs** — Each call triggers its own run with its own retries, concurrency, and step state. Multiple parents can target the same deferred function.
+- **Works inside steps** — Call `defer(...)` directly in a handler or from inside `step.run()`.
+
+Deferred Functions are available now in beta via `createDefer` from `inngest/experimental` in the TypeScript SDK. A great use case is the new [deferred LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=changelog-deferred-functions).
+
+See the [Deferred Functions reference](/docs/reference/typescript/v4/functions/deferred-functions?ref=changelog-deferred-functions) for the full API.

--- a/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
+++ b/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
@@ -1,0 +1,155 @@
+import { Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
+
+export const description = "Fire-and-forget independent work with typed data using deferred functions."
+
+# Deferred Functions
+
+A deferred function is an Inngest function that runs in the background as a side effect of another run. Instead of the usual triggers, a parent run launches it by calling `defer("some-id", { function, data })`. The parent doesn't wait, doesn't see a result, and keeps executing. The deferred run is fully independent: its own retries, concurrency, step state, and typed payload.
+
+<Callout variant="info">
+  Deferred functions are experimental. `createDefer` is imported from `inngest/experimental` and the API may change before GA.
+</Callout>
+
+Use deferred functions for work that should happen *because of* a run, not *as part of* it: scoring an agent's output, sending a notification, logging a side effect, queueing follow-up work. Any function can call the same deferred function, and each call is its own run.
+
+## When to use
+
+| Tool                            | Returns to caller?  | Independent execution?    |
+| ------------------------------- | ------------------- | ------------------------- |
+| `step.invoke(fn, { data })`     | Yes (awaits result) | No (caller blocks)        |
+| `step.sendEvent(...)`           | No                  | Yes (any matching fn)     |
+| `defer(id, { function, data })` | No                  | Yes (single typed target) |
+
+A common use case is an [LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring) that runs against the output of an agent run.
+
+---
+
+## Defining a deferred function
+
+Use `createDefer` to define a deferred function:
+
+```ts
+import { createDefer } from "inngest/experimental";
+import { z } from "zod";
+
+export const sendEmail = createDefer(
+  inngest,
+  {
+    id: "send-email",
+    schema: z.object({ to: z.string(), body: z.string() }),
+    concurrency: { limit: 5 },
+  },
+  async ({ event, step }) => {
+    event.data.to; // typed from `schema`
+    event.data.body;
+  }
+);
+```
+
+A deferred function is a regular Inngest function with its own retries, concurrency, and step state. Register it alongside your other functions in the serve handler:
+
+```ts
+serve({ client: inngest, functions: [...myFunctions, sendEmail] });
+```
+
+### `createDefer(client, config, handler): DeferredFunction`
+
+`createDefer` mirrors [`inngest.createFunction`](/docs/reference/typescript/v4/functions/create) with a few differences:
+
+- The client is the first positional argument.
+- `triggers` is not accepted — the function is triggered implicitly by `defer(...)`.
+- `schema` describes the payload that callers send.
+- `onFailure` and `batchEvents` are not currently supported.
+
+<Properties>
+  <Property name="client" type="Inngest" required>
+    Your Inngest client instance.
+  </Property>
+  <Property name="config" type="object" required>
+    Function configuration. Accepts the same options as `inngest.createFunction` (`concurrency`, `throttle`, `rateLimit`, etc.) except `triggers`, `onFailure`, and `batchEvents`, and adds `schema`.
+    <Properties nested>
+      <Property name="id" type="string" required>
+        A unique identifier for the function.
+      </Property>
+      <Property name="schema" type="StandardSchemaV1">
+        A [Standard Schema](https://standardschema.dev/) describing the payload that callers send via `defer(...)`. Optional. When present, `data` is validated on both the caller and receiver side and types `event.data` in the handler. Without a schema, `data` falls back to `Record<string, any>`.
+      </Property>
+    </Properties>
+  </Property>
+  <Property name="handler" type="function" required>
+    The async handler. Receives the same arguments as a normal Inngest function handler.
+  </Property>
+</Properties>
+
+---
+
+## Calling `defer`
+
+`defer` is always available on the handler context of any Inngest function:
+
+```ts
+const orderPlaced = inngest.createFunction(
+  { id: "order-placed", triggers: { event: "order/placed" } },
+  async ({ defer }) => {
+    defer("send", {
+      function: sendEmail,
+      data: { to: "a@b.com", body: "hi" },
+    });
+  }
+);
+```
+
+`defer(...)` is **synchronous and fire-and-forget**. It returns `void` and the parent run continues immediately. The deferred run starts when the parent run finalizes.
+
+It also works inside `step.run()`:
+
+```ts
+await step.run("notify", async () => {
+  defer("send", { function: sendEmail, data: { to, body } });
+});
+```
+
+### `defer(id, options): void`
+
+<Properties>
+  <Property name="id" type="string" required>
+    A unique identifier for this call. Must be unique within the parent run — unlike step IDs, no implicit index is appended to dedupe. (This is because `defer` can be used inside `step.run()`, where an implicit index would change on re-entry.)
+  </Property>
+  <Property name="options" type="object" required>
+    <Properties nested>
+      <Property name="function" type="DeferredFunction" required>
+        The deferred function to trigger.
+      </Property>
+      <Property name="data" type="object" required>
+        Payload to send to the deferred function. Typed from `function.schema` when present.
+      </Property>
+    </Properties>
+  </Property>
+</Properties>
+
+---
+
+## Schemas
+
+When `schema` is provided on the deferred function:
+
+- `data` is validated at the call site (synchronously).
+- `data` is validated again on the receiver side. This catches serialization round-trips that change the shape (e.g. a `Date` becoming an ISO string).
+- The same schema types `event.data` in the handler.
+
+Call-site validation must be synchronous because `defer(...)` itself is sync. If the schema's `validate` returns a Promise, the SDK logs an error and the call is skipped. Receiver-side validation is async, so async validators work there.
+
+---
+
+## Error handling
+
+`defer(...)` is fire-and-forget, so a bad call should not derail the surrounding handler.
+
+- **Call-site errors** (for example, a synchronous schema failure) are logged via the internal logger and the call is silently skipped. The parent run continues normally and the deferred function does not fire.
+- **Receiver-side errors** (the deferred run reading invalid `event.data`, or the handler throwing) fail the deferred run itself with normal retry semantics.
+
+---
+
+## Sharing across parent functions
+
+A deferred function is one Inngest function in the backend. Multiple parents can hold a reference to it; each `defer(...)` call triggers an independent run with its own retries and concurrency state.

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -317,6 +317,11 @@ const sectionReference: (NavGroup | NavLink)[] = [
         tag: "new",
       },
       {
+        title: "Deferred Functions",
+        href: tsRef("v4", "functions/deferred-functions"),
+        tag: "beta",
+      },
+      {
         title: "Steps",
         links: [
           {


### PR DESCRIPTION
## Summary

Adds Deferred Functions documentation, extracted from Linell's work on PR #1603 into a clean branch against current main.

Three changes:

- **Deferred Functions reference** (`/docs/reference/typescript/v4/functions/deferred-functions.mdx`): Full API reference for `createDefer` and `defer()`. Covers defining deferred functions, calling them, schemas, error handling, and sharing across parent functions. Diataxis: Reference.
- **Changelog entry** (`content/changelog/2026-06-05-deferred-functions.mdx`): Announces the beta release.
- **Nav entry**: Added under TypeScript SDK v4 in the reference sidebar, tagged as beta.

## Context

Linell originally merged this into the `ben/agent-evals-scoring-docs` branch (PR #1603). That branch had diverged significantly from main. This PR applies the same content cleanly against current main with the updated nav structure (patterns, etc.).

Co-authored-by: Linell Bonnette <tlbonnette@gmail.com>