### PR TITLE
Add two deferred functions patterns

### DIFF
--- a/shared/Patterns/_patterns/deferred-cleanup-and-rollbacks.mdx
+++ b/shared/Patterns/_patterns/deferred-cleanup-and-rollbacks.mdx
@@ -1,0 +1,117 @@
+---
+title: Deferred cleanup and rollbacks
+subtitle: Register background cleanup when you create the mess, cancel it if everything succeeds, and keep your critical path fast.
+pattern: durable
+tags: [Durability, Error Handling]
+---
+
+Multi-step functions create resources along the way. An order gets placed, a payment gets charged, inventory gets allocated. If a later step fails, the earlier resources need to be cleaned up.
+
+The traditional approach is `onFailure`, but that handler only sees the original input and the error. It doesn't know which steps succeeded or what state they left behind. You end up querying external systems to figure out what to undo.
+
+With deferred functions, you register cleanup at the point where you know what needs cleaning up. The deferred run fires after the parent completes. If everything succeeds, you cancel the cleanup before it runs.
+
+## How this works
+
+Define a deferred function for each type of cleanup. Register it right after the step that creates the thing you might need to undo.
+
+```typescript
+import { createDefer } from "inngest/experimental";
+import { z } from "zod";
+
+const refundPayment = createDefer(inngest, {
+  id: "refund-payment",
+  schema: z.object({ chargeId: z.string(), amount: z.number() }),
+}, async ({ event, step }) => {
+  await step.run("issue-refund", async () => {
+    await stripe.refunds.create({
+      charge: event.data.chargeId,
+      amount: event.data.amount,
+    });
+  });
+});
+
+const releaseInventory = createDefer(inngest, {
+  id: "release-inventory",
+  schema: z.object({ sku: z.string(), quantity: z.number() }),
+}, async ({ event, step }) => {
+  await step.run("release-stock", async () => {
+    await inventory.release(event.data.sku, event.data.quantity);
+  });
+});
+```
+
+Register them alongside your functions:
+
+```typescript
+serve({
+  client: inngest,
+  functions: [processOrder, refundPayment, releaseInventory],
+});
+```
+
+In your main function, register cleanup after each step. Cancel all of them at the end if the order succeeds.
+
+```typescript
+const processOrder = inngest.createFunction(
+  { id: "process-order", triggers: { event: "order/placed" } },
+  async ({ event, step, defer }) => {
+    const charge = await step.run("charge-card", async () => {
+      return await stripe.charges.create({
+        amount: event.data.total,
+        currency: "usd",
+        source: event.data.paymentSource,
+      });
+    });
+
+    // Register refund cleanup. Fires after the parent run ends.
+    const refundHandle = defer("refund-if-failed", {
+      function: refundPayment,
+      data: { chargeId: charge.id, amount: charge.amount },
+    });
+
+    const allocation = await step.run("allocate-inventory", async () => {
+      return await inventory.allocate(
+        event.data.sku,
+        event.data.quantity,
+      );
+    });
+
+    // Register inventory cleanup.
+    const inventoryHandle = defer("release-if-failed", {
+      function: releaseInventory,
+      data: { sku: event.data.sku, quantity: event.data.quantity },
+    });
+
+    await step.run("create-shipment", async () => {
+      return await shipping.createLabel(event.data.address, allocation);
+    });
+
+    // Everything succeeded. Cancel both cleanups.
+    refundHandle.cancel();
+    inventoryHandle.cancel();
+
+    return { status: "shipped", chargeId: charge.id };
+  }
+);
+```
+
+If `create-shipment` fails after retries are exhausted, the parent run ends in a failed state. Both deferred functions fire: the refund goes out and the inventory is released. If everything succeeds, both are cancelled and never run.
+
+Each deferred function is its own independent run with its own retries. A failed refund doesn't block the inventory release. You see both in the trace view linked to the parent run.
+
+## Alternative approaches
+
+Without deferred functions, you have a few options:
+
+- **`onFailure` handler.** Receives the error and the original event, but not intermediate step outputs. You have to re-derive what was charged and what was allocated from external systems.
+- **Try/catch/finally in the function.** Works, but the cleanup runs in the same function execution. If the cleanup itself fails, the whole run fails and retries from the beginning.
+- **Send events to separate functions.** Achieves the same decoupling, but you lose the typed schema and the automatic parent/child linking in the UI. You also have to manually track which events to send on failure.
+
+Deferred functions give you the decoupling of separate functions with the co-location and typed data of inline code. The cleanup logic lives next to the code that created the resource, and each cleanup run is independently retried.
+
+## Additional resources
+
+- [Deferred Functions reference](/docs/reference/typescript/v4/functions/deferred-functions)
+- [Error handling](/docs/guides/error-handling)
+- [Handling failures](/docs/reference/typescript/v4/functions/handling-failures)

--- a/shared/Patterns/_patterns/post-completion-side-effects.mdx
+++ b/shared/Patterns/_patterns/post-completion-side-effects.mdx
@@ -7,7 +7,9 @@ tags: [Durability, AI, Architecture]
 
 AI agent functions do expensive, latency-sensitive work: calling models, executing tool loops, generating responses. After the agent finishes, you need to do secondary things that the user should never wait for: score the output quality, log token costs to track spend per customer, send a summary to Slack, update a CRM record.
 
-If you add those as steps at the end of the function, a failure in your analytics pipeline retries the entire agent run, including the model calls you already paid for. If you send events to separate functions, you lose the typed connection to the data the agent just produced.
+If you add those as steps at the end of the function, the parent run stays open while secondary work completes. A failure in your analytics step marks the entire run as failed and triggers retries of a run that already did its job. The parent's success status ends up depending on work the user doesn't care about.
+
+If you send events to separate functions, you lose the typed connection to the data the agent just produced.
 
 Deferred functions solve this. Register side effects inline with typed payloads. The agent returns immediately. Each side effect runs as its own function after the parent finalizes, with independent retries and no impact on the parent's success status.
 
@@ -159,16 +161,15 @@ const handleTicket = inngest.createFunction(
 
 The agent responds to the customer in under a second. Three deferred functions fire after the parent finalizes: one scores the output with a cheaper model, one logs token costs per customer, one posts to Slack. Each has its own retries. If Slack is down, scoring and cost tracking still succeed. If the scoring model is slow, the customer already has their answer.
 
-## Why this matters for AI
+## Why not just add more steps?
 
-AI functions are uniquely expensive to retry. A failed analytics step at the end of a function that made three GPT-4o calls means re-running those calls on retry. With deferred functions, the agent run succeeds or fails based on the agent work alone. The scoring, logging, and notifications run on their own lifecycle.
+Adding `step.run("log-usage", ...)` at the end of the function works, and completed steps are memoized so retries skip them. But the parent run stays open while secondary work completes. If the analytics step fails, the entire run is marked as failed even though the agent already delivered the response. The parent's success status ends up reflecting work the user doesn't care about.
 
-This also opens up patterns like LLM-as-judge scoring where you use a second model to evaluate the first. That evaluation can take seconds or minutes, and it should never hold the user's response hostage.
+Deferred functions keep the parent run clean. It succeeds or fails based on the agent work alone. The side effects run on their own timeline with their own success/failure status.
 
 ## Alternative approaches
 
-- **Add more steps at the end.** A failure in analytics retries the entire function, including the model calls. Expensive and wasteful.
-- **Send events to separate functions.** Works, but you lose the typed schema and the parent/child linking in traces. You serialize data into event payloads manually.
+- **Send events to trigger separate functions.** Works, but you lose the typed schema and the parent/child linking in traces. You serialize data into event payloads manually.
 - **External eval platforms (Braintrust, LangSmith, Arize).** Scoring and cost tracking live in a separate system. Tightening the feedback loop between your agent code and its evaluation requires maintaining two platforms.
 - **Fire-and-forget HTTP calls.** No retries, no observability, no connection to the run that produced the data.
 

--- a/shared/Patterns/_patterns/post-completion-side-effects.mdx
+++ b/shared/Patterns/_patterns/post-completion-side-effects.mdx
@@ -1,95 +1,154 @@
 ---
-title: Post-completion side effects
-subtitle: Run analytics, notifications, and logging after your function finishes without blocking the critical path or losing context.
+title: Post-completion side effects for AI agents
+subtitle: Score model output, log token costs, and notify your team after an agent run finishes without blocking the response or losing context.
 pattern: durable
 tags: [Durability, AI, Architecture]
 ---
 
-Your function does the important work. After it finishes, you need to do secondary things: log token usage, send a Slack summary, update a CRM record, track analytics. None of that should block the user-facing response or affect the parent run's success status.
+AI agent functions do expensive, latency-sensitive work: calling models, executing tool loops, generating responses. After the agent finishes, you need to do secondary things that the user should never wait for: score the output quality, log token costs to track spend per customer, send a summary to Slack, update a CRM record.
 
-Today you either do this before the return (blocking) or send events to separate functions (losing easy access to the data your function just produced). Deferred functions let you register side effects inline, keep them typed and linked to the parent, and run them independently after the parent completes.
+If you add those as steps at the end of the function, a failure in your analytics pipeline retries the entire agent run, including the model calls you already paid for. If you send events to separate functions, you lose the typed connection to the data the agent just produced.
+
+Deferred functions solve this. Register side effects inline with typed payloads. The agent returns immediately. Each side effect runs as its own function after the parent finalizes, with independent retries and no impact on the parent's success status.
 
 ## How this works
 
-Define deferred functions for each side effect. Each one receives a typed payload from the parent.
+Define deferred functions for each post-completion task. Each receives a typed payload containing the AI-specific data it needs.
 
 ```typescript
 import { createDefer } from "inngest/experimental";
 import { z } from "zod";
 
-const logUsage = createDefer(inngest, {
-  id: "log-ai-usage",
+const scoreOutput = createDefer(inngest, {
+  id: "score-agent-output",
+  schema: z.object({
+    response: z.string(),
+    model: z.string(),
+    ticketId: z.string(),
+  }),
+}, async ({ event, step }) => {
+  // Use a second model as a judge
+  const evaluation = await step.run("llm-as-judge", async () => {
+    return await openai.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [
+        {
+          role: "system",
+          content: "Rate this support response 1-5 for helpfulness, accuracy, and tone. Return JSON: { helpfulness: number, accuracy: number, tone: number }",
+        },
+        { role: "user", content: event.data.response },
+      ],
+    });
+  });
+
+  await step.run("persist-scores", async () => {
+    const scores = JSON.parse(evaluation.choices[0].message.content);
+    await inngest.score({ name: "helpfulness", value: scores.helpfulness / 5, runId: event.data.ticketId });
+    await inngest.score({ name: "accuracy", value: scores.accuracy / 5, runId: event.data.ticketId });
+  });
+});
+
+const trackCosts = createDefer(inngest, {
+  id: "track-ai-costs",
   schema: z.object({
     model: z.string(),
     promptTokens: z.number(),
     completionTokens: z.number(),
-    runId: z.string(),
+    customerId: z.string(),
   }),
 }, async ({ event, step }) => {
-  await step.run("record-usage", async () => {
-    await analytics.track("ai.tokens.used", {
+  await step.run("log-usage", async () => {
+    const costPer1k = event.data.model === "gpt-4o" ? 0.005 : 0.00015;
+    const totalTokens = event.data.promptTokens + event.data.completionTokens;
+    const cost = (totalTokens / 1000) * costPer1k;
+
+    await analytics.track("ai.cost.incurred", {
       model: event.data.model,
-      prompt_tokens: event.data.promptTokens,
-      completion_tokens: event.data.completionTokens,
-      inngest_run_id: event.data.runId,
+      tokens: totalTokens,
+      cost_usd: cost,
+      customer_id: event.data.customerId,
     });
   });
 });
 
-const notifySlack = createDefer(inngest, {
-  id: "notify-slack-completion",
+const notifyTeam = createDefer(inngest, {
+  id: "notify-agent-completion",
   schema: z.object({
     channel: z.string(),
     summary: z.string(),
     ticketId: z.string(),
+    model: z.string(),
   }),
 }, async ({ event, step }) => {
-  await step.run("post-message", async () => {
+  await step.run("post-to-slack", async () => {
     await slack.chat.postMessage({
       channel: event.data.channel,
-      text: `Ticket ${event.data.ticketId} resolved: ${event.data.summary}`,
+      text: `Agent resolved ticket ${event.data.ticketId} using ${event.data.model}:\n>${event.data.summary}`,
     });
   });
 });
 ```
 
-In the parent function, call `defer()` with the data each side effect needs. The parent returns immediately. The deferred runs fire after it finalizes.
+Register them alongside your agent function:
+
+```typescript
+serve({
+  client: inngest,
+  functions: [handleTicket, scoreOutput, trackCosts, notifyTeam],
+});
+```
+
+In the agent function, call `defer()` after the work is done. The agent returns the response to the user. Scoring, cost tracking, and notifications happen in the background.
 
 ```typescript
 const handleTicket = inngest.createFunction(
   { id: "handle-support-ticket", triggers: { event: "support/ticket.created" } },
   async ({ event, step, defer }) => {
     const response = await step.run("generate-response", async () => {
-      return await llm.chat({
+      return await openai.chat.completions.create({
         model: "gpt-4o",
         messages: [
-          { role: "system", content: "You are a support agent." },
+          { role: "system", content: "You are a support agent. Be concise and helpful." },
           { role: "user", content: event.data.content },
         ],
       });
     });
 
+    const reply = response.choices[0].message.content;
+
     await step.run("send-reply", async () => {
-      await supportPlatform.reply(event.data.ticketId, response.text);
+      await supportPlatform.reply(event.data.ticketId, reply);
     });
 
-    // Side effects. None of these block the response.
-    defer("log-tokens", {
-      function: logUsage,
+    // Score the response with LLM-as-judge. Runs after the parent finishes.
+    defer("score-quality", {
+      function: scoreOutput,
       data: {
-        model: response.model,
-        promptTokens: response.usage.prompt_tokens,
-        completionTokens: response.usage.completion_tokens,
-        runId: event.data.runId,
+        response: reply,
+        model: "gpt-4o",
+        ticketId: event.data.ticketId,
       },
     });
 
-    defer("notify-team", {
-      function: notifySlack,
+    // Track token costs per customer.
+    defer("track-spend", {
+      function: trackCosts,
+      data: {
+        model: "gpt-4o",
+        promptTokens: response.usage.prompt_tokens,
+        completionTokens: response.usage.completion_tokens,
+        customerId: event.data.customerId,
+      },
+    });
+
+    // Notify the team.
+    defer("notify-slack", {
+      function: notifyTeam,
       data: {
         channel: "#support-resolved",
-        summary: response.text.slice(0, 200),
+        summary: reply.slice(0, 200),
         ticketId: event.data.ticketId,
+        model: "gpt-4o",
       },
     });
 
@@ -98,26 +157,24 @@ const handleTicket = inngest.createFunction(
 );
 ```
 
-The parent run completes and returns `resolved`. The token logging and Slack notification run as separate functions with their own retries. If Slack is down, the notification retries without affecting the parent. If analytics fails, the customer still got their response.
+The agent responds to the customer in under a second. Three deferred functions fire after the parent finalizes: one scores the output with a cheaper model, one logs token costs per customer, one posts to Slack. Each has its own retries. If Slack is down, scoring and cost tracking still succeed. If the scoring model is slow, the customer already has their answer.
 
-## Why not just add more steps?
+## Why this matters for AI
 
-Adding `step.run("log-usage", ...)` at the end of the function works, but it means:
+AI functions are uniquely expensive to retry. A failed analytics step at the end of a function that made three GPT-4o calls means re-running those calls on retry. With deferred functions, the agent run succeeds or fails based on the agent work alone. The scoring, logging, and notifications run on their own lifecycle.
 
-- The function stays running longer than it needs to.
-- A failure in analytics logging fails the whole run and triggers retries of the entire function.
-- The parent run's success status depends on secondary work that the user doesn't care about.
-
-Deferred functions keep the parent run clean. It succeeds or fails based on the work that matters. The side effects run on their own timeline.
+This also opens up patterns like LLM-as-judge scoring where you use a second model to evaluate the first. That evaluation can take seconds or minutes, and it should never hold the user's response hostage.
 
 ## Alternative approaches
 
-- **Send events to trigger separate functions.** Works, but you lose the typed schema contract and the parent/child linking in traces. You also need to serialize all the data into the event payload manually.
-- **Fire-and-forget HTTP calls.** No retries, no observability, no way to know if they succeeded.
-- **External tools (Segment, Datadog agents).** Fine for generic telemetry, but you lose the run-level context that makes Inngest traces useful.
+- **Add more steps at the end.** A failure in analytics retries the entire function, including the model calls. Expensive and wasteful.
+- **Send events to separate functions.** Works, but you lose the typed schema and the parent/child linking in traces. You serialize data into event payloads manually.
+- **External eval platforms (Braintrust, LangSmith, Arize).** Scoring and cost tracking live in a separate system. Tightening the feedback loop between your agent code and its evaluation requires maintaining two platforms.
+- **Fire-and-forget HTTP calls.** No retries, no observability, no connection to the run that produced the data.
 
 ## Additional resources
 
 - [Deferred Functions reference](/docs/reference/typescript/v4/functions/deferred-functions)
 - [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring)
+- [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring)
 - [Keeping your API fast](/patterns/keeping-your-api-fast)

--- a/shared/Patterns/_patterns/post-completion-side-effects.mdx
+++ b/shared/Patterns/_patterns/post-completion-side-effects.mdx
@@ -1,0 +1,123 @@
+---
+title: Post-completion side effects
+subtitle: Run analytics, notifications, and logging after your function finishes without blocking the critical path or losing context.
+pattern: durable
+tags: [Durability, AI, Architecture]
+---
+
+Your function does the important work. After it finishes, you need to do secondary things: log token usage, send a Slack summary, update a CRM record, track analytics. None of that should block the user-facing response or affect the parent run's success status.
+
+Today you either do this before the return (blocking) or send events to separate functions (losing easy access to the data your function just produced). Deferred functions let you register side effects inline, keep them typed and linked to the parent, and run them independently after the parent completes.
+
+## How this works
+
+Define deferred functions for each side effect. Each one receives a typed payload from the parent.
+
+```typescript
+import { createDefer } from "inngest/experimental";
+import { z } from "zod";
+
+const logUsage = createDefer(inngest, {
+  id: "log-ai-usage",
+  schema: z.object({
+    model: z.string(),
+    promptTokens: z.number(),
+    completionTokens: z.number(),
+    runId: z.string(),
+  }),
+}, async ({ event, step }) => {
+  await step.run("record-usage", async () => {
+    await analytics.track("ai.tokens.used", {
+      model: event.data.model,
+      prompt_tokens: event.data.promptTokens,
+      completion_tokens: event.data.completionTokens,
+      inngest_run_id: event.data.runId,
+    });
+  });
+});
+
+const notifySlack = createDefer(inngest, {
+  id: "notify-slack-completion",
+  schema: z.object({
+    channel: z.string(),
+    summary: z.string(),
+    ticketId: z.string(),
+  }),
+}, async ({ event, step }) => {
+  await step.run("post-message", async () => {
+    await slack.chat.postMessage({
+      channel: event.data.channel,
+      text: `Ticket ${event.data.ticketId} resolved: ${event.data.summary}`,
+    });
+  });
+});
+```
+
+In the parent function, call `defer()` with the data each side effect needs. The parent returns immediately. The deferred runs fire after it finalizes.
+
+```typescript
+const handleTicket = inngest.createFunction(
+  { id: "handle-support-ticket", triggers: { event: "support/ticket.created" } },
+  async ({ event, step, defer }) => {
+    const response = await step.run("generate-response", async () => {
+      return await llm.chat({
+        model: "gpt-4o",
+        messages: [
+          { role: "system", content: "You are a support agent." },
+          { role: "user", content: event.data.content },
+        ],
+      });
+    });
+
+    await step.run("send-reply", async () => {
+      await supportPlatform.reply(event.data.ticketId, response.text);
+    });
+
+    // Side effects. None of these block the response.
+    defer("log-tokens", {
+      function: logUsage,
+      data: {
+        model: response.model,
+        promptTokens: response.usage.prompt_tokens,
+        completionTokens: response.usage.completion_tokens,
+        runId: event.data.runId,
+      },
+    });
+
+    defer("notify-team", {
+      function: notifySlack,
+      data: {
+        channel: "#support-resolved",
+        summary: response.text.slice(0, 200),
+        ticketId: event.data.ticketId,
+      },
+    });
+
+    return { ticketId: event.data.ticketId, status: "resolved" };
+  }
+);
+```
+
+The parent run completes and returns `resolved`. The token logging and Slack notification run as separate functions with their own retries. If Slack is down, the notification retries without affecting the parent. If analytics fails, the customer still got their response.
+
+## Why not just add more steps?
+
+Adding `step.run("log-usage", ...)` at the end of the function works, but it means:
+
+- The function stays running longer than it needs to.
+- A failure in analytics logging fails the whole run and triggers retries of the entire function.
+- The parent run's success status depends on secondary work that the user doesn't care about.
+
+Deferred functions keep the parent run clean. It succeeds or fails based on the work that matters. The side effects run on their own timeline.
+
+## Alternative approaches
+
+- **Send events to trigger separate functions.** Works, but you lose the typed schema contract and the parent/child linking in traces. You also need to serialize all the data into the event payload manually.
+- **Fire-and-forget HTTP calls.** No retries, no observability, no way to know if they succeeded.
+- **External tools (Segment, Datadog agents).** Fine for generic telemetry, but you lose the run-level context that makes Inngest traces useful.
+
+## Additional resources
+
+- [Deferred Functions reference](/docs/reference/typescript/v4/functions/deferred-functions)
+- [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring)
+- [Keeping your API fast](/patterns/keeping-your-api-fast)

--- a/shared/Patterns/patternsData.ts
+++ b/shared/Patterns/patternsData.ts
@@ -145,6 +145,20 @@ export const PATTERNS: PatternIndexItem[] = [
       "Break multi-step AI pipelines and complex business logic into durable, independently retried steps.",
   },
   {
+    category: "durable",
+    slug: "deferred-cleanup-and-rollbacks",
+    title: "Deferred cleanup and rollbacks",
+    subtitle:
+      "Register background cleanup when you create the mess, cancel it if everything succeeds, and keep your critical path fast.",
+  },
+  {
+    category: "durable",
+    slug: "post-completion-side-effects",
+    title: "Post-completion side effects",
+    subtitle:
+      "Run analytics, notifications, and logging after your function finishes without blocking the critical path or losing context.",
+  },
+  {
     category: "flow",
     slug: "flash-sales-and-bursty-workflows",
     title: "Flash sales and bursty workflows",

--- a/shared/Patterns/patternsData.ts
+++ b/shared/Patterns/patternsData.ts
@@ -154,9 +154,9 @@ export const PATTERNS: PatternIndexItem[] = [
   {
     category: "durable",
     slug: "post-completion-side-effects",
-    title: "Post-completion side effects",
+    title: "Post-completion side effects for AI agents",
     subtitle:
-      "Run analytics, notifications, and logging after your function finishes without blocking the critical path or losing context.",
+      "Score model output, log token costs, and notify your team after an agent run finishes without blocking the response or losing context.",
   },
   {
     category: "flow",


### PR DESCRIPTION
## Summary

Two new pattern pages for deferred functions (`createDefer` / `defer()`).

**Deferred cleanup and rollbacks** — An order processing function registers cleanup (refund, release inventory) after each step via `defer()`, then cancels both if everything succeeds. Shows the `.cancel()` API.

**Post-completion side effects** — An AI support ticket handler defers token usage logging and Slack notification after the parent completes. Shows why defer is better than adding more steps at the end.

Both are Diataxis Explanation (pattern) pages matching the existing pattern structure.

Depends on PR #1633 (Deferred Functions reference docs) for cross-links.

Resolves DEV-380