### PR TITLE
CLI docs: reference, debug guide, and coding agent guide

### DIFF
--- a/pages/docs/ai-patterns/cli-for-coding-agents.mdx
+++ b/pages/docs/ai-patterns/cli-for-coding-agents.mdx
@@ -33,10 +33,10 @@ Tell the agent how to use the CLI. Add this to your project's `CLAUDE.md`, `.cur
 
 Use the Inngest CLI to inspect function runs and traces:
 
-- Get a run: `npx inngest-cli@latest api --prod get-run <run_id>`
+- Get a run: `npx inngest-cli@latest api --prod get-function-run <run_id>`
 - Get a trace: `npx inngest-cli@latest api --prod get-function-trace <run_id> --include-output`
 - Get runs from an event: `npx inngest-cli@latest api --prod get-event-runs <event_id> --include-output --limit 5`
-- Invoke locally: `npx inngest-cli@latest api invoke-function-by-slug <function_slug> --data '{...}'`
+- Invoke locally: `npx inngest-cli@latest api invoke-function <app_id> <function_id> --data '{...}'`
 
 Output is JSON. Use jq to filter.
 ```
@@ -66,7 +66,7 @@ It reads the trace, identifies the failing step, sees the error output, and prop
 After the agent makes a code change, it can invoke the function locally against the dev server:
 
 ```bash
-npx inngest-cli@latest api invoke-function-by-slug my-app-process-order \
+npx inngest-cli@latest api invoke-function my-app process-order \
   --data '{"orderId": "test-123"}'
 ```
 

--- a/pages/docs/ai-patterns/cli-for-coding-agents.mdx
+++ b/pages/docs/ai-patterns/cli-for-coding-agents.mdx
@@ -1,0 +1,95 @@
+export const description = "Give your coding agent access to Inngest runs, traces, and function invocation using the CLI and REST API."
+
+# Use the CLI with coding agents
+
+Coding agents like Claude Code, Cursor, and Codex can use the Inngest CLI to pull real execution data when debugging or iterating on your functions. Instead of guessing what happened, the agent reads the actual trace.
+
+## Prerequisites
+
+- Inngest CLI: `npx inngest-cli@latest`
+- An environment-scoped API key set as `INNGEST_API_KEY`
+- A coding agent that can run shell commands
+
+---
+
+## 1. Give the agent your API key
+
+Set the API key in your environment so the agent's shell commands can access it:
+
+```bash
+export INNGEST_API_KEY=sk-inn-api-...
+```
+
+For Claude Code, add it to your project's `.env` or pass it in your shell profile. The agent inherits the environment.
+
+---
+
+## 2. Add Inngest context to your agent
+
+Tell the agent how to use the CLI. Add this to your project's `CLAUDE.md`, `.cursorrules`, or equivalent:
+
+```markdown
+## Inngest debugging
+
+Use the Inngest CLI to inspect function runs and traces:
+
+- Get a run: `npx inngest-cli@latest api --prod get-run <run_id>`
+- Get a trace: `npx inngest-cli@latest api --prod get-function-trace <run_id> --include-output`
+- Get runs from an event: `npx inngest-cli@latest api --prod get-event-runs <event_id> --include-output --limit 5`
+- Invoke locally: `npx inngest-cli@latest api invoke-function-by-slug <function_slug> --data '{...}'`
+
+Output is JSON. Use jq to filter.
+```
+
+The agent now knows to reach for the CLI when it needs execution context.
+
+---
+
+## 3. Debug a failing function
+
+When a function fails, point the agent at the run ID:
+
+> "The run 01ABC123 is failing in production. Use the Inngest CLI to get the trace and figure out which step is broken."
+
+The agent runs:
+
+```bash
+npx inngest-cli@latest api --prod get-function-trace 01ABC123 --include-output
+```
+
+It reads the trace, identifies the failing step, sees the error output, and proposes a fix with real context instead of guessing.
+
+---
+
+## 4. Test the fix
+
+After the agent makes a code change, it can invoke the function locally against the dev server:
+
+```bash
+npx inngest-cli@latest api invoke-function-by-slug my-app-process-order \
+  --data '{"orderId": "test-123"}'
+```
+
+Then check the result:
+
+```bash
+npx inngest-cli@latest api get-event-runs <event_id> --include-output
+```
+
+The agent verifies its own fix without leaving the terminal.
+
+---
+
+## Why this matters
+
+Without the CLI, an agent debugging an Inngest function has to guess what happened based on code alone. With the CLI, it reads the actual execution trace: which steps ran, which failed, what the error was, and what the output looked like. The feedback loop gets tighter.
+
+This also means the agent can pull production data to reproduce issues locally, compare expected vs actual output, and verify fixes before pushing.
+
+---
+
+## Next steps
+
+- [Inngest CLI reference](/docs/cli) for all commands and options
+- [Debug a function run from your terminal](/docs/guides/debug-with-cli) for the manual workflow
+- [REST API documentation](https://api-docs.inngest.com) for direct HTTP access

--- a/pages/docs/cli.mdx
+++ b/pages/docs/cli.mdx
@@ -30,13 +30,13 @@ export INNGEST_API_KEY=sk-inn-api-...
 
 ```bash
 # Get a function run
-npx inngest-cli@latest api get-run 01KTCTWT8XDEGWDMVX3Q9M69ND
+npx inngest-cli@latest api get-function-run 01KTCTWT8XDEGWDMVX3Q9M69ND
 
 # Get runs triggered by an event
 npx inngest-cli@latest api get-event-runs 01KTCTWSZJEKAFEDA4F9GYHFQW --include-output --limit 5
 
-# Invoke a function by slug
-npx inngest-cli@latest api invoke-function-by-slug my-app-my-function --data '{"message": "hello"}'
+# Invoke a function
+npx inngest-cli@latest api invoke-function my-app my-function --data '{"message": "hello"}'
 
 # Fetch a full trace
 npx inngest-cli@latest api get-function-trace 01KTCTWT8XDEGWDMVX3Q9M69ND --include-output
@@ -67,21 +67,20 @@ The CLI targets your local dev server by default. Use `--prod` to hit Inngest Cl
 
 ```bash
 # Local dev server (default)
-npx inngest-cli@latest api get-run 01ABC123
+npx inngest-cli@latest api get-function-run 01ABC123
 
 # Inngest Cloud
-npx inngest-cli@latest api --prod get-run 01ABC123
+npx inngest-cli@latest api --prod get-function-run 01ABC123
 
-# Explicit URL
-npx inngest-cli@latest api --api-url http://localhost:8288 get-run 01ABC123
+# Custom API host
+npx inngest-cli@latest api --api-host http://localhost:8288 get-function-run 01ABC123
 ```
 
 Target resolution:
 
-1. `--api-url` flag
-2. `INNGEST_API_URL` environment variable
-3. `INNGEST_DEV=1` (implies `http://localhost:8288`)
-4. Default: local dev server
+1. `--api-host` or `--api-port` flags
+2. `--prod` flag
+3. Default: local dev server
 
 ---
 
@@ -91,14 +90,14 @@ All commands live under `inngest-cli api`. Run `--help` on any command to see it
 
 ```bash
 npx inngest-cli@latest api --help
-npx inngest-cli@latest api get-run --help
+npx inngest-cli@latest api get-function-run --help
 ```
 
 ### Runs
 
 | Command | Description |
 |---------|-------------|
-| `get-run <run_id>` | Get a function run summary |
+| `get-function-run <run_id>` | Get a function run summary |
 | `get-function-trace <run_id>` | Get the full trace with step spans |
 | `get-event-runs <event_id>` | List runs triggered by a specific event |
 
@@ -106,7 +105,7 @@ npx inngest-cli@latest api get-run --help
 
 | Command | Description |
 |---------|-------------|
-| `invoke-function-by-slug <slug>` | Invoke a function with a JSON payload |
+| `invoke-function <app_id> <function_id>` | Invoke a function with a JSON payload |
 
 Common flags:
 
@@ -122,10 +121,10 @@ The CLI outputs compact JSON by default. Pipe to jq or other tools:
 
 ```bash
 # Get just the status
-npx inngest-cli@latest api --prod get-run 01ABC123 | jq '.data.status'
+npx inngest-cli@latest api --prod get-function-run 01ABC123 | jq '.data.status'
 
 # Pretty print
-npx inngest-cli@latest api --prod get-run 01ABC123 | jq .
+npx inngest-cli@latest api --prod get-function-run 01ABC123 | jq .
 ```
 
 ---

--- a/pages/docs/cli.mdx
+++ b/pages/docs/cli.mdx
@@ -1,52 +1,48 @@
-import { Callout } from "src/shared/Docs/mdx";
+import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
 export const description = "Use the Inngest CLI to inspect runs, fetch traces, and invoke functions from your terminal or coding agent."
 
 # Inngest CLI
 
-The Inngest CLI gives you direct access to your functions, runs, and traces from the terminal. Use it to debug issues, test functions, and give coding agents access to your Inngest data.
+Inspect runs, fetch traces, invoke functions, and give coding agents access to your Inngest data from the terminal.
 
-Install and run with npx:
-
-```bash
+<CodeGroup>
+```bash {{ title: "npx" }}
 npx inngest-cli@latest
 ```
-
-The CLI auto-generates commands from the Inngest v2 REST API. Every API endpoint is available as a CLI subcommand under `inngest-cli api`.
+```bash {{ title: "brew" }}
+brew install inngest/tap/inngest
+```
+```bash {{ title: "curl" }}
+curl -sfL https://cli.inngest.com/install.sh | sh
+```
+</CodeGroup>
 
 ---
 
 ## Quick start
 
-Set your API key:
+Set your API key and start inspecting runs:
 
 ```bash
 export INNGEST_API_KEY=sk-inn-api-...
 ```
 
-Get a function run:
-
 ```bash
+# Get a function run
 npx inngest-cli@latest api get-run 01KTCTWT8XDEGWDMVX3Q9M69ND
-```
 
-Get runs triggered by an event:
-
-```bash
+# Get runs triggered by an event
 npx inngest-cli@latest api get-event-runs 01KTCTWSZJEKAFEDA4F9GYHFQW --include-output --limit 5
-```
 
-Invoke a function by slug:
-
-```bash
+# Invoke a function by slug
 npx inngest-cli@latest api invoke-function-by-slug my-app-my-function --data '{"message": "hello"}'
-```
 
-Fetch a full trace:
-
-```bash
+# Fetch a full trace
 npx inngest-cli@latest api get-function-trace 01KTCTWT8XDEGWDMVX3Q9M69ND --include-output
 ```
+
+The CLI auto-generates commands from the Inngest v2 REST API. Every API endpoint is available as a subcommand under `inngest-cli api`.
 
 ---
 
@@ -122,10 +118,10 @@ Common flags:
 
 ## Output format
 
-The CLI outputs compact JSON by default. This is optimized for piping to other tools or parsing in scripts:
+The CLI outputs compact JSON by default. Pipe to jq or other tools:
 
 ```bash
-# Pipe to jq
+# Get just the status
 npx inngest-cli@latest api --prod get-run 01ABC123 | jq '.data.status'
 
 # Pretty print
@@ -137,5 +133,6 @@ npx inngest-cli@latest api --prod get-run 01ABC123 | jq .
 ## Related
 
 - [Debug a function run from your terminal](/docs/guides/debug-with-cli) for a step-by-step guide
+- [Use the CLI with coding agents](/docs/ai-patterns/cli-for-coding-agents) to give Claude Code, Cursor, or Codex access to your Inngest data
 - [REST API documentation](https://api-docs.inngest.com) for the full API reference
 - [API Keys](/docs/platform/api-keys) for key management

--- a/pages/docs/cli.mdx
+++ b/pages/docs/cli.mdx
@@ -1,0 +1,141 @@
+import { Callout } from "src/shared/Docs/mdx";
+
+export const description = "Use the Inngest CLI to inspect runs, fetch traces, and invoke functions from your terminal or coding agent."
+
+# Inngest CLI
+
+The Inngest CLI gives you direct access to your functions, runs, and traces from the terminal. Use it to debug issues, test functions, and give coding agents access to your Inngest data.
+
+Install and run with npx:
+
+```bash
+npx inngest-cli@latest
+```
+
+The CLI auto-generates commands from the Inngest v2 REST API. Every API endpoint is available as a CLI subcommand under `inngest-cli api`.
+
+---
+
+## Quick start
+
+Set your API key:
+
+```bash
+export INNGEST_API_KEY=sk-inn-api-...
+```
+
+Get a function run:
+
+```bash
+npx inngest-cli@latest api get-run 01KTCTWT8XDEGWDMVX3Q9M69ND
+```
+
+Get runs triggered by an event:
+
+```bash
+npx inngest-cli@latest api get-event-runs 01KTCTWSZJEKAFEDA4F9GYHFQW --include-output --limit 5
+```
+
+Invoke a function by slug:
+
+```bash
+npx inngest-cli@latest api invoke-function-by-slug my-app-my-function --data '{"message": "hello"}'
+```
+
+Fetch a full trace:
+
+```bash
+npx inngest-cli@latest api get-function-trace 01KTCTWT8XDEGWDMVX3Q9M69ND --include-output
+```
+
+---
+
+## Authentication
+
+The CLI accepts environment-scoped API keys. These are separate from signing keys and can be scoped to a specific environment.
+
+Create an API key in the [Inngest dashboard](https://app.inngest.com) under Settings > API Keys. Environment-scoped keys automatically target the right environment without any extra configuration.
+
+Auth precedence:
+
+1. `--api-key` flag (explicit override)
+2. `INNGEST_API_KEY` environment variable
+3. `INNGEST_SIGNING_KEY` environment variable (fallback)
+4. Dev server: no auth required
+
+---
+
+## Dev server vs cloud
+
+The CLI targets your local dev server by default. Use `--prod` to hit Inngest Cloud:
+
+```bash
+# Local dev server (default)
+npx inngest-cli@latest api get-run 01ABC123
+
+# Inngest Cloud
+npx inngest-cli@latest api --prod get-run 01ABC123
+
+# Explicit URL
+npx inngest-cli@latest api --api-url http://localhost:8288 get-run 01ABC123
+```
+
+Target resolution:
+
+1. `--api-url` flag
+2. `INNGEST_API_URL` environment variable
+3. `INNGEST_DEV=1` (implies `http://localhost:8288`)
+4. Default: local dev server
+
+---
+
+## Available commands
+
+All commands live under `inngest-cli api`. Run `--help` on any command to see its options:
+
+```bash
+npx inngest-cli@latest api --help
+npx inngest-cli@latest api get-run --help
+```
+
+### Runs
+
+| Command | Description |
+|---------|-------------|
+| `get-run <run_id>` | Get a function run summary |
+| `get-function-trace <run_id>` | Get the full trace with step spans |
+| `get-event-runs <event_id>` | List runs triggered by a specific event |
+
+### Functions
+
+| Command | Description |
+|---------|-------------|
+| `invoke-function-by-slug <slug>` | Invoke a function with a JSON payload |
+
+Common flags:
+
+- `--include-output` includes step and run output in the response
+- `--limit N` limits the number of results
+- `--prod` targets Inngest Cloud instead of the dev server
+
+---
+
+## Output format
+
+The CLI outputs compact JSON by default. This is optimized for piping to other tools or parsing in scripts:
+
+```bash
+# Pipe to jq
+npx inngest-cli@latest api --prod get-run 01ABC123 | jq '.data.status'
+
+# Pretty print
+npx inngest-cli@latest api --prod get-run 01ABC123 | jq .
+```
+
+---
+
+## Related
+
+- [Debug a function run from your terminal](/docs/guides/debug-with-cli) for a step-by-step guide
+- [REST API documentation](https://api-docs.inngest.com) for the full API reference
+- [API Keys](/docs/platform/api-keys) for key management

--- a/pages/docs/guides/debug-with-cli.mdx
+++ b/pages/docs/guides/debug-with-cli.mdx
@@ -1,0 +1,125 @@
+export const description = "Step-by-step guide to inspecting a failed function run and identifying the broken step using the Inngest CLI."
+
+# Debug a function run from your terminal
+
+This guide walks you through finding a failed run, pulling its trace, and identifying which step broke. You do this entirely from the terminal using the Inngest CLI.
+
+## Prerequisites
+
+- Inngest CLI: `npx inngest-cli@latest`
+- An API key set as `INNGEST_API_KEY` (create one in the [Inngest dashboard](https://app.inngest.com) under Settings > API Keys)
+
+---
+
+## 1. Get the run summary
+
+You have a run ID from a log, alert, or the dashboard. Fetch the summary:
+
+```bash
+npx inngest-cli@latest api --prod get-run 01KTCTWT8XDEGWDMVX3Q9M69ND
+```
+
+The response shows the run's status, function, timing, and trigger:
+
+```json
+{
+  "data": {
+    "id": "01KTCTWT8XDEGWDMVX3Q9M69ND",
+    "status": "FAILED",
+    "function": {
+      "name": "process-order",
+      "slug": "my-app-process-order"
+    },
+    "queuedAt": "2026-06-05T21:26:44.765Z",
+    "endedAt": "2026-06-05T21:26:45.954Z",
+    "durationMs": "1096"
+  }
+}
+```
+
+The run failed. Pull the trace to see which step broke.
+
+---
+
+## 2. Fetch the trace
+
+The trace shows every step in the run with its status, timing, and output:
+
+```bash
+npx inngest-cli@latest api --prod get-function-trace 01KTCTWT8XDEGWDMVX3Q9M69ND --include-output
+```
+
+The response is a tree of spans. Each span is a step. Look for the one with a failed status:
+
+```json
+{
+  "data": {
+    "runId": "01KTCTWT8XDEGWDMVX3Q9M69ND",
+    "rootSpan": {
+      "name": "process-order",
+      "status": "FAILED",
+      "children": [
+        {
+          "name": "validate-input",
+          "status": "COMPLETED",
+          "stepOp": "RUN",
+          "durationMs": "12"
+        },
+        {
+          "name": "charge-card",
+          "status": "COMPLETED",
+          "stepOp": "RUN",
+          "durationMs": "340"
+        },
+        {
+          "name": "create-shipment",
+          "status": "FAILED",
+          "stepOp": "RUN",
+          "durationMs": "744",
+          "output": {
+            "error": "shipping API returned 503"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+The `create-shipment` step failed with a 503 from the shipping API. The `validate-input` and `charge-card` steps completed. You know exactly where it broke and what the error was.
+
+---
+
+## 3. Pipe to jq for quick filtering
+
+Extract just the failed steps:
+
+```bash
+npx inngest-cli@latest api --prod get-function-trace 01KTCTWT8XDEGWDMVX3Q9M69ND --include-output \
+  | jq '[.data.rootSpan.children[] | select(.status == "FAILED")]'
+```
+
+---
+
+## 4. Test a fix locally
+
+Once you identify the issue, fix the code and test against your local dev server. The CLI targets the dev server by default:
+
+```bash
+# Invoke the function locally
+npx inngest-cli@latest api invoke-function-by-slug my-app-process-order \
+  --data '{"orderId": "test-123", "address": "123 Main St"}'
+
+# Check the run
+npx inngest-cli@latest api get-event-runs <event_id> --include-output
+```
+
+No `--prod` flag means it hits `http://localhost:8288`. The dev server must be running.
+
+---
+
+## Next steps
+
+- [Inngest CLI reference](/docs/cli) for all commands and auth options
+- [Traces](/docs/platform/monitor/traces) for the dashboard trace view
+- [Error handling](/docs/guides/error-handling) for retry and failure handler patterns

--- a/pages/docs/guides/debug-with-cli.mdx
+++ b/pages/docs/guides/debug-with-cli.mdx
@@ -16,7 +16,7 @@ This guide walks you through finding a failed run, pulling its trace, and identi
 You have a run ID from a log, alert, or the dashboard. Fetch the summary:
 
 ```bash
-npx inngest-cli@latest api --prod get-run 01KTCTWT8XDEGWDMVX3Q9M69ND
+npx inngest-cli@latest api --prod get-function-run 01KTCTWT8XDEGWDMVX3Q9M69ND
 ```
 
 The response shows the run's status, function, timing, and trigger:
@@ -107,7 +107,7 @@ Once you identify the issue, fix the code and test against your local dev server
 
 ```bash
 # Invoke the function locally
-npx inngest-cli@latest api invoke-function-by-slug my-app-process-order \
+npx inngest-cli@latest api invoke-function my-app process-order \
   --data '{"orderId": "test-123", "address": "123 Main St"}'
 
 # Check the run

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -10,17 +10,10 @@ import { parse } from "node:path";
 import { TS_STABLE, type TSVersion } from "./LanguageStore";
 import PATTERN_SECTIONS, { PATTERNS } from "../Patterns/patternsData";
 
-// Build a TypeScript SDK reference path.
-//
-// We intentionally link to the concrete generated SSG route for every version,
-// including the stable version. The versionless public route is served by a
-// rewrite, but its `_next/data/...json` URL does not resolve to JSON on Vercel,
-// which breaks Pages Router client transitions.
 function tsRef(version: TSVersion, path: string): string {
   return `/docs/reference/typescript/${version}/${path}`;
 }
 
-// A basic link in the nav
 export type NavLink = {
   title: string;
   href: string;
@@ -33,18 +26,17 @@ export type NavLinkGroup = {
   title: string;
   className?: string;
 };
-// A group nested of nav links with a header
+
 export type NavGroup = {
   title: string;
   href?: string;
   icon?: React.FC<React.SVGProps<SVGSVGElement>>;
   links: (NavGroup | NavLink | NavSection | NavLinkGroup)[];
-  /* Whether group should be open when there is no active group */
   defaultOpen?: boolean;
   tag?: string;
   target?: string;
 };
-// A nav section with a nested navigation section
+
 export type NavSection = NavLink & {
   icon?: React.FC<React.SVGProps<SVGSVGElement>>;
   matcher?: RegExp | Function;
@@ -56,1350 +48,460 @@ export type NavSection = NavLink & {
   }[];
 };
 
-// =============================================================================
-// REFERENCE SECTION
-// =============================================================================
 const sectionReference: (NavGroup | NavLink)[] = [
   {
     title: "TypeScript SDK v3",
     links: [
-      {
-        title: "Introduction",
-        href: tsRef("v3", "intro"),
-      },
-      {
-        title: "Create the client",
-        href: tsRef("v3", "client/create"),
-      },
-      {
-        title: "Create a function",
-        href: tsRef("v3", "functions/create"),
-      },
-      {
-        title: "Send events",
-        href: tsRef("v3", "events/send"),
-      },
-      {
-        title: "Errors",
-        href: `/docs/reference/typescript/functions/errors`,
-      },
-      {
-        title: "Handling failures",
-        href: tsRef("v3", "functions/handling-failures"),
-      },
-      {
-        title: "Cancel on",
-        href: tsRef("v3", "functions/cancel-on"),
-      },
-      {
-        title: "Concurrency",
-        href: `/docs/functions/concurrency`,
-      },
-      {
-        title: "Rate limit",
-        href: tsRef("v3", "functions/rate-limit"),
-      },
-      {
-        title: "Singleton",
-        href: tsRef("v3", "functions/singleton"),
-      },
-      {
-        title: "Debounce",
-        href: tsRef("v3", "functions/debounce"),
-      },
-      {
-        title: "Function run priority",
-        href: tsRef("v3", "functions/run-priority"),
-      },
-      {
-        title: "Extended Traces",
-        href: tsRef("v3", "extended-traces"),
-      },
-      {
-        title: "Referencing functions",
-        href: `/docs/functions/references`,
-      },
-      {
-        title: "Testing",
-        href: tsRef("v3", "testing"),
-      },
-      {
-        title: "Durable Endpoints",
-        href: tsRef("v3", "durable-endpoints"),
-        tag: "new",
-      },
+      { title: "Introduction", href: tsRef("v3", "intro") },
+      { title: "Create the client", href: tsRef("v3", "client/create") },
+      { title: "Create a function", href: tsRef("v3", "functions/create") },
+      { title: "Send events", href: tsRef("v3", "events/send") },
+      { title: "Errors", href: `/docs/reference/typescript/functions/errors` },
+      { title: "Handling failures", href: tsRef("v3", "functions/handling-failures") },
+      { title: "Cancel on", href: tsRef("v3", "functions/cancel-on") },
+      { title: "Concurrency", href: `/docs/functions/concurrency` },
+      { title: "Rate limit", href: tsRef("v3", "functions/rate-limit") },
+      { title: "Singleton", href: tsRef("v3", "functions/singleton") },
+      { title: "Debounce", href: tsRef("v3", "functions/debounce") },
+      { title: "Function run priority", href: tsRef("v3", "functions/run-priority") },
+      { title: "Extended Traces", href: tsRef("v3", "extended-traces") },
+      { title: "Referencing functions", href: `/docs/functions/references` },
+      { title: "Testing", href: tsRef("v3", "testing") },
+      { title: "Durable Endpoints", href: tsRef("v3", "durable-endpoints"), tag: "new" },
       {
         title: "Steps",
         links: [
-          {
-            title: "step.run()",
-            href: tsRef("v3", "functions/step-run"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sleep()",
-            href: tsRef("v3", "functions/step-sleep"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sleepUntil()",
-            href: tsRef("v3", "functions/step-sleep-until"),
-            className: "font-mono",
-          },
-          {
-            title: "step.invoke()",
-            href: tsRef("v3", "functions/step-invoke"),
-            className: "font-mono",
-          },
-          {
-            title: "step.waitForEvent()",
-            href: tsRef("v3", "functions/step-wait-for-event"),
-            className: "font-mono",
-          },
-          {
-            title: "step.waitForSignal()",
-            href: tsRef("v3", "functions/step-wait-for-signal"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sendEvent()",
-            href: tsRef("v3", "functions/step-send-event"),
-            className: "font-mono",
-          },
+          { title: "step.run()", href: tsRef("v3", "functions/step-run"), className: "font-mono" },
+          { title: "step.sleep()", href: tsRef("v3", "functions/step-sleep"), className: "font-mono" },
+          { title: "step.sleepUntil()", href: tsRef("v3", "functions/step-sleep-until"), className: "font-mono" },
+          { title: "step.invoke()", href: tsRef("v3", "functions/step-invoke"), className: "font-mono" },
+          { title: "step.waitForEvent()", href: tsRef("v3", "functions/step-wait-for-event"), className: "font-mono" },
+          { title: "step.waitForSignal()", href: tsRef("v3", "functions/step-wait-for-signal"), className: "font-mono" },
+          { title: "step.sendEvent()", href: tsRef("v3", "functions/step-send-event"), className: "font-mono" },
         ],
       },
       {
         title: "Serve",
         links: [
-          {
-            title: "Framework handlers",
-            href: `/docs/learn/serving-inngest-functions`,
-          },
-          {
-            title: "Configuration",
-            href: tsRef("v3", "serve"),
-          },
-          {
-            title: "Streaming",
-            href: `/docs/streaming`,
-          },
+          { title: "Framework handlers", href: `/docs/learn/serving-inngest-functions` },
+          { title: "Configuration", href: tsRef("v3", "serve") },
+          { title: "Streaming", href: `/docs/streaming` },
         ],
       },
-      {
-        title: "Realtime",
-        tag: "deprecated",
-        links: [
-          {
-            title: "Overview",
-            href: tsRef("v3", "realtime"),
-          },
-          {
-            title: "React hooks / Next.js",
-            href: tsRef("v3", "realtime/react-hooks"),
-          },
-        ],
-      },
-      {
-        title: "Middleware",
-        links: [
-          {
-            title: "Lifecycle",
-            href: tsRef("v3", "middleware/lifecycle"),
-          },
-          {
-            title: "Examples",
-            href: tsRef("v3", "middleware/examples"),
-          },
-          {
-            title: "TypeScript",
-            href: `/docs/reference/middleware/typescript`,
-          },
-        ],
-      },
-      {
-        title: "Using the SDK",
-        links: [
-          {
-            title: "Environment variables",
-            href: `/docs/sdk/environment-variables`,
-          },
-          {
-            title: "Using TypeScript",
-            href: `/docs/typescript`,
-          },
-          {
-            title: "ESLint plugin",
-            href: `/docs/sdk/eslint`,
-          },
-          {
-            title: "Upgrading to v3",
-            href: tsRef("v3", "migrations/v2-to-v3"),
-          },
-        ],
-      },
+      { title: "Realtime", tag: "deprecated", links: [
+        { title: "Overview", href: tsRef("v3", "realtime") },
+        { title: "React hooks / Next.js", href: tsRef("v3", "realtime/react-hooks") },
+      ]},
+      { title: "Middleware", links: [
+        { title: "Lifecycle", href: tsRef("v3", "middleware/lifecycle") },
+        { title: "Examples", href: tsRef("v3", "middleware/examples") },
+        { title: "TypeScript", href: `/docs/reference/middleware/typescript` },
+      ]},
+      { title: "Using the SDK", links: [
+        { title: "Environment variables", href: `/docs/sdk/environment-variables` },
+        { title: "Using TypeScript", href: `/docs/typescript` },
+        { title: "ESLint plugin", href: `/docs/sdk/eslint` },
+        { title: "Upgrading to v3", href: tsRef("v3", "migrations/v2-to-v3") },
+      ]},
     ],
   },
   {
     title: "TypeScript SDK v4",
     tag: "new",
     links: [
-      {
-        title: "Introduction",
-        href: tsRef("v4", "intro"),
-      },
-      {
-        title: "Create the client",
-        href: tsRef("v4", "client/create"),
-      },
-      {
-        title: "Create a function",
-        href: tsRef("v4", "functions/create"),
-      },
-      {
-        title: "Trigger helpers",
-        href: tsRef("v4", "functions/triggers"),
-      },
-      {
-        title: "Send events",
-        href: tsRef("v4", "events/send"),
-      },
-      {
-        title: "Errors",
-        href: `/docs/reference/typescript/functions/errors`,
-      },
-      {
-        title: "Handling failures",
-        href: tsRef("v4", "functions/handling-failures"),
-      },
-      {
-        title: "Cancel on",
-        href: tsRef("v4", "functions/cancel-on"),
-      },
-      {
-        title: "Concurrency",
-        href: tsRef("v4", "functions/concurrency"),
-      },
-      {
-        title: "Rate limit",
-        href: tsRef("v4", "functions/rate-limit"),
-      },
-      {
-        title: "Singleton",
-        href: tsRef("v4", "functions/singleton"),
-      },
-      {
-        title: "Debounce",
-        href: tsRef("v4", "functions/debounce"),
-      },
-      {
-        title: "Function run priority",
-        href: tsRef("v4", "functions/run-priority"),
-      },
-      {
-        title: "Logging",
-        href: tsRef("v4", "logging"),
-      },
-      {
-        title: "Extended Traces",
-        href: tsRef("v4", "extended-traces"),
-      },
-      {
-        title: "Referencing functions",
-        href: tsRef("v4", "functions/references"),
-      },
-      {
-        title: "Testing",
-        href: tsRef("v4", "testing"),
-      },
-      {
-        title: "Durable Endpoints",
-        href: tsRef("v4", "durable-endpoints"),
-        tag: "new",
-      },
-      {
-        title: "Deferred Functions",
-        href: tsRef("v4", "functions/deferred-functions"),
-        tag: "beta",
-      },
+      { title: "Introduction", href: tsRef("v4", "intro") },
+      { title: "Create the client", href: tsRef("v4", "client/create") },
+      { title: "Create a function", href: tsRef("v4", "functions/create") },
+      { title: "Trigger helpers", href: tsRef("v4", "functions/triggers") },
+      { title: "Send events", href: tsRef("v4", "events/send") },
+      { title: "Errors", href: `/docs/reference/typescript/functions/errors` },
+      { title: "Handling failures", href: tsRef("v4", "functions/handling-failures") },
+      { title: "Cancel on", href: tsRef("v4", "functions/cancel-on") },
+      { title: "Concurrency", href: tsRef("v4", "functions/concurrency") },
+      { title: "Rate limit", href: tsRef("v4", "functions/rate-limit") },
+      { title: "Singleton", href: tsRef("v4", "functions/singleton") },
+      { title: "Debounce", href: tsRef("v4", "functions/debounce") },
+      { title: "Function run priority", href: tsRef("v4", "functions/run-priority") },
+      { title: "Logging", href: tsRef("v4", "logging") },
+      { title: "Extended Traces", href: tsRef("v4", "extended-traces") },
+      { title: "Referencing functions", href: tsRef("v4", "functions/references") },
+      { title: "Testing", href: tsRef("v4", "testing") },
+      { title: "Durable Endpoints", href: tsRef("v4", "durable-endpoints"), tag: "new" },
+      { title: "Deferred Functions", href: tsRef("v4", "functions/deferred-functions"), tag: "beta" },
       {
         title: "Steps",
         links: [
-          {
-            title: "step.run()",
-            href: tsRef("v4", "functions/step-run"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sleep()",
-            href: tsRef("v4", "functions/step-sleep"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sleepUntil()",
-            href: tsRef("v4", "functions/step-sleep-until"),
-            className: "font-mono",
-          },
-          {
-            title: "step.invoke()",
-            href: tsRef("v4", "functions/step-invoke"),
-            className: "font-mono",
-          },
-          {
-            title: "step.waitForEvent()",
-            href: tsRef("v4", "functions/step-wait-for-event"),
-            className: "font-mono",
-          },
-          {
-            title: "step.waitForSignal()",
-            href: tsRef("v4", "functions/step-wait-for-signal"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sendEvent()",
-            href: tsRef("v4", "functions/step-send-event"),
-            className: "font-mono",
-          },
-          {
-            title: "step.fetch()",
-            href: tsRef("v4", "functions/fetch"),
-            className: "font-mono",
-          },
+          { title: "step.run()", href: tsRef("v4", "functions/step-run"), className: "font-mono" },
+          { title: "step.sleep()", href: tsRef("v4", "functions/step-sleep"), className: "font-mono" },
+          { title: "step.sleepUntil()", href: tsRef("v4", "functions/step-sleep-until"), className: "font-mono" },
+          { title: "step.invoke()", href: tsRef("v4", "functions/step-invoke"), className: "font-mono" },
+          { title: "step.waitForEvent()", href: tsRef("v4", "functions/step-wait-for-event"), className: "font-mono" },
+          { title: "step.waitForSignal()", href: tsRef("v4", "functions/step-wait-for-signal"), className: "font-mono" },
+          { title: "step.sendEvent()", href: tsRef("v4", "functions/step-send-event"), className: "font-mono" },
+          { title: "step.fetch()", href: tsRef("v4", "functions/fetch"), className: "font-mono" },
         ],
       },
-      {
-        title: "Serve",
-        links: [
-          {
-            title: "Framework handlers",
-            href: `/docs/learn/serving-inngest-functions`,
-          },
-          {
-            title: "Configuration",
-            href: tsRef("v4", "serve"),
-          },
-          {
-            title: "Streaming",
-            href: tsRef("v4", "serve/streaming"),
-          },
-        ],
-      },
-      {
-        title: "Realtime",
-        tag: "new",
-        links: [
-          {
-            title: "Overview",
-            href: tsRef("v4", "realtime"),
-          },
-          {
-            title: "Channels & topics",
-            href: tsRef("v4", "realtime/channels"),
-          },
-          {
-            title: "Publishing",
-            href: tsRef("v4", "realtime/publishing"),
-          },
-          {
-            title: "useRealtime",
-            href: tsRef("v4", "realtime/use-realtime"),
-            className: "font-mono",
-          },
-          {
-            title: "Subscribing",
-            href: tsRef("v4", "realtime/subscribing"),
-          },
-        ],
-      },
-      {
-        title: "Middleware",
-        links: [
-          {
-            title: "Lifecycle",
-            href: tsRef("v4", "middleware/lifecycle"),
-          },
-          {
-            title: "Examples",
-            href: tsRef("v4", "middleware/examples"),
-          },
-          {
-            title: "Custom serialization",
-            href: tsRef("v4", "middleware/serialization"),
-          },
-          {
-            title: "Encryption",
-            href: tsRef("v4", "middleware/encryption"),
-          },
-          {
-            title: "Sentry",
-            href: tsRef("v4", "middleware/sentry"),
-          },
-        ],
-      },
-      {
-        title: "Migrations",
-        links: [
-          {
-            title: "v3 to v4",
-            href: tsRef("v4", "migrations/v3-to-v4"),
-          },
-        ],
-      },
-      {
-        title: "Using the SDK",
-        links: [
-          {
-            title: "Environment variables",
-            href: `/docs/sdk/environment-variables`,
-          },
-          {
-            title: "Using TypeScript",
-            href: `/docs/typescript`,
-          },
-          {
-            title: "ESLint plugin",
-            href: `/docs/sdk/eslint`,
-          },
-        ],
-      },
+      { title: "Serve", links: [
+        { title: "Framework handlers", href: `/docs/learn/serving-inngest-functions` },
+        { title: "Configuration", href: tsRef("v4", "serve") },
+        { title: "Streaming", href: tsRef("v4", "serve/streaming") },
+      ]},
+      { title: "Realtime", tag: "new", links: [
+        { title: "Overview", href: tsRef("v4", "realtime") },
+        { title: "Channels & topics", href: tsRef("v4", "realtime/channels") },
+        { title: "Publishing", href: tsRef("v4", "realtime/publishing") },
+        { title: "useRealtime", href: tsRef("v4", "realtime/use-realtime"), className: "font-mono" },
+        { title: "Subscribing", href: tsRef("v4", "realtime/subscribing") },
+      ]},
+      { title: "Middleware", links: [
+        { title: "Lifecycle", href: tsRef("v4", "middleware/lifecycle") },
+        { title: "Examples", href: tsRef("v4", "middleware/examples") },
+        { title: "Custom serialization", href: tsRef("v4", "middleware/serialization") },
+        { title: "Encryption", href: tsRef("v4", "middleware/encryption") },
+        { title: "Sentry", href: tsRef("v4", "middleware/sentry") },
+      ]},
+      { title: "Migrations", links: [{ title: "v3 to v4", href: tsRef("v4", "migrations/v3-to-v4") }] },
+      { title: "Using the SDK", links: [
+        { title: "Environment variables", href: `/docs/sdk/environment-variables` },
+        { title: "Using TypeScript", href: `/docs/typescript` },
+        { title: "ESLint plugin", href: `/docs/sdk/eslint` },
+      ]},
     ],
   },
   {
     title: "Python SDK",
     links: [
-      {
-        title: "Introduction",
-        href: `/docs/reference/python`,
-      },
-      {
-        title: "Quick start",
-        href: `/docs/reference/python/overview/quick-start`,
-      },
-      {
-        title: "Inngest Client",
-        href: `/docs/reference/python/client/overview`,
-      },
-      {
-        title: "Create function",
-        href: `/docs/reference/python/functions/create`,
-      },
-      {
-        title: "Send events",
-        href: `/docs/reference/python/client/send`,
-      },
-      {
-        title: "Environment variables",
-        href: `/docs/reference/python/overview/env-vars`,
-      },
-      {
-        title: "Production mode",
-        href: `/docs/reference/python/overview/prod-mode`,
-      },
-      {
-        title: "Steps",
-        links: [
-          {
-            title: "invoke",
-            href: `/docs/reference/python/steps/invoke`,
-          },
-          {
-            title: "invoke_by_id",
-            href: `/docs/reference/python/steps/invoke_by_id`,
-          },
-          {
-            title: "parallel",
-            href: `/docs/reference/python/steps/parallel`,
-          },
-          {
-            title: "run",
-            href: `/docs/reference/python/steps/run`,
-          },
-          {
-            title: "send_event",
-            href: `/docs/reference/python/steps/send-event`,
-          },
-          {
-            title: "sleep",
-            href: `/docs/reference/python/steps/sleep`,
-          },
-          {
-            title: "sleep_until",
-            href: `/docs/reference/python/steps/sleep-until`,
-          },
-          {
-            title: "wait_for_event",
-            href: `/docs/reference/python/steps/wait-for-event`,
-          },
-        ],
-      },
-      {
-        title: "Middleware",
-        links: [
-          {
-            title: "Overview",
-            href: `/docs/reference/python/middleware/overview`,
-          },
-          {
-            title: "Lifecycle",
-            href: `/docs/reference/python/middleware/lifecycle`,
-          },
-        ],
-      },
-      {
-        title: "Guides",
-        links: [
-          {
-            title: "Testing",
-            href: `/docs/reference/python/guides/testing`,
-          },
-          {
-            title: "Modal",
-            href: `/docs/reference/python/guides/modal`,
-          },
-          {
-            title: "Pydantic",
-            href: `/docs/reference/python/guides/pydantic`,
-          },
-        ],
-      },
-      {
-        title: "Migrations",
-        links: [
-          {
-            title: "v0.4 to v0.5",
-            href: `/docs/reference/python/migrations/v0.4-to-v0.5`,
-          },
-          {
-            title: "v0.3 to v0.4",
-            href: `/docs/reference/python/migrations/v0.3-to-v0.4`,
-          },
-        ],
-      },
+      { title: "Introduction", href: `/docs/reference/python` },
+      { title: "Quick start", href: `/docs/reference/python/overview/quick-start` },
+      { title: "Inngest Client", href: `/docs/reference/python/client/overview` },
+      { title: "Create function", href: `/docs/reference/python/functions/create` },
+      { title: "Send events", href: `/docs/reference/python/client/send` },
+      { title: "Environment variables", href: `/docs/reference/python/overview/env-vars` },
+      { title: "Production mode", href: `/docs/reference/python/overview/prod-mode` },
+      { title: "Steps", links: [
+        { title: "invoke", href: `/docs/reference/python/steps/invoke` },
+        { title: "invoke_by_id", href: `/docs/reference/python/steps/invoke_by_id` },
+        { title: "parallel", href: `/docs/reference/python/steps/parallel` },
+        { title: "run", href: `/docs/reference/python/steps/run` },
+        { title: "send_event", href: `/docs/reference/python/steps/send-event` },
+        { title: "sleep", href: `/docs/reference/python/steps/sleep` },
+        { title: "sleep_until", href: `/docs/reference/python/steps/sleep-until` },
+        { title: "wait_for_event", href: `/docs/reference/python/steps/wait-for-event` },
+      ]},
+      { title: "Middleware", links: [
+        { title: "Overview", href: `/docs/reference/python/middleware/overview` },
+        { title: "Lifecycle", href: `/docs/reference/python/middleware/lifecycle` },
+      ]},
+      { title: "Guides", links: [
+        { title: "Testing", href: `/docs/reference/python/guides/testing` },
+        { title: "Modal", href: `/docs/reference/python/guides/modal` },
+        { title: "Pydantic", href: `/docs/reference/python/guides/pydantic` },
+      ]},
+      { title: "Migrations", links: [
+        { title: "v0.4 to v0.5", href: `/docs/reference/python/migrations/v0.4-to-v0.5` },
+        { title: "v0.3 to v0.4", href: `/docs/reference/python/migrations/v0.3-to-v0.4` },
+      ]},
     ],
   },
   {
     title: "Go SDK",
     links: [
-      {
-        title: "Reference",
-        href: "https://pkg.go.dev/github.com/inngest/inngestgo",
-      },
-      {
-        title: "Migrations",
-        links: [
-          {
-            title: "v0.8 to v0.11",
-            href: `/docs/reference/go/migrations/v0.8-to-v0.11`,
-          },
-          {
-            title: "v0.7 to v0.8",
-            href: `/docs/reference/go/migrations/v0.7-to-v0.8`,
-          },
-        ],
-      },
+      { title: "Reference", href: "https://pkg.go.dev/github.com/inngest/inngestgo" },
+      { title: "Migrations", links: [
+        { title: "v0.8 to v0.11", href: `/docs/reference/go/migrations/v0.8-to-v0.11` },
+        { title: "v0.7 to v0.8", href: `/docs/reference/go/migrations/v0.7-to-v0.8` },
+      ]},
     ],
   },
   {
-    title: "REST API",
-    href: "https://api-docs.inngest.com",
+    title: "CLI",
+    href: "/docs/cli",
+    tag: "new",
   },
+  { title: "REST API", href: "https://api-docs.inngest.com" },
   {
     title: "System events",
     links: [
-      {
-        title: "function.failed",
-        href: "/docs/reference/system-events/inngest-function-failed",
-        className: "font-mono",
-      },
-      {
-        title: "function.cancelled",
-        href: "/docs/reference/system-events/inngest-function-cancelled",
-        className: "font-mono",
-      },
+      { title: "function.failed", href: "/docs/reference/system-events/inngest-function-failed", className: "font-mono" },
+      { title: "function.cancelled", href: "/docs/reference/system-events/inngest-function-cancelled", className: "font-mono" },
     ],
   },
-  {
-    title: "Self-hosting",
-    href: `/docs/self-hosting`,
-  },
+  { title: "Self-hosting", href: `/docs/self-hosting` },
 ];
 
-// =============================================================================
-// LEARN SECTION
-// =============================================================================
 const sectionLearn: (NavGroup | NavLink)[] = [
   { title: "Home", href: "/docs" },
   {
     title: "Quick starts",
     defaultOpen: true,
     links: [
-      {
-        title: "Next.js",
-        href: "/docs/getting-started/nextjs-quick-start",
-      },
-      {
-        title: "Node.js",
-        links: [
-          {
-            title: "Express",
-            href: "/docs/getting-started/express-quick-start",
-          },
-          {
-            title: "Astro",
-            href: "/docs/getting-started/astro-quick-start",
-          },
-          {
-            title: "H3",
-            href: "/docs/getting-started/h3-quick-start",
-          },
-          {
-            title: "NestJS",
-            href: "/docs/getting-started/nestjs-quick-start",
-          },
-          {
-            title: "TanStack Start",
-            href: "/docs/getting-started/tanstack-start-quick-start",
-          },
-          {
-            title: "Other frameworks",
-            href: "/docs/getting-started/nodejs-quick-start",
-          },
-        ],
-      },
-      {
-        title: "Python",
-        href: "/docs/getting-started/python-quick-start",
-      },
+      { title: "Next.js", href: "/docs/getting-started/nextjs-quick-start" },
+      { title: "Node.js", links: [
+        { title: "Express", href: "/docs/getting-started/express-quick-start" },
+        { title: "Astro", href: "/docs/getting-started/astro-quick-start" },
+        { title: "H3", href: "/docs/getting-started/h3-quick-start" },
+        { title: "NestJS", href: "/docs/getting-started/nestjs-quick-start" },
+        { title: "TanStack Start", href: "/docs/getting-started/tanstack-start-quick-start" },
+        { title: "Other frameworks", href: "/docs/getting-started/nodejs-quick-start" },
+      ]},
+      { title: "Python", href: "/docs/getting-started/python-quick-start" },
     ],
   },
   {
     title: "Concepts",
     defaultOpen: true,
     links: [
-      {
-        title: "How Durable execution works",
-        href: `/docs/learn/how-functions-are-executed`,
-      },
-      {
-        title: "Durable Functions",
-        links: [
-          {
-            title: "Overview",
-            href: `/docs/learn/inngest-functions`,
-          },
-          {
-            title: "Serve Inngest Functions",
-            href: "/docs/learn/serving-inngest-functions",
-          },
-          {
-            title: "Triggering functions",
-            href: `/docs/features/events-triggers`,
-          },
-          {
-            title: "Idempotency",
-            href: `/docs/guides/handling-idempotency`,
-          },
-          {
-            title: "Logging",
-            href: "/docs/guides/logging",
-          },
-        ],
-      },
-      {
-        title: "Durable Endpoints",
-        links: [
-          {
-            title: "Overview",
-            href: `/docs/learn/durable-endpoints`,
-          },
-          {
-            title: "Streaming",
-            href: "/docs/learn/durable-endpoints/streaming",
-          },
-        ],
-        tag: "new",
-      },
-      {
-        title: "Steps",
-        links: [
-          {
-            title: "Building with steps",
-            href: `/docs/learn/inngest-steps`,
-          },
-          {
-            title: "Sleeping",
-            href: "/docs/features/inngest-functions/steps-workflows/sleeps",
-          },
-          {
-            title: "Wait for event",
-            href: "/docs/features/inngest-functions/steps-workflows/wait-for-event",
-          },
-          {
-            title: "Wait for signal",
-            href: "/docs/features/inngest-functions/steps-workflows/wait-for-signal",
-          },
-          {
-            title: "Invoke other functions",
-            href: `/docs/guides/invoking-functions-directly`,
-          },
-          {
-            title: "AI steps (LLM calls)",
-            href: "/docs/features/inngest-functions/steps-workflows/step-ai-orchestration",
-          },
-          {
-            title: "Durable Fetch",
-            href: tsRef("v4", "functions/fetch"),
-          },
-        ],
-      },
-      {
-        title: "Error handling",
-        links: [
-          {
-            title: "Overview",
-            href: `/docs/guides/error-handling`,
-          },
-          {
-            title: "Retries",
-            href: "/docs/features/inngest-functions/error-retries/retries",
-          },
-          {
-            title: "Rollbacks",
-            href: "/docs/features/inngest-functions/error-retries/rollbacks",
-          },
-          {
-            title: "Failure handlers",
-            href: "/docs/features/inngest-functions/error-retries/failure-handlers",
-          },
-          {
-            title: "Inngest errors",
-            href: "/docs/features/inngest-functions/error-retries/inngest-errors",
-          },
-        ],
-      },
-      {
-        title: "Flow control",
-        links: [
-          {
-            title: "Overview",
-            href: `/docs/guides/flow-control`,
-          },
-          {
-            title: "Concurrency",
-            href: `/docs/guides/concurrency`,
-          },
-          {
-            title: "Throttling",
-            href: `/docs/guides/throttling`,
-          },
-          {
-            title: "Batching",
-            href: `/docs/guides/batching`,
-          },
-          {
-            title: "Rate limit",
-            href: `/docs/guides/rate-limiting`,
-          },
-          {
-            title: "Singleton",
-            href: `/docs/guides/singleton`,
-          },
-          {
-            title: "Debounce",
-            href: `/docs/guides/debounce`,
-          },
-          {
-            title: "Priority",
-            href: `/docs/guides/priority`,
-          },
-        ],
-      },
-      {
-        title: "Cancellation",
-        links: [
-          {
-            title: "Overview",
-            href: `/docs/features/inngest-functions/cancellation`,
-          },
-          {
-            title: "Cancel on timeouts",
-            href: `/docs/features/inngest-functions/cancellation/cancel-on-timeouts`,
-          },
-          {
-            title: "Cancel on events",
-            href: `/docs/features/inngest-functions/cancellation/cancel-on-events`,
-          },
-          {
-            title: "Bulk cancellation",
-            href: `/docs/guides/cancel-running-functions`,
-          },
-        ],
-      },
-      {
-        title: "Realtime",
-        tag: "new",
-        links: [
-          {
-            title: "Overview",
-            href: "/docs/features/realtime",
-          },
-          {
-            title: "React hooks / Next.js",
-            href: "/docs/features/realtime/react-hooks",
-          },
-        ],
-      },
-      {
-        title: "Environments and Apps",
-        href: "/docs/apps",
-        links: [
-          {
-            title: "Overview",
-            href: "/docs/apps",
-          },
-          {
-            title: "Environments",
-            href: `/docs/platform/environments`,
-          },
-          {
-            title: "Apps",
-            href: `/docs/platform/manage/apps`,
-          },
-          {
-            title: "Event keys",
-            href: `/docs/events/creating-an-event-key`,
-          },
-          {
-            title: "Signing keys",
-            href: `/docs/platform/signing-keys`,
-          },
-        ],
-      },
+      { title: "How Durable execution works", href: `/docs/learn/how-functions-are-executed` },
+      { title: "Durable Functions", links: [
+        { title: "Overview", href: `/docs/learn/inngest-functions` },
+        { title: "Serve Inngest Functions", href: "/docs/learn/serving-inngest-functions" },
+        { title: "Triggering functions", href: `/docs/features/events-triggers` },
+        { title: "Idempotency", href: `/docs/guides/handling-idempotency` },
+        { title: "Logging", href: "/docs/guides/logging" },
+      ]},
+      { title: "Durable Endpoints", tag: "new", links: [
+        { title: "Overview", href: `/docs/learn/durable-endpoints` },
+        { title: "Streaming", href: "/docs/learn/durable-endpoints/streaming" },
+      ]},
+      { title: "Steps", links: [
+        { title: "Building with steps", href: `/docs/learn/inngest-steps` },
+        { title: "Sleeping", href: "/docs/features/inngest-functions/steps-workflows/sleeps" },
+        { title: "Wait for event", href: "/docs/features/inngest-functions/steps-workflows/wait-for-event" },
+        { title: "Wait for signal", href: "/docs/features/inngest-functions/steps-workflows/wait-for-signal" },
+        { title: "Invoke other functions", href: `/docs/guides/invoking-functions-directly` },
+        { title: "AI steps (LLM calls)", href: "/docs/features/inngest-functions/steps-workflows/step-ai-orchestration" },
+        { title: "Durable Fetch", href: tsRef("v4", "functions/fetch") },
+      ]},
+      { title: "Error handling", links: [
+        { title: "Overview", href: `/docs/guides/error-handling` },
+        { title: "Retries", href: "/docs/features/inngest-functions/error-retries/retries" },
+        { title: "Rollbacks", href: "/docs/features/inngest-functions/error-retries/rollbacks" },
+        { title: "Failure handlers", href: "/docs/features/inngest-functions/error-retries/failure-handlers" },
+        { title: "Inngest errors", href: "/docs/features/inngest-functions/error-retries/inngest-errors" },
+      ]},
+      { title: "Flow control", links: [
+        { title: "Overview", href: `/docs/guides/flow-control` },
+        { title: "Concurrency", href: `/docs/guides/concurrency` },
+        { title: "Throttling", href: `/docs/guides/throttling` },
+        { title: "Batching", href: `/docs/guides/batching` },
+        { title: "Rate limit", href: `/docs/guides/rate-limiting` },
+        { title: "Singleton", href: `/docs/guides/singleton` },
+        { title: "Debounce", href: `/docs/guides/debounce` },
+        { title: "Priority", href: `/docs/guides/priority` },
+      ]},
+      { title: "Cancellation", links: [
+        { title: "Overview", href: `/docs/features/inngest-functions/cancellation` },
+        { title: "Cancel on timeouts", href: `/docs/features/inngest-functions/cancellation/cancel-on-timeouts` },
+        { title: "Cancel on events", href: `/docs/features/inngest-functions/cancellation/cancel-on-events` },
+        { title: "Bulk cancellation", href: `/docs/guides/cancel-running-functions` },
+      ]},
+      { title: "Realtime", tag: "new", links: [
+        { title: "Overview", href: "/docs/features/realtime" },
+        { title: "React hooks / Next.js", href: "/docs/features/realtime/react-hooks" },
+      ]},
+      { title: "Environments and Apps", href: "/docs/apps", links: [
+        { title: "Overview", href: "/docs/apps" },
+        { title: "Environments", href: `/docs/platform/environments` },
+        { title: "Apps", href: `/docs/platform/manage/apps` },
+        { title: "Event keys", href: `/docs/events/creating-an-event-key` },
+        { title: "Signing keys", href: `/docs/platform/signing-keys` },
+      ]},
     ],
   },
   {
     title: "Guides",
     defaultOpen: true,
     links: [
-      {
-        title: "Local development",
-        href: `/docs/local-development`,
-      },
-      {
-        title: "Events and Triggers",
-        links: [
-          {
-            title: "Overview",
-            href: `/docs/features/events-triggers`,
-          },
-          {
-            title: "Sending events",
-            href: `/docs/events`,
-          },
-          {
-            title: "Event payload format",
-            href: `/docs/features/events-triggers/event-format`,
-          },
-          {
-            title: "Writing expressions",
-            href: `/docs/guides/writing-expressions`,
-          },
-          {
-            title: "Consuming webhook events",
-            href: `/docs/platform/webhooks`,
-          },
-          {
-            title: "Parallel steps",
-            href: "/docs/guides/step-parallelism",
-          },
-          {
-            title: "Fan-out",
-            href: `/docs/guides/fan-out-jobs`,
-          },
-          {
-            title: "Working with loops",
-            href: "/docs/guides/working-with-loops",
-          },
-          {
-            title: "Delayed functions",
-            href: `/docs/guides/delayed-functions`,
-          },
-          {
-            title: "Cron functions",
-            href: `/docs/guides/scheduled-functions`,
-          },
-          {
-            title: "Background jobs",
-            href: `/docs/guides/background-jobs`,
-          },
-          {
-            title: "Multiple triggers & wildcards",
-            href: `/docs/guides/multiple-triggers`,
-          },
-          {
-            title: "Sending events from functions",
-            href: `/docs/guides/sending-events-from-functions`,
-          },
-          {
-            title: "User-defined Workflows",
-            href: `/docs/guides/user-defined-workflows`,
-          },
-          {
-            title: "Mergent migration guide",
-            href: `/docs/guides/mergent-migration`,
-          },
-          {
-            title: "Workflow Kit",
-            links: [
-              {
-                title: "Introduction",
-                href: `/docs/reference/workflow-kit`,
-              },
-              {
-                title: "Creating Workflow Actions",
-                href: `/docs/reference/workflow-kit/actions`,
-              },
-              {
-                title: "Using the Workflow Engine",
-                href: `/docs/reference/workflow-kit/engine`,
-              },
-              {
-                title: "Workflow instance format",
-                href: `/docs/reference/workflow-kit/workflow-instance`,
-              },
-              {
-                title: "Components API (React)",
-                href: `/docs/reference/workflow-kit/components-api`,
-              },
-            ],
-          },
-        ],
-      },
+      { title: "Local development", href: `/docs/local-development` },
+      { title: "CLI", tag: "new", links: [
+        { title: "CLI reference", href: "/docs/cli" },
+        { title: "Debug with the CLI", href: "/docs/guides/debug-with-cli" },
+      ]},
+      { title: "Events and Triggers", links: [
+        { title: "Overview", href: `/docs/features/events-triggers` },
+        { title: "Sending events", href: `/docs/events` },
+        { title: "Event payload format", href: `/docs/features/events-triggers/event-format` },
+        { title: "Writing expressions", href: `/docs/guides/writing-expressions` },
+        { title: "Consuming webhook events", href: `/docs/platform/webhooks` },
+        { title: "Parallel steps", href: "/docs/guides/step-parallelism" },
+        { title: "Fan-out", href: `/docs/guides/fan-out-jobs` },
+        { title: "Working with loops", href: "/docs/guides/working-with-loops" },
+        { title: "Delayed functions", href: `/docs/guides/delayed-functions` },
+        { title: "Cron functions", href: `/docs/guides/scheduled-functions` },
+        { title: "Background jobs", href: `/docs/guides/background-jobs` },
+        { title: "Multiple triggers & wildcards", href: `/docs/guides/multiple-triggers` },
+        { title: "Sending events from functions", href: `/docs/guides/sending-events-from-functions` },
+        { title: "User-defined Workflows", href: `/docs/guides/user-defined-workflows` },
+        { title: "Mergent migration guide", href: `/docs/guides/mergent-migration` },
+        { title: "Workflow Kit", links: [
+          { title: "Introduction", href: `/docs/reference/workflow-kit` },
+          { title: "Creating Workflow Actions", href: `/docs/reference/workflow-kit/actions` },
+          { title: "Using the Workflow Engine", href: `/docs/reference/workflow-kit/engine` },
+          { title: "Workflow instance format", href: `/docs/reference/workflow-kit/workflow-instance` },
+          { title: "Components API (React)", href: `/docs/reference/workflow-kit/components-api` },
+        ]},
+      ]},
       {
         title: "Agents",
         links: [
-          {
-            title: "Agent tool loops",
-            href: `/docs/ai-patterns/agent-tool-loops`,
-          },
-          {
-            title: "Human-in-the-loop",
-            href: `/docs/ai-patterns/human-in-the-loop`,
-          },
-          {
-            title: "Sub-agents",
-            href: `/docs/ai-patterns/sub-agent-delegation`,
-          },
+          { title: "Agent tool loops", href: `/docs/ai-patterns/agent-tool-loops` },
+          { title: "Human-in-the-loop", href: `/docs/ai-patterns/human-in-the-loop` },
+          { title: "Sub-agents", href: `/docs/ai-patterns/sub-agent-delegation` },
+          { title: "CLI for coding agents", href: `/docs/ai-patterns/cli-for-coding-agents`, tag: "new" },
         ],
       },
-      {
-        title: "Deploying",
-        defaultOpen: true,
-        links: [
-          {
-            title: "Overview",
-            href: `/docs/platform/deployment`,
-          },
-          {
-            title: "Sync your app",
-            href: `/docs/apps/cloud`,
-          },
-          {
-            title: "Connect (workers)",
-            href: `/docs/setup/connect`,
-            tag: "beta",
-          },
-          {
-            title: "Checkpointing",
-            href: `/docs/setup/checkpointing`,
-            tag: "new",
-          },
-          {
-            title: "Cloud providers",
-            links: [
-              {
-                title: "Vercel",
-                href: "/docs/deploy/vercel",
-              },
-              {
-                title: "DigitalOcean",
-                href: "/docs/deploy/digital-ocean",
-                tag: "new",
-              },
-              {
-                title: "Cloudflare Pages",
-                href: `/docs/deploy/cloudflare`,
-              },
-              {
-                title: "Netlify",
-                href: `/docs/deploy/netlify`,
-              },
-              {
-                title: "Render",
-                href: `/docs/deploy/render`,
-              },
-              {
-                title: "Cloud Provider Usage Limits",
-                href: `/docs/usage-limits/providers`,
-              },
-            ],
-          },
-        ],
-      },
-      {
-        title: "Optimizing Performance",
-        href: `/docs/improve-performance`,
-      },
-      {
-        title: "Versioning",
-        href: `/docs/learn/versioning`,
-      },
-      {
-        title: "Logging",
-        href: "/docs/guides/logging",
-      },
-      {
-        title: "Middleware",
-        links: [
-          {
-            title: "Overview",
-            href: `/docs/features/middleware`,
-          },
-          {
-            title: "Creating middleware",
-            href: `/docs/features/middleware/create`,
-          },
-          {
-            title: "Dependency Injection",
-            href: "/docs/features/middleware/dependency-injection",
-          },
-          {
-            title: "Encryption Middleware",
-            href: "/docs/features/middleware/encryption-middleware",
-          },
-          {
-            title: "Sentry Middleware",
-            href: "/docs/features/middleware/sentry-middleware",
-          },
-        ],
-      },
+      { title: "Deploying", defaultOpen: true, links: [
+        { title: "Overview", href: `/docs/platform/deployment` },
+        { title: "Sync your app", href: `/docs/apps/cloud` },
+        { title: "Connect (workers)", href: `/docs/setup/connect`, tag: "beta" },
+        { title: "Checkpointing", href: `/docs/setup/checkpointing`, tag: "new" },
+        { title: "Cloud providers", links: [
+          { title: "Vercel", href: "/docs/deploy/vercel" },
+          { title: "DigitalOcean", href: "/docs/deploy/digital-ocean", tag: "new" },
+          { title: "Cloudflare Pages", href: `/docs/deploy/cloudflare` },
+          { title: "Netlify", href: `/docs/deploy/netlify` },
+          { title: "Render", href: `/docs/deploy/render` },
+          { title: "Cloud Provider Usage Limits", href: `/docs/usage-limits/providers` },
+        ]},
+      ]},
+      { title: "Optimizing Performance", href: `/docs/improve-performance` },
+      { title: "Versioning", href: `/docs/learn/versioning` },
+      { title: "Logging", href: "/docs/guides/logging" },
+      { title: "Middleware", links: [
+        { title: "Overview", href: `/docs/features/middleware` },
+        { title: "Creating middleware", href: `/docs/features/middleware/create` },
+        { title: "Dependency Injection", href: "/docs/features/middleware/dependency-injection" },
+        { title: "Encryption Middleware", href: "/docs/features/middleware/encryption-middleware" },
+        { title: "Sentry Middleware", href: "/docs/features/middleware/sentry-middleware" },
+      ]},
     ],
   },
   {
     title: "Platform",
     links: [
-      {
-        title: "Manage",
-        links: [
-          {
-            title: "Bulk replay",
-            href: "/docs/platform/replay",
-          },
-          {
-            title: "Bulk cancel",
-            href: "/docs/platform/manage/bulk-cancellation",
-          },
-          {
-            title: "Pausing",
-            href: "/docs/guides/pause-functions",
-          },
-          {
-            title: "Rotating keys",
-            href: "/docs/platform/manage/rotating-keys",
-          },
-          {
-            title: "API keys",
-            href: "/docs/platform/api-keys",
-          },
-        ],
-      },
-      {
-        title: "Monitor",
-        links: [
-          {
-            title: "Inspecting runs",
-            href: "/docs/platform/monitor/inspecting-function-runs",
-          },
-          {
-            title: "Traces",
-            href: "/docs/platform/monitor/traces",
-            tag: "new",
-          },
-          {
-            title: "Observability and metrics",
-            href: "/docs/platform/monitor/observability-metrics",
-          },
-          {
-            title: "Insights",
-            href: "/docs/platform/monitor/insights",
-            tag: "new",
-          },
-          {
-            title: "Events",
-            href: "/docs/platform/monitor/inspecting-events",
-          },
-        ],
-      },
-      {
-        title: "Integrations",
-        links: [
-          {
-            title: "Neon",
-            href: `/docs/features/events-triggers/neon`,
-          },
-          {
-            title: "Datadog",
-            href: "/docs/platform/monitor/datadog-integration",
-          },
-          {
-            title: "Prometheus",
-            href: "/docs/platform/monitor/prometheus-metrics-export-integration",
-          },
-        ],
-      },
+      { title: "Manage", links: [
+        { title: "Bulk replay", href: "/docs/platform/replay" },
+        { title: "Bulk cancel", href: "/docs/platform/manage/bulk-cancellation" },
+        { title: "Pausing", href: "/docs/guides/pause-functions" },
+        { title: "Rotating keys", href: "/docs/platform/manage/rotating-keys" },
+        { title: "API keys", href: "/docs/platform/api-keys" },
+      ]},
+      { title: "Monitor", links: [
+        { title: "Inspecting runs", href: "/docs/platform/monitor/inspecting-function-runs" },
+        { title: "Traces", href: "/docs/platform/monitor/traces", tag: "new" },
+        { title: "Observability and metrics", href: "/docs/platform/monitor/observability-metrics" },
+        { title: "Insights", href: "/docs/platform/monitor/insights", tag: "new" },
+        { title: "Events", href: "/docs/platform/monitor/inspecting-events" },
+      ]},
+      { title: "Integrations", links: [
+        { title: "Neon", href: `/docs/features/events-triggers/neon` },
+        { title: "Datadog", href: "/docs/platform/monitor/datadog-integration" },
+        { title: "Prometheus", href: "/docs/platform/monitor/prometheus-metrics-export-integration" },
+      ]},
     ],
   },
   {
     title: "AI",
     links: [
-      {
-        title: "Agent Plugins and Skills",
-        href: "/docs/ai-dev-tools/agent-skills",
-      },
-      {
-        title: "Dev Server MCP",
-        href: "/docs/ai-dev-tools/mcp",
-      },
-      {
-        title: "AgentKit",
-        href: "https://agentkit.inngest.com",
-        target: "_blank",
-      },
+      { title: "Agent Plugins and Skills", href: "/docs/ai-dev-tools/agent-skills" },
+      { title: "Dev Server MCP", href: "/docs/ai-dev-tools/mcp" },
+      { title: "AgentKit", href: "https://agentkit.inngest.com", target: "_blank" },
     ],
   },
   {
     title: "Resources",
     links: [
-      {
-        title: "Security",
-        href: "/docs/learn/security",
-      },
-      {
-        title: "Glossary",
-        href: `/docs/learn/glossary`,
-      },
-      {
-        title: "Release phases",
-        href: `/docs/release-phases`,
-      },
-      {
-        title: "FAQ",
-        href: `/docs/faq`,
-      },
-      {
-        title: "Limitations",
-        href: `/docs/usage-limits/inngest`,
-      },
+      { title: "Security", href: "/docs/learn/security" },
+      { title: "Glossary", href: `/docs/learn/glossary` },
+      { title: "Release phases", href: `/docs/release-phases` },
+      { title: "FAQ", href: `/docs/faq` },
+      { title: "Limitations", href: `/docs/usage-limits/inngest` },
     ],
   },
 ];
 
-// =============================================================================
-// EXAMPLES SECTION (kept for backwards compatibility)
-// =============================================================================
 const sectionExamples: NavGroup[] = [
   {
     title: "Examples",
     defaultOpen: true,
     links: [
       { title: "All examples", href: `/docs/examples/` },
-      {
-        title: "AI Agents and RAG",
-        href: `/docs/examples/ai-agents-and-rag`,
-      },
-      {
-        title: "Email Sequence",
-        href: `/docs/examples/email-sequence`,
-      },
-      {
-        title: "Scheduling a one-off function",
-        href: `/docs/examples/scheduling-one-off-function`,
-      },
-      {
-        title: "Fetch run status and output",
-        href: `/docs/examples/fetch-run-status-and-output`,
-      },
-      {
-        title: "Track all function failures in Datadog",
-        href: `/docs/examples/track-failures-in-datadog`,
-      },
-      {
-        title: "Cleanup after function cancellation",
-        href: `/docs/examples/cleanup-after-function-cancellation`,
-      },
-      {
-        title: "Fetch: Durable HTTP requests",
-        href: `/docs/examples/fetch`,
-      },
-      {
-        title: "Stream updates from functions",
-        href: `/docs/examples/realtime`,
-      },
-      {
-        title: "Setup OpenTelemetry with Inngest",
-        href: `/docs/examples/open-telemetry`,
-      },
-      {
-        title: "Durable Endpoints",
-        href: `/docs/examples/durable-endpoints`,
-      },
-      {
-        title: "Trigger workflows from Retool",
-        href: `/docs/guides/trigger-your-code-from-retool`,
-      },
-      {
-        title: "Instrumenting GraphQL",
-        href: `/docs/guides/instrumenting-graphql`,
-      },
-      {
-        title: "Handle Clerk webhooks",
-        href: `/docs/guides/clerk-webhook-events`,
-      },
-      {
-        title: "Handle Resend webhooks",
-        href: `/docs/guides/resend-webhook-events`,
-      },
+      { title: "AI Agents and RAG", href: `/docs/examples/ai-agents-and-rag` },
+      { title: "Email Sequence", href: `/docs/examples/email-sequence` },
+      { title: "Scheduling a one-off function", href: `/docs/examples/scheduling-one-off-function` },
+      { title: "Fetch run status and output", href: `/docs/examples/fetch-run-status-and-output` },
+      { title: "Track all function failures in Datadog", href: `/docs/examples/track-failures-in-datadog` },
+      { title: "Cleanup after function cancellation", href: `/docs/examples/cleanup-after-function-cancellation` },
+      { title: "Fetch: Durable HTTP requests", href: `/docs/examples/fetch` },
+      { title: "Stream updates from functions", href: `/docs/examples/realtime` },
+      { title: "Setup OpenTelemetry with Inngest", href: `/docs/examples/open-telemetry` },
+      { title: "Durable Endpoints", href: `/docs/examples/durable-endpoints` },
+      { title: "Trigger workflows from Retool", href: `/docs/guides/trigger-your-code-from-retool` },
+      { title: "Instrumenting GraphQL", href: `/docs/guides/instrumenting-graphql` },
+      { title: "Handle Clerk webhooks", href: `/docs/guides/clerk-webhook-events` },
+      { title: "Handle Resend webhooks", href: `/docs/guides/resend-webhook-events` },
     ],
   },
   {
     title: "Middleware",
     defaultOpen: true,
     links: [
-      {
-        title: "Cloudflare Workers & Hono environment variables",
-        href: `/docs/examples/middleware/cloudflare-workers-environment-variables`,
-      },
+      { title: "Cloudflare Workers & Hono environment variables", href: `/docs/examples/middleware/cloudflare-workers-environment-variables` },
     ],
   },
 ];
 
-// =============================================================================
-// TYPE GUARDS
-// =============================================================================
-export const isNavGroup = (
-  item: NavGroup | NavLink | NavSection | NavLinkGroup
-): item is NavGroup => {
+export const isNavGroup = (item: NavGroup | NavLink | NavSection | NavLinkGroup): item is NavGroup => {
   return !!(item as NavGroup).links;
 };
-export const isNavSection = (
-  item: NavGroup | NavLink | NavSection | NavLinkGroup
-): item is NavSection => {
+export const isNavSection = (item: NavGroup | NavLink | NavSection | NavLinkGroup): item is NavSection => {
   return !!(item as NavSection).sectionLinks;
 };
-export const isNavLinkGroup = (
-  item: NavGroup | NavLink | NavSection | NavLinkGroup
-): item is NavLinkGroup => {
+export const isNavLinkGroup = (item: NavGroup | NavLink | NavSection | NavLinkGroup): item is NavLinkGroup => {
   return item.title && !(item as NavGroup).links && !(item as NavLink).href;
 };
-export const isNavLink = (
-  item: NavGroup | NavLink | NavSection | NavLinkGroup
-): item is NavLink => {
+export const isNavLink = (item: NavGroup | NavLink | NavSection | NavLinkGroup): item is NavLink => {
   return !!item.title && !!(item as NavLink).href;
 };
 
-// =============================================================================
-// LINK SEARCH HELPERS
-// =============================================================================
 function linkSearch(groups: (NavGroup | NavLink)[], pathname) {
   return groups.find((item) =>
-    isNavGroup(item)
-      ? recursiveLinkSearch(item, pathname)
-      : item.href === pathname
+    isNavGroup(item) ? recursiveLinkSearch(item, pathname) : item.href === pathname
   );
 }
 
 function recursiveLinkSearch(group: NavGroup, pathname) {
-  if (group.href === pathname) {
-    return true;
-  }
+  if (group.href === pathname) return true;
   return group.links.find((link) => {
-    return isNavLink(link)
-      ? link.href === pathname
-      : "links" in link && recursiveLinkSearch(link, pathname);
+    return isNavLink(link) ? link.href === pathname : "links" in link && recursiveLinkSearch(link, pathname);
   });
 }
 
-// =============================================================================
-// MATCHERS
-// =============================================================================
 const matchers: Record<string, (pathname: string) => any> = {
   docs: (pathname) => pathname === "/docs" || pathname === "/docs/",
-  examples: (pathname) =>
-    /^\/docs\/examples/.test(pathname) || linkSearch(sectionExamples, pathname),
-  reference: (pathname) =>
-    /^\/docs\/reference/.test(pathname) ||
-    linkSearch(sectionReference, pathname),
+  examples: (pathname) => /^\/docs\/examples/.test(pathname) || linkSearch(sectionExamples, pathname),
+  reference: (pathname) => /^\/docs\/reference/.test(pathname) || linkSearch(sectionReference, pathname),
   learn: (pathname) => linkSearch(sectionLearn, pathname),
   patterns: (pathname) => /^\/docs\/patterns/.test(pathname),
 };
 matchers.default = matchers.learn;
 
-// =============================================================================
-// MENU TABS (Top navigation)
-// =============================================================================
 export const menuTabs = [
-  {
-    title: "Documentation",
-    icon: PlayIcon,
-    href: "/docs",
-    matcher: matchers.default,
-  },
-  {
-    title: "Examples",
-    icon: LightBulbIcon,
-    href: "/docs/examples/",
-    matcher: matchers.examples,
-  },
-  {
-    title: "Patterns",
-    icon: Squares2X2Icon,
-    href: "/docs/patterns",
-    matcher: matchers.patterns,
-  },
+  { title: "Documentation", icon: PlayIcon, href: "/docs", matcher: matchers.default },
+  { title: "Examples", icon: LightBulbIcon, href: "/docs/examples/", matcher: matchers.examples },
+  { title: "Patterns", icon: Squares2X2Icon, href: "/docs/patterns", matcher: matchers.patterns },
 ];
 
-// =============================================================================
-// SIDEBAR TABS (Sidebar navigation)
-// =============================================================================
 export const sidebarMenuTabs = [
-  {
-    title: "Learn",
-    icon: BookOpenIcon,
-    href: "/docs",
-    matcher: matchers.learn,
-  },
-  {
-    title: "Reference",
-    icon: CodeBracketIcon,
-    href: `/docs/reference/typescript/${TS_STABLE}/intro`,
-    matcher: matchers.reference,
-  },
+  { title: "Learn", icon: BookOpenIcon, href: "/docs", matcher: matchers.learn },
+  { title: "Reference", icon: CodeBracketIcon, href: `/docs/reference/typescript/${TS_STABLE}/intro`, matcher: matchers.reference },
 ];
 
-// =============================================================================
-// TOP LEVEL NAV
-// =============================================================================
-// Patterns nav: one non-collapsible group per primitive (Examples-style),
-// derived from the static pattern index. `defaultOpen` keeps every group open.
 const sectionPatterns: NavGroup[] = [
-  {
-    title: "Overview",
-    defaultOpen: true,
-    links: [{ title: "All patterns", href: "/docs/patterns" }],
-  },
+  { title: "Overview", defaultOpen: true, links: [{ title: "All patterns", href: "/docs/patterns" }] },
   ...PATTERN_SECTIONS.flatMap((s): NavGroup[] => {
     const links = PATTERNS.filter((p) => p.category === s.id).map((p) => ({
-      title: p.title,
-      href: `/docs/patterns/${s.id}/${p.slug}`,
+      title: p.title, href: `/docs/patterns/${s.id}/${p.slug}`,
     }));
     if (links.length === 0) return [];
     return [{ title: s.name, defaultOpen: true, links }];
@@ -1407,32 +509,8 @@ const sectionPatterns: NavGroup[] = [
 ];
 
 export const topLevelNav = [
-  {
-    title: "Learn",
-    icon: BookOpenIcon,
-    href: `/docs`,
-    sectionLinks: sectionLearn,
-    matcher: matchers.learn,
-  },
-  {
-    title: "Patterns",
-    icon: Squares2X2Icon,
-    href: "/docs/patterns",
-    sectionLinks: sectionPatterns,
-    matcher: matchers.patterns,
-  },
-  {
-    title: "Reference",
-    icon: CodeBracketIcon,
-    href: `/docs/reference/typescript/${TS_STABLE}/intro`,
-    matcher: matchers.reference,
-    sectionLinks: sectionReference,
-  },
-  {
-    title: "Examples",
-    icon: LightBulbIcon,
-    href: "/docs/examples/",
-    sectionLinks: sectionExamples,
-    matcher: matchers.examples,
-  },
+  { title: "Learn", icon: BookOpenIcon, href: `/docs`, sectionLinks: sectionLearn, matcher: matchers.learn },
+  { title: "Patterns", icon: Squares2X2Icon, href: "/docs/patterns", sectionLinks: sectionPatterns, matcher: matchers.patterns },
+  { title: "Reference", icon: CodeBracketIcon, href: `/docs/reference/typescript/${TS_STABLE}/intro`, matcher: matchers.reference, sectionLinks: sectionReference },
+  { title: "Examples", icon: LightBulbIcon, href: "/docs/examples/", sectionLinks: sectionExamples, matcher: matchers.examples },
 ];


### PR DESCRIPTION
## Summary

Three new docs pages for the CLI + Agentic API launch (June 9-11).

**CLI reference** (`/docs/cli`) — Diataxis Reference. Quick start, authentication (env-scoped API keys), dev server vs cloud targeting, available commands table, output format. Based on the Agentic API PRD and Jacob's shipped CLI examples.

**Debug a function run from your terminal** (`/docs/guides/debug-with-cli`) — Diataxis How-to. Four steps: get the run summary, fetch the trace, pipe to jq, test a fix locally. Uses realistic JSON output showing a failed step.

**Use the CLI with coding agents** (`/docs/ai-patterns/cli-for-coding-agents`) — Diataxis How-to. Four steps: set the API key, add Inngest context to your agent (CLAUDE.md / .cursorrules snippet), debug a failing function, test the fix. The AX angle from the PRD.

All three cross-link to each other, to the REST API docs at api-docs.inngest.com, and to relevant existing pages (traces, error handling, API keys).

Nav entries not included in this PR to avoid conflicts with other in-flight nav changes. Will add in a follow-up.

Resolves DEV-385