### PR TITLE
Add experiments to docs navbar

### DIFF
--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -63,178 +63,65 @@ const sectionReference: (NavGroup | NavLink)[] = [
   {
     title: "TypeScript SDK v3",
     links: [
-      {
-        title: "Introduction",
-        href: tsRef("v3", "intro"),
-      },
-      {
-        title: "Create the client",
-        href: tsRef("v3", "client/create"),
-      },
-      {
-        title: "Create a function",
-        href: tsRef("v3", "functions/create"),
-      },
-      {
-        title: "Send events",
-        href: tsRef("v3", "events/send"),
-      },
-      {
-        title: "Errors",
-        href: `/docs/reference/typescript/functions/errors`,
-      },
-      {
-        title: "Handling failures",
-        href: tsRef("v3", "functions/handling-failures"),
-      },
-      {
-        title: "Cancel on",
-        href: tsRef("v3", "functions/cancel-on"),
-      },
-      {
-        title: "Concurrency",
-        href: `/docs/functions/concurrency`,
-      },
-      {
-        title: "Rate limit",
-        href: tsRef("v3", "functions/rate-limit"),
-      },
-      {
-        title: "Singleton",
-        href: tsRef("v3", "functions/singleton"),
-      },
-      {
-        title: "Debounce",
-        href: tsRef("v3", "functions/debounce"),
-      },
-      {
-        title: "Function run priority",
-        href: tsRef("v3", "functions/run-priority"),
-      },
-      {
-        title: "Extended Traces",
-        href: tsRef("v3", "extended-traces"),
-      },
-      {
-        title: "Referencing functions",
-        href: `/docs/functions/references`,
-      },
-      {
-        title: "Testing",
-        href: tsRef("v3", "testing"),
-      },
-      {
-        title: "Durable Endpoints",
-        href: tsRef("v3", "durable-endpoints"),
-        tag: "new",
-      },
+      { title: "Introduction", href: tsRef("v3", "intro") },
+      { title: "Create the client", href: tsRef("v3", "client/create") },
+      { title: "Create a function", href: tsRef("v3", "functions/create") },
+      { title: "Send events", href: tsRef("v3", "events/send") },
+      { title: "Errors", href: `/docs/reference/typescript/functions/errors` },
+      { title: "Handling failures", href: tsRef("v3", "functions/handling-failures") },
+      { title: "Cancel on", href: tsRef("v3", "functions/cancel-on") },
+      { title: "Concurrency", href: `/docs/functions/concurrency` },
+      { title: "Rate limit", href: tsRef("v3", "functions/rate-limit") },
+      { title: "Singleton", href: tsRef("v3", "functions/singleton") },
+      { title: "Debounce", href: tsRef("v3", "functions/debounce") },
+      { title: "Function run priority", href: tsRef("v3", "functions/run-priority") },
+      { title: "Extended Traces", href: tsRef("v3", "extended-traces") },
+      { title: "Referencing functions", href: `/docs/functions/references` },
+      { title: "Testing", href: tsRef("v3", "testing") },
+      { title: "Durable Endpoints", href: tsRef("v3", "durable-endpoints"), tag: "new" },
       {
         title: "Steps",
         links: [
-          {
-            title: "step.run()",
-            href: tsRef("v3", "functions/step-run"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sleep()",
-            href: tsRef("v3", "functions/step-sleep"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sleepUntil()",
-            href: tsRef("v3", "functions/step-sleep-until"),
-            className: "font-mono",
-          },
-          {
-            title: "step.invoke()",
-            href: tsRef("v3", "functions/step-invoke"),
-            className: "font-mono",
-          },
-          {
-            title: "step.waitForEvent()",
-            href: tsRef("v3", "functions/step-wait-for-event"),
-            className: "font-mono",
-          },
-          {
-            title: "step.waitForSignal()",
-            href: tsRef("v3", "functions/step-wait-for-signal"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sendEvent()",
-            href: tsRef("v3", "functions/step-send-event"),
-            className: "font-mono",
-          },
+          { title: "step.run()", href: tsRef("v3", "functions/step-run"), className: "font-mono" },
+          { title: "step.sleep()", href: tsRef("v3", "functions/step-sleep"), className: "font-mono" },
+          { title: "step.sleepUntil()", href: tsRef("v3", "functions/step-sleep-until"), className: "font-mono" },
+          { title: "step.invoke()", href: tsRef("v3", "functions/step-invoke"), className: "font-mono" },
+          { title: "step.waitForEvent()", href: tsRef("v3", "functions/step-wait-for-event"), className: "font-mono" },
+          { title: "step.waitForSignal()", href: tsRef("v3", "functions/step-wait-for-signal"), className: "font-mono" },
+          { title: "step.sendEvent()", href: tsRef("v3", "functions/step-send-event"), className: "font-mono" },
         ],
       },
       {
         title: "Serve",
         links: [
-          {
-            title: "Framework handlers",
-            href: `/docs/learn/serving-inngest-functions`,
-          },
-          {
-            title: "Configuration",
-            href: tsRef("v3", "serve"),
-          },
-          {
-            title: "Streaming",
-            href: `/docs/streaming`,
-          },
+          { title: "Framework handlers", href: `/docs/learn/serving-inngest-functions` },
+          { title: "Configuration", href: tsRef("v3", "serve") },
+          { title: "Streaming", href: `/docs/streaming` },
         ],
       },
       {
         title: "Realtime",
         tag: "deprecated",
         links: [
-          {
-            title: "Overview",
-            href: tsRef("v3", "realtime"),
-          },
-          {
-            title: "React hooks / Next.js",
-            href: tsRef("v3", "realtime/react-hooks"),
-          },
+          { title: "Overview", href: tsRef("v3", "realtime") },
+          { title: "React hooks / Next.js", href: tsRef("v3", "realtime/react-hooks") },
         ],
       },
       {
         title: "Middleware",
         links: [
-          {
-            title: "Lifecycle",
-            href: tsRef("v3", "middleware/lifecycle"),
-          },
-          {
-            title: "Examples",
-            href: tsRef("v3", "middleware/examples"),
-          },
-          {
-            title: "TypeScript",
-            href: `/docs/reference/middleware/typescript`,
-          },
+          { title: "Lifecycle", href: tsRef("v3", "middleware/lifecycle") },
+          { title: "Examples", href: tsRef("v3", "middleware/examples") },
+          { title: "TypeScript", href: `/docs/reference/middleware/typescript` },
         ],
       },
       {
         title: "Using the SDK",
         links: [
-          {
-            title: "Environment variables",
-            href: `/docs/sdk/environment-variables`,
-          },
-          {
-            title: "Using TypeScript",
-            href: `/docs/typescript`,
-          },
-          {
-            title: "ESLint plugin",
-            href: `/docs/sdk/eslint`,
-          },
-          {
-            title: "Upgrading to v3",
-            href: tsRef("v3", "migrations/v2-to-v3"),
-          },
+          { title: "Environment variables", href: `/docs/sdk/environment-variables` },
+          { title: "Using TypeScript", href: `/docs/typescript` },
+          { title: "ESLint plugin", href: `/docs/sdk/eslint` },
+          { title: "Upgrading to v3", href: tsRef("v3", "migrations/v2-to-v3") },
         ],
       },
     ],
@@ -243,222 +130,86 @@ const sectionReference: (NavGroup | NavLink)[] = [
     title: "TypeScript SDK v4",
     tag: "new",
     links: [
+      { title: "Introduction", href: tsRef("v4", "intro") },
+      { title: "Create the client", href: tsRef("v4", "client/create") },
+      { title: "Create a function", href: tsRef("v4", "functions/create") },
+      { title: "Trigger helpers", href: tsRef("v4", "functions/triggers") },
+      { title: "Send events", href: tsRef("v4", "events/send") },
+      { title: "Errors", href: `/docs/reference/typescript/functions/errors` },
+      { title: "Handling failures", href: tsRef("v4", "functions/handling-failures") },
+      { title: "Cancel on", href: tsRef("v4", "functions/cancel-on") },
+      { title: "Concurrency", href: tsRef("v4", "functions/concurrency") },
+      { title: "Rate limit", href: tsRef("v4", "functions/rate-limit") },
+      { title: "Singleton", href: tsRef("v4", "functions/singleton") },
+      { title: "Debounce", href: tsRef("v4", "functions/debounce") },
+      { title: "Function run priority", href: tsRef("v4", "functions/run-priority") },
+      { title: "Logging", href: tsRef("v4", "logging") },
+      { title: "Extended Traces", href: tsRef("v4", "extended-traces") },
+      { title: "Referencing functions", href: tsRef("v4", "functions/references") },
+      { title: "Testing", href: tsRef("v4", "testing") },
+      { title: "Durable Endpoints", href: tsRef("v4", "durable-endpoints"), tag: "new" },
+      { title: "Deferred Functions", href: tsRef("v4", "functions/deferred-functions"), tag: "beta" },
       {
-        title: "Introduction",
-        href: tsRef("v4", "intro"),
-      },
-      {
-        title: "Create the client",
-        href: tsRef("v4", "client/create"),
-      },
-      {
-        title: "Create a function",
-        href: tsRef("v4", "functions/create"),
-      },
-      {
-        title: "Trigger helpers",
-        href: tsRef("v4", "functions/triggers"),
-      },
-      {
-        title: "Send events",
-        href: tsRef("v4", "events/send"),
-      },
-      {
-        title: "Errors",
-        href: `/docs/reference/typescript/functions/errors`,
-      },
-      {
-        title: "Handling failures",
-        href: tsRef("v4", "functions/handling-failures"),
-      },
-      {
-        title: "Cancel on",
-        href: tsRef("v4", "functions/cancel-on"),
-      },
-      {
-        title: "Concurrency",
-        href: tsRef("v4", "functions/concurrency"),
-      },
-      {
-        title: "Rate limit",
-        href: tsRef("v4", "functions/rate-limit"),
-      },
-      {
-        title: "Singleton",
-        href: tsRef("v4", "functions/singleton"),
-      },
-      {
-        title: "Debounce",
-        href: tsRef("v4", "functions/debounce"),
-      },
-      {
-        title: "Function run priority",
-        href: tsRef("v4", "functions/run-priority"),
-      },
-      {
-        title: "Logging",
-        href: tsRef("v4", "logging"),
-      },
-      {
-        title: "Extended Traces",
-        href: tsRef("v4", "extended-traces"),
-      },
-      {
-        title: "Referencing functions",
-        href: tsRef("v4", "functions/references"),
-      },
-      {
-        title: "Testing",
-        href: tsRef("v4", "testing"),
-      },
-      {
-        title: "Durable Endpoints",
-        href: tsRef("v4", "durable-endpoints"),
-        tag: "new",
-      },
-      {
-        title: "Deferred Functions",
-        href: tsRef("v4", "functions/deferred-functions"),
+        title: "Experiments",
         tag: "beta",
+        links: [
+          { title: "group.experiment()", href: tsRef("v4", "functions/group-experiment"), className: "font-mono" },
+        ],
       },
       {
         title: "Steps",
         links: [
-          {
-            title: "step.run()",
-            href: tsRef("v4", "functions/step-run"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sleep()",
-            href: tsRef("v4", "functions/step-sleep"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sleepUntil()",
-            href: tsRef("v4", "functions/step-sleep-until"),
-            className: "font-mono",
-          },
-          {
-            title: "step.invoke()",
-            href: tsRef("v4", "functions/step-invoke"),
-            className: "font-mono",
-          },
-          {
-            title: "step.waitForEvent()",
-            href: tsRef("v4", "functions/step-wait-for-event"),
-            className: "font-mono",
-          },
-          {
-            title: "step.waitForSignal()",
-            href: tsRef("v4", "functions/step-wait-for-signal"),
-            className: "font-mono",
-          },
-          {
-            title: "step.sendEvent()",
-            href: tsRef("v4", "functions/step-send-event"),
-            className: "font-mono",
-          },
-          {
-            title: "step.fetch()",
-            href: tsRef("v4", "functions/fetch"),
-            className: "font-mono",
-          },
+          { title: "step.run()", href: tsRef("v4", "functions/step-run"), className: "font-mono" },
+          { title: "step.sleep()", href: tsRef("v4", "functions/step-sleep"), className: "font-mono" },
+          { title: "step.sleepUntil()", href: tsRef("v4", "functions/step-sleep-until"), className: "font-mono" },
+          { title: "step.invoke()", href: tsRef("v4", "functions/step-invoke"), className: "font-mono" },
+          { title: "step.waitForEvent()", href: tsRef("v4", "functions/step-wait-for-event"), className: "font-mono" },
+          { title: "step.waitForSignal()", href: tsRef("v4", "functions/step-wait-for-signal"), className: "font-mono" },
+          { title: "step.sendEvent()", href: tsRef("v4", "functions/step-send-event"), className: "font-mono" },
+          { title: "step.fetch()", href: tsRef("v4", "functions/fetch"), className: "font-mono" },
         ],
       },
       {
         title: "Serve",
         links: [
-          {
-            title: "Framework handlers",
-            href: `/docs/learn/serving-inngest-functions`,
-          },
-          {
-            title: "Configuration",
-            href: tsRef("v4", "serve"),
-          },
-          {
-            title: "Streaming",
-            href: tsRef("v4", "serve/streaming"),
-          },
+          { title: "Framework handlers", href: `/docs/learn/serving-inngest-functions` },
+          { title: "Configuration", href: tsRef("v4", "serve") },
+          { title: "Streaming", href: tsRef("v4", "serve/streaming") },
         ],
       },
       {
         title: "Realtime",
         tag: "new",
         links: [
-          {
-            title: "Overview",
-            href: tsRef("v4", "realtime"),
-          },
-          {
-            title: "Channels & topics",
-            href: tsRef("v4", "realtime/channels"),
-          },
-          {
-            title: "Publishing",
-            href: tsRef("v4", "realtime/publishing"),
-          },
-          {
-            title: "useRealtime",
-            href: tsRef("v4", "realtime/use-realtime"),
-            className: "font-mono",
-          },
-          {
-            title: "Subscribing",
-            href: tsRef("v4", "realtime/subscribing"),
-          },
+          { title: "Overview", href: tsRef("v4", "realtime") },
+          { title: "Channels & topics", href: tsRef("v4", "realtime/channels") },
+          { title: "Publishing", href: tsRef("v4", "realtime/publishing") },
+          { title: "useRealtime", href: tsRef("v4", "realtime/use-realtime"), className: "font-mono" },
+          { title: "Subscribing", href: tsRef("v4", "realtime/subscribing") },
         ],
       },
       {
         title: "Middleware",
         links: [
-          {
-            title: "Lifecycle",
-            href: tsRef("v4", "middleware/lifecycle"),
-          },
-          {
-            title: "Examples",
-            href: tsRef("v4", "middleware/examples"),
-          },
-          {
-            title: "Custom serialization",
-            href: tsRef("v4", "middleware/serialization"),
-          },
-          {
-            title: "Encryption",
-            href: tsRef("v4", "middleware/encryption"),
-          },
-          {
-            title: "Sentry",
-            href: tsRef("v4", "middleware/sentry"),
-          },
+          { title: "Lifecycle", href: tsRef("v4", "middleware/lifecycle") },
+          { title: "Examples", href: tsRef("v4", "middleware/examples") },
+          { title: "Custom serialization", href: tsRef("v4", "middleware/serialization") },
+          { title: "Encryption", href: tsRef("v4", "middleware/encryption") },
+          { title: "Sentry", href: tsRef("v4", "middleware/sentry") },
         ],
       },
       {
         title: "Migrations",
         links: [
-          {
-            title: "v3 to v4",
-            href: tsRef("v4", "migrations/v3-to-v4"),
-          },
+          { title: "v3 to v4", href: tsRef("v4", "migrations/v3-to-v4") },
         ],
       },
       {
         title: "Using the SDK",
         links: [
-          {
-            title: "Environment variables",
-            href: `/docs/sdk/environment-variables`,
-          },
-          {
-            title: "Using TypeScript",
-            href: `/docs/typescript`,
-          },
-          {
-            title: "ESLint plugin",
-            href: `/docs/sdk/eslint`,
-          },
+          { title: "Environment variables", href: `/docs/sdk/environment-variables` },
+          { title: "Using TypeScript", href: `/docs/typescript` },
+          { title: "ESLint plugin", href: `/docs/sdk/eslint` },
         ],
       },
     ],
@@ -466,112 +217,46 @@ const sectionReference: (NavGroup | NavLink)[] = [
   {
     title: "Python SDK",
     links: [
-      {
-        title: "Introduction",
-        href: `/docs/reference/python`,
-      },
-      {
-        title: "Quick start",
-        href: `/docs/reference/python/overview/quick-start`,
-      },
-      {
-        title: "Inngest Client",
-        href: `/docs/reference/python/client/overview`,
-      },
-      {
-        title: "Create function",
-        href: `/docs/reference/python/functions/create`,
-      },
-      {
-        title: "Send events",
-        href: `/docs/reference/python/client/send`,
-      },
-      {
-        title: "Environment variables",
-        href: `/docs/reference/python/overview/env-vars`,
-      },
-      {
-        title: "Production mode",
-        href: `/docs/reference/python/overview/prod-mode`,
-      },
+      { title: "Introduction", href: `/docs/reference/python` },
+      { title: "Quick start", href: `/docs/reference/python/overview/quick-start` },
+      { title: "Inngest Client", href: `/docs/reference/python/client/overview` },
+      { title: "Create function", href: `/docs/reference/python/functions/create` },
+      { title: "Send events", href: `/docs/reference/python/client/send` },
+      { title: "Environment variables", href: `/docs/reference/python/overview/env-vars` },
+      { title: "Production mode", href: `/docs/reference/python/overview/prod-mode` },
       {
         title: "Steps",
         links: [
-          {
-            title: "invoke",
-            href: `/docs/reference/python/steps/invoke`,
-          },
-          {
-            title: "invoke_by_id",
-            href: `/docs/reference/python/steps/invoke_by_id`,
-          },
-          {
-            title: "parallel",
-            href: `/docs/reference/python/steps/parallel`,
-          },
-          {
-            title: "run",
-            href: `/docs/reference/python/steps/run`,
-          },
-          {
-            title: "send_event",
-            href: `/docs/reference/python/steps/send-event`,
-          },
-          {
-            title: "sleep",
-            href: `/docs/reference/python/steps/sleep`,
-          },
-          {
-            title: "sleep_until",
-            href: `/docs/reference/python/steps/sleep-until`,
-          },
-          {
-            title: "wait_for_event",
-            href: `/docs/reference/python/steps/wait-for-event`,
-          },
+          { title: "invoke", href: `/docs/reference/python/steps/invoke` },
+          { title: "invoke_by_id", href: `/docs/reference/python/steps/invoke_by_id` },
+          { title: "parallel", href: `/docs/reference/python/steps/parallel` },
+          { title: "run", href: `/docs/reference/python/steps/run` },
+          { title: "send_event", href: `/docs/reference/python/steps/send-event` },
+          { title: "sleep", href: `/docs/reference/python/steps/sleep` },
+          { title: "sleep_until", href: `/docs/reference/python/steps/sleep-until` },
+          { title: "wait_for_event", href: `/docs/reference/python/steps/wait-for-event` },
         ],
       },
       {
         title: "Middleware",
         links: [
-          {
-            title: "Overview",
-            href: `/docs/reference/python/middleware/overview`,
-          },
-          {
-            title: "Lifecycle",
-            href: `/docs/reference/python/middleware/lifecycle`,
-          },
+          { title: "Overview", href: `/docs/reference/python/middleware/overview` },
+          { title: "Lifecycle", href: `/docs/reference/python/middleware/lifecycle` },
         ],
       },
       {
         title: "Guides",
         links: [
-          {
-            title: "Testing",
-            href: `/docs/reference/python/guides/testing`,
-          },
-          {
-            title: "Modal",
-            href: `/docs/reference/python/guides/modal`,
-          },
-          {
-            title: "Pydantic",
-            href: `/docs/reference/python/guides/pydantic`,
-          },
+          { title: "Testing", href: `/docs/reference/python/guides/testing` },
+          { title: "Modal", href: `/docs/reference/python/guides/modal` },
+          { title: "Pydantic", href: `/docs/reference/python/guides/pydantic` },
         ],
       },
       {
         title: "Migrations",
         links: [
-          {
-            title: "v0.4 to v0.5",
-            href: `/docs/reference/python/migrations/v0.4-to-v0.5`,
-          },
-          {
-            title: "v0.3 to v0.4",
-            href: `/docs/reference/python/migrations/v0.3-to-v0.4`,
-          },
+          { title: "v0.4 to v0.5", href: `/docs/reference/python/migrations/v0.4-to-v0.5` },
+          { title: "v0.3 to v0.4", href: `/docs/reference/python/migrations/v0.3-to-v0.4` },
         ],
       },
     ],
@@ -579,48 +264,25 @@ const sectionReference: (NavGroup | NavLink)[] = [
   {
     title: "Go SDK",
     links: [
-      {
-        title: "Reference",
-        href: "https://pkg.go.dev/github.com/inngest/inngestgo",
-      },
+      { title: "Reference", href: "https://pkg.go.dev/github.com/inngest/inngestgo" },
       {
         title: "Migrations",
         links: [
-          {
-            title: "v0.8 to v0.11",
-            href: `/docs/reference/go/migrations/v0.8-to-v0.11`,
-          },
-          {
-            title: "v0.7 to v0.8",
-            href: `/docs/reference/go/migrations/v0.7-to-v0.8`,
-          },
+          { title: "v0.8 to v0.11", href: `/docs/reference/go/migrations/v0.8-to-v0.11` },
+          { title: "v0.7 to v0.8", href: `/docs/reference/go/migrations/v0.7-to-v0.8` },
         ],
       },
     ],
   },
-  {
-    title: "REST API",
-    href: "https://api-docs.inngest.com",
-  },
+  { title: "REST API", href: "https://api-docs.inngest.com" },
   {
     title: "System events",
     links: [
-      {
-        title: "function.failed",
-        href: "/docs/reference/system-events/inngest-function-failed",
-        className: "font-mono",
-      },
-      {
-        title: "function.cancelled",
-        href: "/docs/reference/system-events/inngest-function-cancelled",
-        className: "font-mono",
-      },
+      { title: "function.failed", href: "/docs/reference/system-events/inngest-function-failed", className: "font-mono" },
+      { title: "function.cancelled", href: "/docs/reference/system-events/inngest-function-cancelled", className: "font-mono" },
     ],
   },
-  {
-    title: "Self-hosting",
-    href: `/docs/self-hosting`,
-  },
+  { title: "Self-hosting", href: `/docs/self-hosting` },
 ];
 
 // =============================================================================
@@ -632,246 +294,105 @@ const sectionLearn: (NavGroup | NavLink)[] = [
     title: "Quick starts",
     defaultOpen: true,
     links: [
-      {
-        title: "Next.js",
-        href: "/docs/getting-started/nextjs-quick-start",
-      },
+      { title: "Next.js", href: "/docs/getting-started/nextjs-quick-start" },
       {
         title: "Node.js",
         links: [
-          {
-            title: "Express",
-            href: "/docs/getting-started/express-quick-start",
-          },
-          {
-            title: "Astro",
-            href: "/docs/getting-started/astro-quick-start",
-          },
-          {
-            title: "H3",
-            href: "/docs/getting-started/h3-quick-start",
-          },
-          {
-            title: "NestJS",
-            href: "/docs/getting-started/nestjs-quick-start",
-          },
-          {
-            title: "TanStack Start",
-            href: "/docs/getting-started/tanstack-start-quick-start",
-          },
-          {
-            title: "Other frameworks",
-            href: "/docs/getting-started/nodejs-quick-start",
-          },
+          { title: "Express", href: "/docs/getting-started/express-quick-start" },
+          { title: "Astro", href: "/docs/getting-started/astro-quick-start" },
+          { title: "H3", href: "/docs/getting-started/h3-quick-start" },
+          { title: "NestJS", href: "/docs/getting-started/nestjs-quick-start" },
+          { title: "TanStack Start", href: "/docs/getting-started/tanstack-start-quick-start" },
+          { title: "Other frameworks", href: "/docs/getting-started/nodejs-quick-start" },
         ],
       },
-      {
-        title: "Python",
-        href: "/docs/getting-started/python-quick-start",
-      },
+      { title: "Python", href: "/docs/getting-started/python-quick-start" },
     ],
   },
   {
     title: "Concepts",
     defaultOpen: true,
     links: [
-      {
-        title: "How Durable execution works",
-        href: `/docs/learn/how-functions-are-executed`,
-      },
+      { title: "How Durable execution works", href: `/docs/learn/how-functions-are-executed` },
       {
         title: "Durable Functions",
         links: [
-          {
-            title: "Overview",
-            href: `/docs/learn/inngest-functions`,
-          },
-          {
-            title: "Serve Inngest Functions",
-            href: "/docs/learn/serving-inngest-functions",
-          },
-          {
-            title: "Triggering functions",
-            href: `/docs/features/events-triggers`,
-          },
-          {
-            title: "Idempotency",
-            href: `/docs/guides/handling-idempotency`,
-          },
-          {
-            title: "Logging",
-            href: "/docs/guides/logging",
-          },
+          { title: "Overview", href: `/docs/learn/inngest-functions` },
+          { title: "Serve Inngest Functions", href: "/docs/learn/serving-inngest-functions" },
+          { title: "Triggering functions", href: `/docs/features/events-triggers` },
+          { title: "Idempotency", href: `/docs/guides/handling-idempotency` },
+          { title: "Logging", href: "/docs/guides/logging" },
         ],
       },
       {
         title: "Durable Endpoints",
         links: [
-          {
-            title: "Overview",
-            href: `/docs/learn/durable-endpoints`,
-          },
-          {
-            title: "Streaming",
-            href: "/docs/learn/durable-endpoints/streaming",
-          },
+          { title: "Overview", href: `/docs/learn/durable-endpoints` },
+          { title: "Streaming", href: "/docs/learn/durable-endpoints/streaming" },
         ],
         tag: "new",
       },
       {
         title: "Steps",
         links: [
-          {
-            title: "Building with steps",
-            href: `/docs/learn/inngest-steps`,
-          },
-          {
-            title: "Sleeping",
-            href: "/docs/features/inngest-functions/steps-workflows/sleeps",
-          },
-          {
-            title: "Wait for event",
-            href: "/docs/features/inngest-functions/steps-workflows/wait-for-event",
-          },
-          {
-            title: "Wait for signal",
-            href: "/docs/features/inngest-functions/steps-workflows/wait-for-signal",
-          },
-          {
-            title: "Invoke other functions",
-            href: `/docs/guides/invoking-functions-directly`,
-          },
-          {
-            title: "AI steps (LLM calls)",
-            href: "/docs/features/inngest-functions/steps-workflows/step-ai-orchestration",
-          },
-          {
-            title: "Durable Fetch",
-            href: tsRef("v4", "functions/fetch"),
-          },
+          { title: "Building with steps", href: `/docs/learn/inngest-steps` },
+          { title: "Sleeping", href: "/docs/features/inngest-functions/steps-workflows/sleeps" },
+          { title: "Wait for event", href: "/docs/features/inngest-functions/steps-workflows/wait-for-event" },
+          { title: "Wait for signal", href: "/docs/features/inngest-functions/steps-workflows/wait-for-signal" },
+          { title: "Invoke other functions", href: `/docs/guides/invoking-functions-directly` },
+          { title: "AI steps (LLM calls)", href: "/docs/features/inngest-functions/steps-workflows/step-ai-orchestration" },
+          { title: "Durable Fetch", href: tsRef("v4", "functions/fetch") },
         ],
       },
       {
         title: "Error handling",
         links: [
-          {
-            title: "Overview",
-            href: `/docs/guides/error-handling`,
-          },
-          {
-            title: "Retries",
-            href: "/docs/features/inngest-functions/error-retries/retries",
-          },
-          {
-            title: "Rollbacks",
-            href: "/docs/features/inngest-functions/error-retries/rollbacks",
-          },
-          {
-            title: "Failure handlers",
-            href: "/docs/features/inngest-functions/error-retries/failure-handlers",
-          },
-          {
-            title: "Inngest errors",
-            href: "/docs/features/inngest-functions/error-retries/inngest-errors",
-          },
+          { title: "Overview", href: `/docs/guides/error-handling` },
+          { title: "Retries", href: "/docs/features/inngest-functions/error-retries/retries" },
+          { title: "Rollbacks", href: "/docs/features/inngest-functions/error-retries/rollbacks" },
+          { title: "Failure handlers", href: "/docs/features/inngest-functions/error-retries/failure-handlers" },
+          { title: "Inngest errors", href: "/docs/features/inngest-functions/error-retries/inngest-errors" },
         ],
       },
       {
         title: "Flow control",
         links: [
-          {
-            title: "Overview",
-            href: `/docs/guides/flow-control`,
-          },
-          {
-            title: "Concurrency",
-            href: `/docs/guides/concurrency`,
-          },
-          {
-            title: "Throttling",
-            href: `/docs/guides/throttling`,
-          },
-          {
-            title: "Batching",
-            href: `/docs/guides/batching`,
-          },
-          {
-            title: "Rate limit",
-            href: `/docs/guides/rate-limiting`,
-          },
-          {
-            title: "Singleton",
-            href: `/docs/guides/singleton`,
-          },
-          {
-            title: "Debounce",
-            href: `/docs/guides/debounce`,
-          },
-          {
-            title: "Priority",
-            href: `/docs/guides/priority`,
-          },
+          { title: "Overview", href: `/docs/guides/flow-control` },
+          { title: "Concurrency", href: `/docs/guides/concurrency` },
+          { title: "Throttling", href: `/docs/guides/throttling` },
+          { title: "Batching", href: `/docs/guides/batching` },
+          { title: "Rate limit", href: `/docs/guides/rate-limiting` },
+          { title: "Singleton", href: `/docs/guides/singleton` },
+          { title: "Debounce", href: `/docs/guides/debounce` },
+          { title: "Priority", href: `/docs/guides/priority` },
         ],
       },
       {
         title: "Cancellation",
         links: [
-          {
-            title: "Overview",
-            href: `/docs/features/inngest-functions/cancellation`,
-          },
-          {
-            title: "Cancel on timeouts",
-            href: `/docs/features/inngest-functions/cancellation/cancel-on-timeouts`,
-          },
-          {
-            title: "Cancel on events",
-            href: `/docs/features/inngest-functions/cancellation/cancel-on-events`,
-          },
-          {
-            title: "Bulk cancellation",
-            href: `/docs/guides/cancel-running-functions`,
-          },
+          { title: "Overview", href: `/docs/features/inngest-functions/cancellation` },
+          { title: "Cancel on timeouts", href: `/docs/features/inngest-functions/cancellation/cancel-on-timeouts` },
+          { title: "Cancel on events", href: `/docs/features/inngest-functions/cancellation/cancel-on-events` },
+          { title: "Bulk cancellation", href: `/docs/guides/cancel-running-functions` },
         ],
       },
       {
         title: "Realtime",
         tag: "new",
         links: [
-          {
-            title: "Overview",
-            href: "/docs/features/realtime",
-          },
-          {
-            title: "React hooks / Next.js",
-            href: "/docs/features/realtime/react-hooks",
-          },
+          { title: "Overview", href: "/docs/features/realtime" },
+          { title: "React hooks / Next.js", href: "/docs/features/realtime/react-hooks" },
         ],
       },
       {
         title: "Environments and Apps",
         href: "/docs/apps",
         links: [
-          {
-            title: "Overview",
-            href: "/docs/apps",
-          },
-          {
-            title: "Environments",
-            href: `/docs/platform/environments`,
-          },
-          {
-            title: "Apps",
-            href: `/docs/platform/manage/apps`,
-          },
-          {
-            title: "Event keys",
-            href: `/docs/events/creating-an-event-key`,
-          },
-          {
-            title: "Signing keys",
-            href: `/docs/platform/signing-keys`,
-          },
+          { title: "Overview", href: "/docs/apps" },
+          { title: "Environments", href: `/docs/platform/environments` },
+          { title: "Apps", href: `/docs/platform/manage/apps` },
+          { title: "Event keys", href: `/docs/events/creating-an-event-key` },
+          { title: "Signing keys", href: `/docs/platform/signing-keys` },
         ],
       },
     ],
@@ -880,96 +401,33 @@ const sectionLearn: (NavGroup | NavLink)[] = [
     title: "Guides",
     defaultOpen: true,
     links: [
-      {
-        title: "Local development",
-        href: `/docs/local-development`,
-      },
+      { title: "Local development", href: `/docs/local-development` },
       {
         title: "Events and Triggers",
         links: [
-          {
-            title: "Overview",
-            href: `/docs/features/events-triggers`,
-          },
-          {
-            title: "Sending events",
-            href: `/docs/events`,
-          },
-          {
-            title: "Event payload format",
-            href: `/docs/features/events-triggers/event-format`,
-          },
-          {
-            title: "Writing expressions",
-            href: `/docs/guides/writing-expressions`,
-          },
-          {
-            title: "Consuming webhook events",
-            href: `/docs/platform/webhooks`,
-          },
-          {
-            title: "Parallel steps",
-            href: "/docs/guides/step-parallelism",
-          },
-          {
-            title: "Fan-out",
-            href: `/docs/guides/fan-out-jobs`,
-          },
-          {
-            title: "Working with loops",
-            href: "/docs/guides/working-with-loops",
-          },
-          {
-            title: "Delayed functions",
-            href: `/docs/guides/delayed-functions`,
-          },
-          {
-            title: "Cron functions",
-            href: `/docs/guides/scheduled-functions`,
-          },
-          {
-            title: "Background jobs",
-            href: `/docs/guides/background-jobs`,
-          },
-          {
-            title: "Multiple triggers & wildcards",
-            href: `/docs/guides/multiple-triggers`,
-          },
-          {
-            title: "Sending events from functions",
-            href: `/docs/guides/sending-events-from-functions`,
-          },
-          {
-            title: "User-defined Workflows",
-            href: `/docs/guides/user-defined-workflows`,
-          },
-          {
-            title: "Mergent migration guide",
-            href: `/docs/guides/mergent-migration`,
-          },
+          { title: "Overview", href: `/docs/features/events-triggers` },
+          { title: "Sending events", href: `/docs/events` },
+          { title: "Event payload format", href: `/docs/features/events-triggers/event-format` },
+          { title: "Writing expressions", href: `/docs/guides/writing-expressions` },
+          { title: "Consuming webhook events", href: `/docs/platform/webhooks` },
+          { title: "Parallel steps", href: "/docs/guides/step-parallelism" },
+          { title: "Fan-out", href: `/docs/guides/fan-out-jobs` },
+          { title: "Working with loops", href: "/docs/guides/working-with-loops" },
+          { title: "Delayed functions", href: `/docs/guides/delayed-functions` },
+          { title: "Cron functions", href: `/docs/guides/scheduled-functions` },
+          { title: "Background jobs", href: `/docs/guides/background-jobs` },
+          { title: "Multiple triggers & wildcards", href: `/docs/guides/multiple-triggers` },
+          { title: "Sending events from functions", href: `/docs/guides/sending-events-from-functions` },
+          { title: "User-defined Workflows", href: `/docs/guides/user-defined-workflows` },
+          { title: "Mergent migration guide", href: `/docs/guides/mergent-migration` },
           {
             title: "Workflow Kit",
             links: [
-              {
-                title: "Introduction",
-                href: `/docs/reference/workflow-kit`,
-              },
-              {
-                title: "Creating Workflow Actions",
-                href: `/docs/reference/workflow-kit/actions`,
-              },
-              {
-                title: "Using the Workflow Engine",
-                href: `/docs/reference/workflow-kit/engine`,
-              },
-              {
-                title: "Workflow instance format",
-                href: `/docs/reference/workflow-kit/workflow-instance`,
-              },
-              {
-                title: "Components API (React)",
-                href: `/docs/reference/workflow-kit/components-api`,
-              },
+              { title: "Introduction", href: `/docs/reference/workflow-kit` },
+              { title: "Creating Workflow Actions", href: `/docs/reference/workflow-kit/actions` },
+              { title: "Using the Workflow Engine", href: `/docs/reference/workflow-kit/engine` },
+              { title: "Workflow instance format", href: `/docs/reference/workflow-kit/workflow-instance` },
+              { title: "Components API (React)", href: `/docs/reference/workflow-kit/components-api` },
             ],
           },
         ],
@@ -977,109 +435,44 @@ const sectionLearn: (NavGroup | NavLink)[] = [
       {
         title: "Agents",
         links: [
-          {
-            title: "Agent tool loops",
-            href: `/docs/ai-patterns/agent-tool-loops`,
-          },
-          {
-            title: "Human-in-the-loop",
-            href: `/docs/ai-patterns/human-in-the-loop`,
-          },
-          {
-            title: "Sub-agents",
-            href: `/docs/ai-patterns/sub-agent-delegation`,
-          },
+          { title: "Agent tool loops", href: `/docs/ai-patterns/agent-tool-loops` },
+          { title: "Human-in-the-loop", href: `/docs/ai-patterns/human-in-the-loop` },
+          { title: "Sub-agents", href: `/docs/ai-patterns/sub-agent-delegation` },
+          { title: "Run experiments", href: `/docs/features/inngest-functions/steps-workflows/running-experiments`, tag: "beta" },
         ],
       },
       {
         title: "Deploying",
         defaultOpen: true,
         links: [
-          {
-            title: "Overview",
-            href: `/docs/platform/deployment`,
-          },
-          {
-            title: "Sync your app",
-            href: `/docs/apps/cloud`,
-          },
-          {
-            title: "Connect (workers)",
-            href: `/docs/setup/connect`,
-            tag: "beta",
-          },
-          {
-            title: "Checkpointing",
-            href: `/docs/setup/checkpointing`,
-            tag: "new",
-          },
+          { title: "Overview", href: `/docs/platform/deployment` },
+          { title: "Sync your app", href: `/docs/apps/cloud` },
+          { title: "Connect (workers)", href: `/docs/setup/connect`, tag: "beta" },
+          { title: "Checkpointing", href: `/docs/setup/checkpointing`, tag: "new" },
           {
             title: "Cloud providers",
             links: [
-              {
-                title: "Vercel",
-                href: "/docs/deploy/vercel",
-              },
-              {
-                title: "DigitalOcean",
-                href: "/docs/deploy/digital-ocean",
-                tag: "new",
-              },
-              {
-                title: "Cloudflare Pages",
-                href: `/docs/deploy/cloudflare`,
-              },
-              {
-                title: "Netlify",
-                href: `/docs/deploy/netlify`,
-              },
-              {
-                title: "Render",
-                href: `/docs/deploy/render`,
-              },
-              {
-                title: "Cloud Provider Usage Limits",
-                href: `/docs/usage-limits/providers`,
-              },
+              { title: "Vercel", href: "/docs/deploy/vercel" },
+              { title: "DigitalOcean", href: "/docs/deploy/digital-ocean", tag: "new" },
+              { title: "Cloudflare Pages", href: `/docs/deploy/cloudflare` },
+              { title: "Netlify", href: `/docs/deploy/netlify` },
+              { title: "Render", href: `/docs/deploy/render` },
+              { title: "Cloud Provider Usage Limits", href: `/docs/usage-limits/providers` },
             ],
           },
         ],
       },
-      {
-        title: "Optimizing Performance",
-        href: `/docs/improve-performance`,
-      },
-      {
-        title: "Versioning",
-        href: `/docs/learn/versioning`,
-      },
-      {
-        title: "Logging",
-        href: "/docs/guides/logging",
-      },
+      { title: "Optimizing Performance", href: `/docs/improve-performance` },
+      { title: "Versioning", href: `/docs/learn/versioning` },
+      { title: "Logging", href: "/docs/guides/logging" },
       {
         title: "Middleware",
         links: [
-          {
-            title: "Overview",
-            href: `/docs/features/middleware`,
-          },
-          {
-            title: "Creating middleware",
-            href: `/docs/features/middleware/create`,
-          },
-          {
-            title: "Dependency Injection",
-            href: "/docs/features/middleware/dependency-injection",
-          },
-          {
-            title: "Encryption Middleware",
-            href: "/docs/features/middleware/encryption-middleware",
-          },
-          {
-            title: "Sentry Middleware",
-            href: "/docs/features/middleware/sentry-middleware",
-          },
+          { title: "Overview", href: `/docs/features/middleware` },
+          { title: "Creating middleware", href: `/docs/features/middleware/create` },
+          { title: "Dependency Injection", href: "/docs/features/middleware/dependency-injection" },
+          { title: "Encryption Middleware", href: "/docs/features/middleware/encryption-middleware" },
+          { title: "Sentry Middleware", href: "/docs/features/middleware/sentry-middleware" },
         ],
       },
     ],
@@ -1090,70 +483,29 @@ const sectionLearn: (NavGroup | NavLink)[] = [
       {
         title: "Manage",
         links: [
-          {
-            title: "Bulk replay",
-            href: "/docs/platform/replay",
-          },
-          {
-            title: "Bulk cancel",
-            href: "/docs/platform/manage/bulk-cancellation",
-          },
-          {
-            title: "Pausing",
-            href: "/docs/guides/pause-functions",
-          },
-          {
-            title: "Rotating keys",
-            href: "/docs/platform/manage/rotating-keys",
-          },
-          {
-            title: "API keys",
-            href: "/docs/platform/api-keys",
-          },
+          { title: "Bulk replay", href: "/docs/platform/replay" },
+          { title: "Bulk cancel", href: "/docs/platform/manage/bulk-cancellation" },
+          { title: "Pausing", href: "/docs/guides/pause-functions" },
+          { title: "Rotating keys", href: "/docs/platform/manage/rotating-keys" },
+          { title: "API keys", href: "/docs/platform/api-keys" },
         ],
       },
       {
         title: "Monitor",
         links: [
-          {
-            title: "Inspecting runs",
-            href: "/docs/platform/monitor/inspecting-function-runs",
-          },
-          {
-            title: "Traces",
-            href: "/docs/platform/monitor/traces",
-            tag: "new",
-          },
-          {
-            title: "Observability and metrics",
-            href: "/docs/platform/monitor/observability-metrics",
-          },
-          {
-            title: "Insights",
-            href: "/docs/platform/monitor/insights",
-            tag: "new",
-          },
-          {
-            title: "Events",
-            href: "/docs/platform/monitor/inspecting-events",
-          },
+          { title: "Inspecting runs", href: "/docs/platform/monitor/inspecting-function-runs" },
+          { title: "Traces", href: "/docs/platform/monitor/traces", tag: "new" },
+          { title: "Observability and metrics", href: "/docs/platform/monitor/observability-metrics" },
+          { title: "Insights", href: "/docs/platform/monitor/insights", tag: "new" },
+          { title: "Events", href: "/docs/platform/monitor/inspecting-events" },
         ],
       },
       {
         title: "Integrations",
         links: [
-          {
-            title: "Neon",
-            href: `/docs/features/events-triggers/neon`,
-          },
-          {
-            title: "Datadog",
-            href: "/docs/platform/monitor/datadog-integration",
-          },
-          {
-            title: "Prometheus",
-            href: "/docs/platform/monitor/prometheus-metrics-export-integration",
-          },
+          { title: "Neon", href: `/docs/features/events-triggers/neon` },
+          { title: "Datadog", href: "/docs/platform/monitor/datadog-integration" },
+          { title: "Prometheus", href: "/docs/platform/monitor/prometheus-metrics-export-integration" },
         ],
       },
     ],
@@ -1161,44 +513,19 @@ const sectionLearn: (NavGroup | NavLink)[] = [
   {
     title: "AI",
     links: [
-      {
-        title: "Agent Plugins and Skills",
-        href: "/docs/ai-dev-tools/agent-skills",
-      },
-      {
-        title: "Dev Server MCP",
-        href: "/docs/ai-dev-tools/mcp",
-      },
-      {
-        title: "AgentKit",
-        href: "https://agentkit.inngest.com",
-        target: "_blank",
-      },
+      { title: "Agent Plugins and Skills", href: "/docs/ai-dev-tools/agent-skills" },
+      { title: "Dev Server MCP", href: "/docs/ai-dev-tools/mcp" },
+      { title: "AgentKit", href: "https://agentkit.inngest.com", target: "_blank" },
     ],
   },
   {
     title: "Resources",
     links: [
-      {
-        title: "Security",
-        href: "/docs/learn/security",
-      },
-      {
-        title: "Glossary",
-        href: `/docs/learn/glossary`,
-      },
-      {
-        title: "Release phases",
-        href: `/docs/release-phases`,
-      },
-      {
-        title: "FAQ",
-        href: `/docs/faq`,
-      },
-      {
-        title: "Limitations",
-        href: `/docs/usage-limits/inngest`,
-      },
+      { title: "Security", href: "/docs/learn/security" },
+      { title: "Glossary", href: `/docs/learn/glossary` },
+      { title: "Release phases", href: `/docs/release-phases` },
+      { title: "FAQ", href: `/docs/faq` },
+      { title: "Limitations", href: `/docs/usage-limits/inngest` },
     ],
   },
 ];
@@ -1212,72 +539,27 @@ const sectionExamples: NavGroup[] = [
     defaultOpen: true,
     links: [
       { title: "All examples", href: `/docs/examples/` },
-      {
-        title: "AI Agents and RAG",
-        href: `/docs/examples/ai-agents-and-rag`,
-      },
-      {
-        title: "Email Sequence",
-        href: `/docs/examples/email-sequence`,
-      },
-      {
-        title: "Scheduling a one-off function",
-        href: `/docs/examples/scheduling-one-off-function`,
-      },
-      {
-        title: "Fetch run status and output",
-        href: `/docs/examples/fetch-run-status-and-output`,
-      },
-      {
-        title: "Track all function failures in Datadog",
-        href: `/docs/examples/track-failures-in-datadog`,
-      },
-      {
-        title: "Cleanup after function cancellation",
-        href: `/docs/examples/cleanup-after-function-cancellation`,
-      },
-      {
-        title: "Fetch: Durable HTTP requests",
-        href: `/docs/examples/fetch`,
-      },
-      {
-        title: "Stream updates from functions",
-        href: `/docs/examples/realtime`,
-      },
-      {
-        title: "Setup OpenTelemetry with Inngest",
-        href: `/docs/examples/open-telemetry`,
-      },
-      {
-        title: "Durable Endpoints",
-        href: `/docs/examples/durable-endpoints`,
-      },
-      {
-        title: "Trigger workflows from Retool",
-        href: `/docs/guides/trigger-your-code-from-retool`,
-      },
-      {
-        title: "Instrumenting GraphQL",
-        href: `/docs/guides/instrumenting-graphql`,
-      },
-      {
-        title: "Handle Clerk webhooks",
-        href: `/docs/guides/clerk-webhook-events`,
-      },
-      {
-        title: "Handle Resend webhooks",
-        href: `/docs/guides/resend-webhook-events`,
-      },
+      { title: "AI Agents and RAG", href: `/docs/examples/ai-agents-and-rag` },
+      { title: "Email Sequence", href: `/docs/examples/email-sequence` },
+      { title: "Scheduling a one-off function", href: `/docs/examples/scheduling-one-off-function` },
+      { title: "Fetch run status and output", href: `/docs/examples/fetch-run-status-and-output` },
+      { title: "Track all function failures in Datadog", href: `/docs/examples/track-failures-in-datadog` },
+      { title: "Cleanup after function cancellation", href: `/docs/examples/cleanup-after-function-cancellation` },
+      { title: "Fetch: Durable HTTP requests", href: `/docs/examples/fetch` },
+      { title: "Stream updates from functions", href: `/docs/examples/realtime` },
+      { title: "Setup OpenTelemetry with Inngest", href: `/docs/examples/open-telemetry` },
+      { title: "Durable Endpoints", href: `/docs/examples/durable-endpoints` },
+      { title: "Trigger workflows from Retool", href: `/docs/guides/trigger-your-code-from-retool` },
+      { title: "Instrumenting GraphQL", href: `/docs/guides/instrumenting-graphql` },
+      { title: "Handle Clerk webhooks", href: `/docs/guides/clerk-webhook-events` },
+      { title: "Handle Resend webhooks", href: `/docs/guides/resend-webhook-events` },
     ],
   },
   {
     title: "Middleware",
     defaultOpen: true,
     links: [
-      {
-        title: "Cloudflare Workers & Hono environment variables",
-        href: `/docs/examples/middleware/cloudflare-workers-environment-variables`,
-      },
+      { title: "Cloudflare Workers & Hono environment variables", href: `/docs/examples/middleware/cloudflare-workers-environment-variables` },
     ],
   },
 ];
@@ -1347,49 +629,22 @@ matchers.default = matchers.learn;
 // MENU TABS (Top navigation)
 // =============================================================================
 export const menuTabs = [
-  {
-    title: "Documentation",
-    icon: PlayIcon,
-    href: "/docs",
-    matcher: matchers.default,
-  },
-  {
-    title: "Examples",
-    icon: LightBulbIcon,
-    href: "/docs/examples/",
-    matcher: matchers.examples,
-  },
-  {
-    title: "Patterns",
-    icon: Squares2X2Icon,
-    href: "/docs/patterns",
-    matcher: matchers.patterns,
-  },
+  { title: "Documentation", icon: PlayIcon, href: "/docs", matcher: matchers.default },
+  { title: "Examples", icon: LightBulbIcon, href: "/docs/examples/", matcher: matchers.examples },
+  { title: "Patterns", icon: Squares2X2Icon, href: "/docs/patterns", matcher: matchers.patterns },
 ];
 
 // =============================================================================
 // SIDEBAR TABS (Sidebar navigation)
 // =============================================================================
 export const sidebarMenuTabs = [
-  {
-    title: "Learn",
-    icon: BookOpenIcon,
-    href: "/docs",
-    matcher: matchers.learn,
-  },
-  {
-    title: "Reference",
-    icon: CodeBracketIcon,
-    href: `/docs/reference/typescript/${TS_STABLE}/intro`,
-    matcher: matchers.reference,
-  },
+  { title: "Learn", icon: BookOpenIcon, href: "/docs", matcher: matchers.learn },
+  { title: "Reference", icon: CodeBracketIcon, href: `/docs/reference/typescript/${TS_STABLE}/intro`, matcher: matchers.reference },
 ];
 
 // =============================================================================
 // TOP LEVEL NAV
 // =============================================================================
-// Patterns nav: one non-collapsible group per primitive (Examples-style),
-// derived from the static pattern index. `defaultOpen` keeps every group open.
 const sectionPatterns: NavGroup[] = [
   {
     title: "Overview",
@@ -1407,32 +662,8 @@ const sectionPatterns: NavGroup[] = [
 ];
 
 export const topLevelNav = [
-  {
-    title: "Learn",
-    icon: BookOpenIcon,
-    href: `/docs`,
-    sectionLinks: sectionLearn,
-    matcher: matchers.learn,
-  },
-  {
-    title: "Patterns",
-    icon: Squares2X2Icon,
-    href: "/docs/patterns",
-    sectionLinks: sectionPatterns,
-    matcher: matchers.patterns,
-  },
-  {
-    title: "Reference",
-    icon: CodeBracketIcon,
-    href: `/docs/reference/typescript/${TS_STABLE}/intro`,
-    matcher: matchers.reference,
-    sectionLinks: sectionReference,
-  },
-  {
-    title: "Examples",
-    icon: LightBulbIcon,
-    href: "/docs/examples/",
-    sectionLinks: sectionExamples,
-    matcher: matchers.examples,
-  },
+  { title: "Learn", icon: BookOpenIcon, href: `/docs`, sectionLinks: sectionLearn, matcher: matchers.learn },
+  { title: "Patterns", icon: Squares2X2Icon, href: "/docs/patterns", sectionLinks: sectionPatterns, matcher: matchers.patterns },
+  { title: "Reference", icon: CodeBracketIcon, href: `/docs/reference/typescript/${TS_STABLE}/intro`, matcher: matchers.reference, sectionLinks: sectionReference },
+  { title: "Examples", icon: LightBulbIcon, href: "/docs/examples/", sectionLinks: sectionExamples, matcher: matchers.examples },
 ];


### PR DESCRIPTION
## Summary

Adds experiments to the docs sidebar navigation. Both pages already exist and are live but had no nav entries, making them undiscoverable.

Two additions:

1. **Learn > Guides > Agents:** "Run experiments" linking to the existing how-to at `/docs/features/inngest-functions/steps-workflows/running-experiments` (beta tag)

2. **Reference > TypeScript SDK v4:** New "Experiments" group (beta tag) with `group.experiment()` linking to the existing reference at `/docs/reference/typescript/v4/functions/group-experiment`

No new pages created. Just wiring existing content into the nav.

Resolves DEV-384