### PR TITLE
Pattern: Experiment, score, and compare AI models

### DIFF
--- a/shared/Patterns/_patterns/experiment-score-and-compare-ai-models.mdx
+++ b/shared/Patterns/_patterns/experiment-score-and-compare-ai-models.mdx
@@ -1,21 +1,20 @@
 ---
-title: Experiment, score, and compare AI models
-subtitle: Use experiments to split traffic between models, defer scoring to run after the response, and query results to pick the winner.
+title: Experiment and compare AI models
+subtitle: Use experiments to split traffic between models, then query Insights to compare latency, token usage, and success rates across variants.
 pattern: durable
 tags: [Durability, AI, Architecture]
 ---
 
 You shipped an AI feature with GPT-4o. A new model drops. Your team wants to know: is it better for our use case? Faster? Cheaper? More accurate? You need to compare them in production with real traffic, not a synthetic benchmark.
 
-This pattern composes three Inngest primitives to answer that question without building a separate eval pipeline:
+This pattern uses two Inngest primitives to answer that question:
 
 | Primitive | Role in this pattern |
 |---|---|
 | **`group.experiment()`** | Splits traffic between model variants |
-| **`defer()`** | Scores each variant's output after the response ships |
-| **Insights** | Aggregates scores so you can query which variant wins |
+| **Insights** | Aggregates run data so you can query which variant performs better |
 
-The function serves a response to the user immediately. The scoring happens in the background. The data accumulates over days or weeks. You make a decision based on real production outcomes, not a one-off test.
+The function serves a response to the user immediately. Run metadata (variant, model, token counts) is captured automatically. The data accumulates over days or weeks. You make a decision based on real production outcomes, not a one-off test.
 
 ---
 
@@ -25,90 +24,10 @@ Here is the complete function. Each section is explained below.
 
 ```typescript
 import { inngest } from "./client";
-import { createDefer } from "inngest/experimental";
-import { z } from "zod";
 
-// --- Deferred scorer ---
-// Runs after the parent completes. Evaluates the response
-// using a cheaper model as a judge.
-const qualityScorer = createDefer(inngest, {
-  id: "score-response-quality",
-  schema: z.object({
-    response: z.string(),
-    model: z.string(),
-    variant: z.string(),
-    ticketId: z.string(),
-  }),
-}, async ({ event, step }) => {
-  const evaluation = await step.run("llm-judge", async () => {
-    return await openai.chat.completions.create({
-      model: "gpt-4o-mini",
-      messages: [
-        {
-          role: "system",
-          content: `Rate this support response on three dimensions.
-Return JSON: { "helpfulness": 1-5, "accuracy": 1-5, "tone": 1-5 }
-Be strict. A 3 means acceptable. A 5 means exceptional.`,
-        },
-        { role: "user", content: event.data.response },
-      ],
-    });
-  });
-
-  await step.run("persist-scores", async () => {
-    const scores = JSON.parse(evaluation.choices[0].message.content);
-
-    // Each score is attached to the parent run and tagged with the variant.
-    // This is what makes the data queryable in Insights.
-    await inngest.score({
-      name: "helpfulness",
-      value: scores.helpfulness / 5,
-      runId: event.data.ticketId,
-    });
-    await inngest.score({
-      name: "accuracy",
-      value: scores.accuracy / 5,
-      runId: event.data.ticketId,
-    });
-    await inngest.score({
-      name: "tone",
-      value: scores.tone / 5,
-      runId: event.data.ticketId,
-    });
-  });
-});
-
-// --- Cost tracker ---
-// Logs token usage per variant per customer.
-const costTracker = createDefer(inngest, {
-  id: "track-experiment-costs",
-  schema: z.object({
-    model: z.string(),
-    variant: z.string(),
-    promptTokens: z.number(),
-    completionTokens: z.number(),
-    customerId: z.string(),
-  }),
-}, async ({ event, step }) => {
-  await step.run("log-cost", async () => {
-    const rates = { "gpt-4o": 0.005, "claude-sonnet-4-20250514": 0.003 };
-    const costPer1k = rates[event.data.model] || 0.005;
-    const totalTokens = event.data.promptTokens + event.data.completionTokens;
-
-    await analytics.track("ai.experiment.cost", {
-      variant: event.data.variant,
-      model: event.data.model,
-      tokens: totalTokens,
-      cost_usd: (totalTokens / 1000) * costPer1k,
-      customer_id: event.data.customerId,
-    });
-  });
-});
-
-// --- Agent function ---
 const handleTicket = inngest.createFunction(
   { id: "handle-support-ticket", triggers: { event: "support/ticket.created" } },
-  async ({ event, step, group, defer }) => {
+  async ({ event, step, group }) => {
 
     // 1. EXPERIMENT: select a model variant
     const { result: response, variant } = await group.experiment(
@@ -152,49 +71,23 @@ const handleTicket = inngest.createFunction(
       await supportPlatform.reply(event.data.ticketId, reply);
     });
 
-    // 3. DEFER: score and track costs after the parent completes
-    defer("score-quality", {
-      function: qualityScorer,
-      data: {
-        response: reply,
-        model: variant === "gpt4o" ? "gpt-4o" : "claude-sonnet-4-20250514",
-        variant,
-        ticketId: event.data.ticketId,
-      },
-    });
-
-    defer("track-costs", {
-      function: costTracker,
-      data: {
-        model: variant === "gpt4o" ? "gpt-4o" : "claude-sonnet-4-20250514",
-        variant,
-        promptTokens: variant === "gpt4o"
-          ? response.usage.prompt_tokens
-          : response.usage.input_tokens,
-        completionTokens: variant === "gpt4o"
-          ? response.usage.completion_tokens
-          : response.usage.output_tokens,
-        customerId: event.data.customerId,
-      },
-    });
-
     return { ticketId: event.data.ticketId, variant, status: "resolved" };
   }
 );
 ```
 
-Register all functions:
+Register the function:
 
 ```typescript
 serve({
   client: inngest,
-  functions: [handleTicket, qualityScorer, costTracker],
+  functions: [handleTicket],
 });
 ```
 
 ---
 
-## How the pieces compose
+## How the pieces work together
 
 ### Experiments select the variant
 
@@ -202,34 +95,41 @@ serve({
 
 Start with 50/50. Once you have enough data, shift to 90/10 to confirm the winner at scale before cutting over completely.
 
-### Defer handles the scoring
+Each variant wraps its model call in `step.run()`. This means the model call is independently retried if it fails, and the variant selection is preserved across retries.
 
-The scorer runs as a completely separate function after the parent finalizes. The customer gets their response immediately. The LLM-as-judge evaluation happens on its own timeline with its own retries.
+### Run data captures the comparison
 
-This is important because scoring can be slow (the judge model needs to read and evaluate the response) and can fail (model rate limits, timeouts). Neither of those should affect the customer experience or the parent run's success status.
-
-### Scores land on the run
-
-`inngest.score()` attaches named numeric values to the parent run. Each score is tagged with the variant that produced it. Over time, you accumulate thousands of scored runs across both variants.
+Every run records which variant was selected, how long each step took, and whether it succeeded. The variant name is returned in the function output. Extended traces capture token counts and latency per step if you have the middleware enabled.
 
 ### Insights reveals the winner
 
-Query your scores in Insights to compare variants:
+Query your run data in Insights to compare variants. For example, compare average step duration:
 
 ```sql
 SELECT
-  JSON_VALUE(metadata, '$.variant') AS variant,
-  AVG(scores.helpfulness) AS avg_helpfulness,
-  AVG(scores.accuracy) AS avg_accuracy,
-  AVG(scores.tone) AS avg_tone,
+  output.variant AS variant,
+  AVG(duration_ms) AS avg_duration_ms,
+  COUNT(*) AS total_runs,
+  SUM(CASE WHEN status = 'FAILED' THEN 1 ELSE 0 END) AS failures
+FROM runs
+WHERE function_id = 'handle-support-ticket'
+  AND status IN ('COMPLETED', 'FAILED')
+GROUP BY output.variant
+```
+
+If Sonnet averages 800ms and GPT-4o averages 1200ms across 500 runs each with similar failure rates, you have a data-driven answer. Not a gut check. Not a benchmark on synthetic data. A measurement from your production traffic.
+
+With Extended Traces enabled, you can also compare token usage:
+
+```sql
+SELECT
+  output.variant AS variant,
+  AVG(steps.duration_ms) AS avg_model_call_ms,
   COUNT(*) AS runs
 FROM runs
 WHERE function_id = 'handle-support-ticket'
-  AND status = 'COMPLETED'
-GROUP BY variant
+GROUP BY output.variant
 ```
-
-If Sonnet scores 4.2 on helpfulness and GPT-4o scores 3.8 across 500 runs each, you have a data-driven answer. Not a gut check. Not a benchmark on synthetic data. A measurement from your production traffic.
 
 ---
 
@@ -264,45 +164,19 @@ variants: {
 },
 ```
 
-**Add temporal scoring.** Instead of scoring immediately with LLM-as-judge, use `step.waitForEvent()` inside the scorer to wait for a real user signal:
+**Compare RAG strategies.** One variant uses a simple vector search. The other adds a reranking step. Same model, different retrieval pipelines. Insights shows you whether the extra latency from reranking actually improves outcomes.
 
-```typescript
-const feedbackScorer = createDefer(inngest, {
-  id: "wait-for-feedback",
-  schema: z.object({ ticketId: z.string(), variant: z.string() }),
-}, async ({ event, step }) => {
-  const feedback = await step.waitForEvent("wait-for-thumbs", {
-    event: "support/feedback.received",
-    timeout: "7d",
-    if: `async.data.ticketId == '${event.data.ticketId}'`,
-  });
-
-  await step.run("record-feedback", async () => {
-    await inngest.score({
-      name: "user-satisfaction",
-      value: feedback ? (feedback.data.helpful ? 1 : 0) : 0.5,
-      runId: event.data.ticketId,
-    });
-  });
-});
-```
-
-Now your experiment measures what actually matters: did the user find the response helpful? The scorer waits up to 7 days for a thumbs-up/down event. This is something no external eval platform can do because they don't have access to your event stream.
-
-**Track cost alongside quality.** The cost tracker in the example above runs as a separate deferred function. When you query Insights, you can compare not just quality but cost-per-response across variants. A model that scores 5% better but costs 3x more might not be the right choice.
+**Gradually roll out a new model.** Start at `weights: { current: 95, new: 5 }`. Monitor for a week. If the new model performs well, shift to 50/50. Then 90/10 in favor of the new model. Then cut over. The experiment tracks which variant every run used, so you can always query the data by variant.
 
 ---
 
-## Why not use an external eval platform?
+## Adding scoring later
 
-External platforms (Braintrust, LangSmith, Arize) score what you explicitly send them, at eval time, against whatever you remembered to capture. Inngest scores alongside the execution, where all the context already lives.
+When scoring ships, you can layer it onto this pattern to measure quality directly. A deferred scorer runs after the parent completes, evaluates the response with LLM-as-judge or waits for user feedback, and attaches a numeric score to the run. Insights then lets you compare average scores across variants, not just latency and success rates.
 
-The differences that matter:
+The pattern structure doesn't change. You add `defer()` calls after the response ships, and the scores accumulate alongside the operational data you're already collecting.
 
-- **No data pipeline.** Scores are attached to runs. You don't export traces to another system.
-- **Temporal scoring.** Wait for real user feedback days after the run. External platforms can't pause and resume a scorer based on your event stream.
-- **Durable scoring.** The scorer is an Inngest function with retries and step state. If the judge model rate-limits you, the scorer retries on its own.
-- **One codebase.** Your agent code, your experiment config, and your scoring logic live in the same repo. An agent reading your code sees the full picture.
+See [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring) for how this works.
 
 ---
 
@@ -310,6 +184,5 @@ The differences that matter:
 
 - [Run experiments in AI pipelines](/docs/features/inngest-functions/steps-workflows/running-experiments) for the experiments how-to
 - [`group.experiment()` reference](/docs/reference/typescript/v4/functions/group-experiment) for the full API
-- [Deferred Functions reference](/docs/reference/typescript/v4/functions/deferred-functions) for defer
-- [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring) for scoring
-- [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring) for temporal scoring with waitForEvent
+- [Insights](/docs/platform/monitor/insights) for querying run data
+- [Extended Traces](/docs/reference/typescript/v4/extended-traces) for capturing token counts and latency

--- a/shared/Patterns/_patterns/experiment-score-and-compare-ai-models.mdx
+++ b/shared/Patterns/_patterns/experiment-score-and-compare-ai-models.mdx
@@ -121,15 +121,6 @@ const handleTicket = inngest.createFunction(
 );
 ```
 
-Register both functions:
-
-```typescript
-serve({
-  client: inngest,
-  functions: [handleTicket, trackCosts],
-});
-```
-
 ---
 
 ## How the pieces work together

--- a/shared/Patterns/_patterns/experiment-score-and-compare-ai-models.mdx
+++ b/shared/Patterns/_patterns/experiment-score-and-compare-ai-models.mdx
@@ -1,0 +1,315 @@
+---
+title: Experiment, score, and compare AI models
+subtitle: Use experiments to split traffic between models, defer scoring to run after the response, and query results to pick the winner.
+pattern: durable
+tags: [Durability, AI, Architecture]
+---
+
+You shipped an AI feature with GPT-4o. A new model drops. Your team wants to know: is it better for our use case? Faster? Cheaper? More accurate? You need to compare them in production with real traffic, not a synthetic benchmark.
+
+This pattern composes three Inngest primitives to answer that question without building a separate eval pipeline:
+
+| Primitive | Role in this pattern |
+|---|---|
+| **`group.experiment()`** | Splits traffic between model variants |
+| **`defer()`** | Scores each variant's output after the response ships |
+| **Insights** | Aggregates scores so you can query which variant wins |
+
+The function serves a response to the user immediately. The scoring happens in the background. The data accumulates over days or weeks. You make a decision based on real production outcomes, not a one-off test.
+
+---
+
+## The full flow
+
+Here is the complete function. Each section is explained below.
+
+```typescript
+import { inngest } from "./client";
+import { createDefer } from "inngest/experimental";
+import { z } from "zod";
+
+// --- Deferred scorer ---
+// Runs after the parent completes. Evaluates the response
+// using a cheaper model as a judge.
+const qualityScorer = createDefer(inngest, {
+  id: "score-response-quality",
+  schema: z.object({
+    response: z.string(),
+    model: z.string(),
+    variant: z.string(),
+    ticketId: z.string(),
+  }),
+}, async ({ event, step }) => {
+  const evaluation = await step.run("llm-judge", async () => {
+    return await openai.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [
+        {
+          role: "system",
+          content: `Rate this support response on three dimensions.
+Return JSON: { "helpfulness": 1-5, "accuracy": 1-5, "tone": 1-5 }
+Be strict. A 3 means acceptable. A 5 means exceptional.`,
+        },
+        { role: "user", content: event.data.response },
+      ],
+    });
+  });
+
+  await step.run("persist-scores", async () => {
+    const scores = JSON.parse(evaluation.choices[0].message.content);
+
+    // Each score is attached to the parent run and tagged with the variant.
+    // This is what makes the data queryable in Insights.
+    await inngest.score({
+      name: "helpfulness",
+      value: scores.helpfulness / 5,
+      runId: event.data.ticketId,
+    });
+    await inngest.score({
+      name: "accuracy",
+      value: scores.accuracy / 5,
+      runId: event.data.ticketId,
+    });
+    await inngest.score({
+      name: "tone",
+      value: scores.tone / 5,
+      runId: event.data.ticketId,
+    });
+  });
+});
+
+// --- Cost tracker ---
+// Logs token usage per variant per customer.
+const costTracker = createDefer(inngest, {
+  id: "track-experiment-costs",
+  schema: z.object({
+    model: z.string(),
+    variant: z.string(),
+    promptTokens: z.number(),
+    completionTokens: z.number(),
+    customerId: z.string(),
+  }),
+}, async ({ event, step }) => {
+  await step.run("log-cost", async () => {
+    const rates = { "gpt-4o": 0.005, "claude-sonnet-4-20250514": 0.003 };
+    const costPer1k = rates[event.data.model] || 0.005;
+    const totalTokens = event.data.promptTokens + event.data.completionTokens;
+
+    await analytics.track("ai.experiment.cost", {
+      variant: event.data.variant,
+      model: event.data.model,
+      tokens: totalTokens,
+      cost_usd: (totalTokens / 1000) * costPer1k,
+      customer_id: event.data.customerId,
+    });
+  });
+});
+
+// --- Agent function ---
+const handleTicket = inngest.createFunction(
+  { id: "handle-support-ticket", triggers: { event: "support/ticket.created" } },
+  async ({ event, step, group, defer }) => {
+
+    // 1. EXPERIMENT: select a model variant
+    const { result: response, variant } = await group.experiment(
+      "model-comparison",
+      {
+        variants: {
+          gpt4o: async () => {
+            return await step.run("call-gpt4o", async () => {
+              return await openai.chat.completions.create({
+                model: "gpt-4o",
+                messages: [
+                  { role: "system", content: "You are a support agent. Be concise and helpful." },
+                  { role: "user", content: event.data.content },
+                ],
+              });
+            });
+          },
+          sonnet: async () => {
+            return await step.run("call-sonnet", async () => {
+              return await anthropic.messages.create({
+                model: "claude-sonnet-4-20250514",
+                max_tokens: 1024,
+                messages: [
+                  { role: "user", content: event.data.content },
+                ],
+              });
+            });
+          },
+        },
+        weights: { gpt4o: 50, sonnet: 50 },
+      }
+    );
+
+    // Normalize the response text across providers
+    const reply = variant === "gpt4o"
+      ? response.choices[0].message.content
+      : response.content[0].text;
+
+    // 2. SERVE: send the response to the customer
+    await step.run("send-reply", async () => {
+      await supportPlatform.reply(event.data.ticketId, reply);
+    });
+
+    // 3. DEFER: score and track costs after the parent completes
+    defer("score-quality", {
+      function: qualityScorer,
+      data: {
+        response: reply,
+        model: variant === "gpt4o" ? "gpt-4o" : "claude-sonnet-4-20250514",
+        variant,
+        ticketId: event.data.ticketId,
+      },
+    });
+
+    defer("track-costs", {
+      function: costTracker,
+      data: {
+        model: variant === "gpt4o" ? "gpt-4o" : "claude-sonnet-4-20250514",
+        variant,
+        promptTokens: variant === "gpt4o"
+          ? response.usage.prompt_tokens
+          : response.usage.input_tokens,
+        completionTokens: variant === "gpt4o"
+          ? response.usage.completion_tokens
+          : response.usage.output_tokens,
+        customerId: event.data.customerId,
+      },
+    });
+
+    return { ticketId: event.data.ticketId, variant, status: "resolved" };
+  }
+);
+```
+
+Register all functions:
+
+```typescript
+serve({
+  client: inngest,
+  functions: [handleTicket, qualityScorer, costTracker],
+});
+```
+
+---
+
+## How the pieces compose
+
+### Experiments select the variant
+
+`group.experiment()` picks one variant per run. The selection is memoized as a durable step. If the function retries, the same variant runs again. You control the traffic split with `weights`.
+
+Start with 50/50. Once you have enough data, shift to 90/10 to confirm the winner at scale before cutting over completely.
+
+### Defer handles the scoring
+
+The scorer runs as a completely separate function after the parent finalizes. The customer gets their response immediately. The LLM-as-judge evaluation happens on its own timeline with its own retries.
+
+This is important because scoring can be slow (the judge model needs to read and evaluate the response) and can fail (model rate limits, timeouts). Neither of those should affect the customer experience or the parent run's success status.
+
+### Scores land on the run
+
+`inngest.score()` attaches named numeric values to the parent run. Each score is tagged with the variant that produced it. Over time, you accumulate thousands of scored runs across both variants.
+
+### Insights reveals the winner
+
+Query your scores in Insights to compare variants:
+
+```sql
+SELECT
+  JSON_VALUE(metadata, '$.variant') AS variant,
+  AVG(scores.helpfulness) AS avg_helpfulness,
+  AVG(scores.accuracy) AS avg_accuracy,
+  AVG(scores.tone) AS avg_tone,
+  COUNT(*) AS runs
+FROM runs
+WHERE function_id = 'handle-support-ticket'
+  AND status = 'COMPLETED'
+GROUP BY variant
+```
+
+If Sonnet scores 4.2 on helpfulness and GPT-4o scores 3.8 across 500 runs each, you have a data-driven answer. Not a gut check. Not a benchmark on synthetic data. A measurement from your production traffic.
+
+---
+
+## Adapting this pattern
+
+**Compare prompts instead of models.** Replace the model variants with different system prompts on the same model. Everything else stays the same.
+
+```typescript
+variants: {
+  concise: async () => {
+    return await step.run("call-concise", async () => {
+      return await openai.chat.completions.create({
+        model: "gpt-4o",
+        messages: [
+          { role: "system", content: "You are a support agent. Answer in 2-3 sentences max." },
+          { role: "user", content: event.data.content },
+        ],
+      });
+    });
+  },
+  detailed: async () => {
+    return await step.run("call-detailed", async () => {
+      return await openai.chat.completions.create({
+        model: "gpt-4o",
+        messages: [
+          { role: "system", content: "You are a support agent. Be thorough. Include relevant links and next steps." },
+          { role: "user", content: event.data.content },
+        ],
+      });
+    });
+  },
+},
+```
+
+**Add temporal scoring.** Instead of scoring immediately with LLM-as-judge, use `step.waitForEvent()` inside the scorer to wait for a real user signal:
+
+```typescript
+const feedbackScorer = createDefer(inngest, {
+  id: "wait-for-feedback",
+  schema: z.object({ ticketId: z.string(), variant: z.string() }),
+}, async ({ event, step }) => {
+  const feedback = await step.waitForEvent("wait-for-thumbs", {
+    event: "support/feedback.received",
+    timeout: "7d",
+    if: `async.data.ticketId == '${event.data.ticketId}'`,
+  });
+
+  await step.run("record-feedback", async () => {
+    await inngest.score({
+      name: "user-satisfaction",
+      value: feedback ? (feedback.data.helpful ? 1 : 0) : 0.5,
+      runId: event.data.ticketId,
+    });
+  });
+});
+```
+
+Now your experiment measures what actually matters: did the user find the response helpful? The scorer waits up to 7 days for a thumbs-up/down event. This is something no external eval platform can do because they don't have access to your event stream.
+
+**Track cost alongside quality.** The cost tracker in the example above runs as a separate deferred function. When you query Insights, you can compare not just quality but cost-per-response across variants. A model that scores 5% better but costs 3x more might not be the right choice.
+
+---
+
+## Why not use an external eval platform?
+
+External platforms (Braintrust, LangSmith, Arize) score what you explicitly send them, at eval time, against whatever you remembered to capture. Inngest scores alongside the execution, where all the context already lives.
+
+The differences that matter:
+
+- **No data pipeline.** Scores are attached to runs. You don't export traces to another system.
+- **Temporal scoring.** Wait for real user feedback days after the run. External platforms can't pause and resume a scorer based on your event stream.
+- **Durable scoring.** The scorer is an Inngest function with retries and step state. If the judge model rate-limits you, the scorer retries on its own.
+- **One codebase.** Your agent code, your experiment config, and your scoring logic live in the same repo. An agent reading your code sees the full picture.
+
+---
+
+## Additional resources
+
+- [Run experiments in AI pipelines](/docs/features/inngest-functions/steps-workflows/running-experiments) for the experiments how-to
+- [`group.experiment()` reference](/docs/reference/typescript/v4/functions/group-experiment) for the full API
+- [Deferred Functions reference](/docs/reference/typescript/v4/functions/deferred-functions) for defer
+- [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring) for scoring
+- [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring) for temporal scoring with waitForEvent

--- a/shared/Patterns/_patterns/experiment-score-and-compare-ai-models.mdx
+++ b/shared/Patterns/_patterns/experiment-score-and-compare-ai-models.mdx
@@ -1,35 +1,62 @@
 ---
 title: Experiment and compare AI models
-subtitle: Use experiments to split traffic between models, then query Insights to compare latency, token usage, and success rates across variants.
+subtitle: Use experiments to split traffic between models, defer cost tracking to run after the response, and query Insights to pick the winner.
 pattern: durable
 tags: [Durability, AI, Architecture]
 ---
 
 You shipped an AI feature with GPT-4o. A new model drops. Your team wants to know: is it better for our use case? Faster? Cheaper? More accurate? You need to compare them in production with real traffic, not a synthetic benchmark.
 
-This pattern uses two Inngest primitives to answer that question:
-
-| Primitive | Role in this pattern |
-|---|---|
-| **`group.experiment()`** | Splits traffic between model variants |
-| **Insights** | Aggregates run data so you can query which variant performs better |
-
-The function serves a response to the user immediately. Run metadata (variant, model, token counts) is captured automatically. The data accumulates over days or weeks. You make a decision based on real production outcomes, not a one-off test.
+This pattern composes three AI primitives from the Inngest SDK to answer that question without building a separate eval pipeline. Experiments split traffic. Defer handles background work that the user should never wait for. Insights ties it all together so you can query the results.
 
 ---
 
 ## The full flow
 
-Here is the complete function. Each section is explained below.
+The agent function uses `group.experiment()` to select a model variant, serves the response, then defers a cost tracker that logs token usage per variant. Insights lets you compare latency, failure rate, and cost across variants.
 
 ```typescript
 import { inngest } from "./client";
+import { createDefer } from "inngest/experimental";
+import { z } from "zod";
 
+// --- Deferred cost tracker ---
+// Runs as an independent function after the parent completes.
+// Calculates per-variant, per-customer token cost.
+const trackCosts = createDefer(inngest, {
+  id: "track-experiment-costs",
+  schema: z.object({
+    model: z.string(),
+    variant: z.string(),
+    promptTokens: z.number(),
+    completionTokens: z.number(),
+    customerId: z.string(),
+  }),
+}, async ({ event, step }) => {
+  await step.run("log-cost", async () => {
+    const rates: Record<string, number> = {
+      "gpt-4o": 0.005,
+      "claude-sonnet-4-20250514": 0.003,
+    };
+    const costPer1k = rates[event.data.model] || 0.005;
+    const totalTokens = event.data.promptTokens + event.data.completionTokens;
+
+    await analytics.track("ai.experiment.cost", {
+      variant: event.data.variant,
+      model: event.data.model,
+      tokens: totalTokens,
+      cost_usd: (totalTokens / 1000) * costPer1k,
+      customer_id: event.data.customerId,
+    });
+  });
+});
+
+// --- Agent function ---
 const handleTicket = inngest.createFunction(
   { id: "handle-support-ticket", triggers: { event: "support/ticket.created" } },
-  async ({ event, step, group }) => {
+  async ({ event, step, group, defer }) => {
 
-    // 1. EXPERIMENT: select a model variant
+    // EXPERIMENT: select a model variant
     const { result: response, variant } = await group.experiment(
       "model-comparison",
       {
@@ -66,9 +93,27 @@ const handleTicket = inngest.createFunction(
       ? response.choices[0].message.content
       : response.content[0].text;
 
-    // 2. SERVE: send the response to the customer
+    // SERVE: send the response to the customer
     await step.run("send-reply", async () => {
       await supportPlatform.reply(event.data.ticketId, reply);
+    });
+
+    // DEFER: track costs in the background after the parent completes.
+    // This is an AI primitive — the cost tracker runs as its own function
+    // with independent retries. The customer never waits for analytics.
+    defer("track-costs", {
+      function: trackCosts,
+      data: {
+        model: variant === "gpt4o" ? "gpt-4o" : "claude-sonnet-4-20250514",
+        variant,
+        promptTokens: variant === "gpt4o"
+          ? response.usage.prompt_tokens
+          : response.usage.input_tokens,
+        completionTokens: variant === "gpt4o"
+          ? response.usage.completion_tokens
+          : response.usage.output_tokens,
+        customerId: event.data.customerId,
+      },
     });
 
     return { ticketId: event.data.ticketId, variant, status: "resolved" };
@@ -76,12 +121,12 @@ const handleTicket = inngest.createFunction(
 );
 ```
 
-Register the function:
+Register both functions:
 
 ```typescript
 serve({
   client: inngest,
-  functions: [handleTicket],
+  functions: [handleTicket, trackCosts],
 });
 ```
 
@@ -95,15 +140,17 @@ serve({
 
 Start with 50/50. Once you have enough data, shift to 90/10 to confirm the winner at scale before cutting over completely.
 
-Each variant wraps its model call in `step.run()`. This means the model call is independently retried if it fails, and the variant selection is preserved across retries.
+Each variant wraps its model call in `step.run()`. The model call is independently retried if it fails, and the variant selection is preserved across retries.
 
-### Run data captures the comparison
+### Defer handles cost tracking
 
-Every run records which variant was selected, how long each step took, and whether it succeeded. The variant name is returned in the function output. Extended traces capture token counts and latency per step if you have the middleware enabled.
+The cost tracker is an AI primitive built on `defer()`. It runs as a completely separate function after the parent finalizes. The customer gets their response immediately. The cost calculation and analytics write happen on their own timeline with their own retries.
+
+If your analytics platform is slow or down, the cost tracker retries independently. The parent run's success status is unaffected. The deferred function receives a typed payload with the model name, variant, and token counts, so it has everything it needs without querying external systems.
 
 ### Insights reveals the winner
 
-Query your run data in Insights to compare variants. For example, compare average step duration:
+Query your run data in Insights to compare variants:
 
 ```sql
 SELECT
@@ -117,25 +164,13 @@ WHERE function_id = 'handle-support-ticket'
 GROUP BY output.variant
 ```
 
-If Sonnet averages 800ms and GPT-4o averages 1200ms across 500 runs each with similar failure rates, you have a data-driven answer. Not a gut check. Not a benchmark on synthetic data. A measurement from your production traffic.
-
-With Extended Traces enabled, you can also compare token usage:
-
-```sql
-SELECT
-  output.variant AS variant,
-  AVG(steps.duration_ms) AS avg_model_call_ms,
-  COUNT(*) AS runs
-FROM runs
-WHERE function_id = 'handle-support-ticket'
-GROUP BY output.variant
-```
+If Sonnet averages 800ms and GPT-4o averages 1200ms across 500 runs each with similar failure rates, you have a data-driven answer. Combine this with the cost data from the deferred tracker to see which model gives you the best quality-to-cost ratio.
 
 ---
 
 ## Adapting this pattern
 
-**Compare prompts instead of models.** Replace the model variants with different system prompts on the same model. Everything else stays the same.
+**Compare prompts instead of models.** Replace the model variants with different system prompts on the same model. The cost tracker still works since it's tracking tokens regardless of the prompt.
 
 ```typescript
 variants: {
@@ -164,19 +199,11 @@ variants: {
 },
 ```
 
-**Compare RAG strategies.** One variant uses a simple vector search. The other adds a reranking step. Same model, different retrieval pipelines. Insights shows you whether the extra latency from reranking actually improves outcomes.
+**Compare RAG strategies.** One variant uses a simple vector search. The other adds a reranking step. Same model, different retrieval pipelines. Insights shows you whether the extra latency from reranking is worth it.
 
 **Gradually roll out a new model.** Start at `weights: { current: 95, new: 5 }`. Monitor for a week. If the new model performs well, shift to 50/50. Then 90/10 in favor of the new model. Then cut over. The experiment tracks which variant every run used, so you can always query the data by variant.
 
----
-
-## Adding scoring later
-
-When scoring ships, you can layer it onto this pattern to measure quality directly. A deferred scorer runs after the parent completes, evaluates the response with LLM-as-judge or waits for user feedback, and attaches a numeric score to the run. Insights then lets you compare average scores across variants, not just latency and success rates.
-
-The pattern structure doesn't change. You add `defer()` calls after the response ships, and the scores accumulate alongside the operational data you're already collecting.
-
-See [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring) for how this works.
+**Defer more than costs.** The cost tracker is one example. You can defer any background work per variant: send a Slack notification with the variant name, log to a custom dashboard, or write to a data warehouse for longer-term analysis. Each deferred function is an independent AI primitive with its own retries.
 
 ---
 
@@ -184,5 +211,6 @@ See [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/d
 
 - [Run experiments in AI pipelines](/docs/features/inngest-functions/steps-workflows/running-experiments) for the experiments how-to
 - [`group.experiment()` reference](/docs/reference/typescript/v4/functions/group-experiment) for the full API
+- [Deferred Functions reference](/docs/reference/typescript/v4/functions/deferred-functions) for defer
 - [Insights](/docs/platform/monitor/insights) for querying run data
 - [Extended Traces](/docs/reference/typescript/v4/extended-traces) for capturing token counts and latency

--- a/shared/Patterns/_patterns/experiment-score-and-compare-ai-models.mdx
+++ b/shared/Patterns/_patterns/experiment-score-and-compare-ai-models.mdx
@@ -5,24 +5,152 @@ pattern: durable
 tags: [Durability, AI, Architecture]
 ---
 
-You shipped an AI feature with GPT-4o. A new model drops. Your team wants to know: is it better for our use case? Faster? Cheaper? More accurate? You need to compare them in production with real traffic, not a synthetic benchmark.
+You shipped an AI feature with GPT-4o. It works. Customers are using it. Then a new model drops and your team wants to know: is it better for our use case? Faster? Cheaper? More accurate?
 
-This pattern composes three AI primitives from the Inngest SDK to answer that question without building a separate eval pipeline. Experiments split traffic. Defer handles background work that the user should never wait for. Insights ties it all together so you can query the results.
+You could spin up a notebook and test it against a handful of prompts. But that tells you how the model performs on your test data, not on your production traffic. The only way to know for real is to run both models side by side, on real requests, and measure what happens.
+
+This pattern walks through doing exactly that with three AI primitives from the Inngest SDK.
 
 ---
 
-## The full flow
+## Split the traffic
 
-The agent function uses `group.experiment()` to select a model variant, serves the response, then defers a cost tracker that logs token usage per variant. Insights lets you compare latency, failure rate, and cost across variants.
+The first thing you need is a way to send some requests to the new model without taking the old one offline. `group.experiment()` does this inside any Inngest function.
+
+```typescript
+const { result: response, variant } = await group.experiment(
+  "model-comparison",
+  {
+    variants: {
+      gpt4o: async () => {
+        return await step.run("call-gpt4o", async () => {
+          return await openai.chat.completions.create({
+            model: "gpt-4o",
+            messages: [
+              { role: "system", content: "You are a support agent. Be concise and helpful." },
+              { role: "user", content: event.data.content },
+            ],
+          });
+        });
+      },
+      sonnet: async () => {
+        return await step.run("call-sonnet", async () => {
+          return await anthropic.messages.create({
+            model: "claude-sonnet-4-20250514",
+            max_tokens: 1024,
+            messages: [
+              { role: "user", content: event.data.content },
+            ],
+          });
+        });
+      },
+    },
+    weights: { gpt4o: 50, sonnet: 50 },
+  }
+);
+```
+
+Each request gets one model. The selection is memoized as a durable step, so if the function retries, the same model runs again. The user never sees the experiment. They get a response from whichever model was selected.
+
+You control the split with `weights`. Start at 50/50 to collect data fast. Later, shift to 90/10 to confirm the winner at scale before cutting over.
+
+---
+
+## Track the cost
+
+The response is served. Now you want to know: what did that cost? Different models have different token pricing, and you're running both at the same time. You need per-variant cost data without slowing down the response.
+
+This is where `defer()` comes in. Define a deferred function that calculates the cost and logs it. It runs after the parent function completes, on its own timeline, with its own retries.
+
+```typescript
+import { createDefer } from "inngest/experimental";
+import { z } from "zod";
+
+const trackCosts = createDefer(inngest, {
+  id: "track-experiment-costs",
+  schema: z.object({
+    model: z.string(),
+    variant: z.string(),
+    promptTokens: z.number(),
+    completionTokens: z.number(),
+    customerId: z.string(),
+  }),
+}, async ({ event, step }) => {
+  await step.run("log-cost", async () => {
+    const rates: Record<string, number> = {
+      "gpt-4o": 0.005,
+      "claude-sonnet-4-20250514": 0.003,
+    };
+    const costPer1k = rates[event.data.model] || 0.005;
+    const totalTokens = event.data.promptTokens + event.data.completionTokens;
+
+    await analytics.track("ai.experiment.cost", {
+      variant: event.data.variant,
+      model: event.data.model,
+      tokens: totalTokens,
+      cost_usd: (totalTokens / 1000) * costPer1k,
+      customer_id: event.data.customerId,
+    });
+  });
+});
+```
+
+Call `defer()` at the end of your agent function, after the response ships:
+
+```typescript
+defer("track-costs", {
+  function: trackCosts,
+  data: {
+    model: variant === "gpt4o" ? "gpt-4o" : "claude-sonnet-4-20250514",
+    variant,
+    promptTokens: variant === "gpt4o"
+      ? response.usage.prompt_tokens
+      : response.usage.input_tokens,
+    completionTokens: variant === "gpt4o"
+      ? response.usage.completion_tokens
+      : response.usage.output_tokens,
+    customerId: event.data.customerId,
+  },
+});
+```
+
+The customer gets their response immediately. The cost tracker fires after the parent run finalizes. If your analytics platform is down, the tracker retries on its own. The parent run's success status is unaffected.
+
+---
+
+## Pick the winner
+
+You've been running the experiment for a week. Both models have handled hundreds of real requests. Now you need the answer.
+
+Open Insights and query your run data:
+
+```sql
+SELECT
+  output.variant AS variant,
+  AVG(duration_ms) AS avg_duration_ms,
+  COUNT(*) AS total_runs,
+  SUM(CASE WHEN status = 'FAILED' THEN 1 ELSE 0 END) AS failures
+FROM runs
+WHERE function_id = 'handle-support-ticket'
+  AND status IN ('COMPLETED', 'FAILED')
+GROUP BY output.variant
+```
+
+Sonnet averages 800ms. GPT-4o averages 1200ms. Failure rates are similar. Combine that with the cost data from your deferred tracker: Sonnet is 40% cheaper per response at the current token rates.
+
+That's not a benchmark result. That's a measurement from your production traffic, on your data, with your users. You shift the weights to `{ gpt4o: 10, sonnet: 90 }`, watch it for another few days, and then cut over.
+
+---
+
+## The complete function
+
+Here's everything together:
 
 ```typescript
 import { inngest } from "./client";
 import { createDefer } from "inngest/experimental";
 import { z } from "zod";
 
-// --- Deferred cost tracker ---
-// Runs as an independent function after the parent completes.
-// Calculates per-variant, per-customer token cost.
 const trackCosts = createDefer(inngest, {
   id: "track-experiment-costs",
   schema: z.object({
@@ -51,12 +179,10 @@ const trackCosts = createDefer(inngest, {
   });
 });
 
-// --- Agent function ---
 const handleTicket = inngest.createFunction(
   { id: "handle-support-ticket", triggers: { event: "support/ticket.created" } },
   async ({ event, step, group, defer }) => {
 
-    // EXPERIMENT: select a model variant
     const { result: response, variant } = await group.experiment(
       "model-comparison",
       {
@@ -88,19 +214,14 @@ const handleTicket = inngest.createFunction(
       }
     );
 
-    // Normalize the response text across providers
     const reply = variant === "gpt4o"
       ? response.choices[0].message.content
       : response.content[0].text;
 
-    // SERVE: send the response to the customer
     await step.run("send-reply", async () => {
       await supportPlatform.reply(event.data.ticketId, reply);
     });
 
-    // DEFER: track costs in the background after the parent completes.
-    // This is an AI primitive — the cost tracker runs as its own function
-    // with independent retries. The customer never waits for analytics.
     defer("track-costs", {
       function: trackCosts,
       data: {
@@ -123,45 +244,9 @@ const handleTicket = inngest.createFunction(
 
 ---
 
-## How the pieces work together
+## Other things you can compare
 
-### Experiments select the variant
-
-`group.experiment()` picks one variant per run. The selection is memoized as a durable step. If the function retries, the same variant runs again. You control the traffic split with `weights`.
-
-Start with 50/50. Once you have enough data, shift to 90/10 to confirm the winner at scale before cutting over completely.
-
-Each variant wraps its model call in `step.run()`. The model call is independently retried if it fails, and the variant selection is preserved across retries.
-
-### Defer handles cost tracking
-
-The cost tracker is an AI primitive built on `defer()`. It runs as a completely separate function after the parent finalizes. The customer gets their response immediately. The cost calculation and analytics write happen on their own timeline with their own retries.
-
-If your analytics platform is slow or down, the cost tracker retries independently. The parent run's success status is unaffected. The deferred function receives a typed payload with the model name, variant, and token counts, so it has everything it needs without querying external systems.
-
-### Insights reveals the winner
-
-Query your run data in Insights to compare variants:
-
-```sql
-SELECT
-  output.variant AS variant,
-  AVG(duration_ms) AS avg_duration_ms,
-  COUNT(*) AS total_runs,
-  SUM(CASE WHEN status = 'FAILED' THEN 1 ELSE 0 END) AS failures
-FROM runs
-WHERE function_id = 'handle-support-ticket'
-  AND status IN ('COMPLETED', 'FAILED')
-GROUP BY output.variant
-```
-
-If Sonnet averages 800ms and GPT-4o averages 1200ms across 500 runs each with similar failure rates, you have a data-driven answer. Combine this with the cost data from the deferred tracker to see which model gives you the best quality-to-cost ratio.
-
----
-
-## Adapting this pattern
-
-**Compare prompts instead of models.** Replace the model variants with different system prompts on the same model. The cost tracker still works since it's tracking tokens regardless of the prompt.
+**Prompts.** Same model, different system prompts. One concise, one thorough. Which one do your users prefer? Which one resolves more tickets without follow-ups?
 
 ```typescript
 variants: {
@@ -190,11 +275,11 @@ variants: {
 },
 ```
 
-**Compare RAG strategies.** One variant uses a simple vector search. The other adds a reranking step. Same model, different retrieval pipelines. Insights shows you whether the extra latency from reranking is worth it.
+**RAG strategies.** One variant does a simple vector search. The other reranks the results before passing them to the model. Same model, different retrieval pipeline. Insights tells you whether the extra latency from reranking is worth it.
 
-**Gradually roll out a new model.** Start at `weights: { current: 95, new: 5 }`. Monitor for a week. If the new model performs well, shift to 50/50. Then 90/10 in favor of the new model. Then cut over. The experiment tracks which variant every run used, so you can always query the data by variant.
+**Rollout strategy.** You don't have to go 50/50. Start at `{ current: 95, new: 5 }` and monitor for a week. Shift to 70/30. Then 50/50. Then 90/10 in favor of the new model. Then cut over. Every run records which variant it used, so you always have the data to justify the next shift.
 
-**Defer more than costs.** The cost tracker is one example. You can defer any background work per variant: send a Slack notification with the variant name, log to a custom dashboard, or write to a data warehouse for longer-term analysis. Each deferred function is an independent AI primitive with its own retries.
+**Background work.** The cost tracker is one deferred function. You can defer anything: a Slack notification tagged with the variant, a write to your data warehouse, a webhook to an external dashboard. Each one runs independently after the response ships.
 
 ---
 
@@ -204,4 +289,3 @@ variants: {
 - [`group.experiment()` reference](/docs/reference/typescript/v4/functions/group-experiment) for the full API
 - [Deferred Functions reference](/docs/reference/typescript/v4/functions/deferred-functions) for defer
 - [Insights](/docs/platform/monitor/insights) for querying run data
-- [Extended Traces](/docs/reference/typescript/v4/extended-traces) for capturing token counts and latency

--- a/shared/Patterns/patternsData.ts
+++ b/shared/Patterns/patternsData.ts
@@ -145,6 +145,13 @@ export const PATTERNS: PatternIndexItem[] = [
       "Break multi-step AI pipelines and complex business logic into durable, independently retried steps.",
   },
   {
+    category: "durable",
+    slug: "experiment-score-and-compare-ai-models",
+    title: "Experiment, score, and compare AI models",
+    subtitle:
+      "Use experiments to split traffic between models, defer scoring to run after the response, and query results to pick the winner.",
+  },
+  {
     category: "flow",
     slug: "flash-sales-and-bursty-workflows",
     title: "Flash sales and bursty workflows",


### PR DESCRIPTION
## Summary

Comprehensive AI experimentation pattern in the style of the flash-sales-and-bursty-workflows pattern. Shows three AI primitives from the Inngest SDK composing together in one flow:

- **`group.experiment()`** splits traffic between GPT-4o and Claude Sonnet (50/50)
- **`defer()`** kicks off a cost tracker that calculates per-variant, per-customer token spend after the response ships
- **Insights** aggregates run data so you can query latency, failure rate, and cost across variants

The function serves a response immediately. The cost tracking runs in the background as a deferred function with independent retries. Data accumulates over days or weeks. You make a decision based on real production traffic.

Includes the full function (agent + deferred cost tracker), an explanation of how the pieces compose, and four adaptation sections: compare prompts instead of models, compare RAG strategies, gradual model rollout, and deferring more than just costs.

No scoring API dependency. Everything in this pattern ships in the next two weeks (experiments + defer + insights).

Diataxis: Explanation (pattern). Matches the structure and comprehensiveness of the flash sales pattern.