### PR TITLE
Platform page improvements and AI page layout updates

### DIFF
--- a/components/v1/sections/AI/GoDeeper.tsx
+++ b/components/v1/sections/AI/GoDeeper.tsx
@@ -69,12 +69,12 @@ const BANNER_BLUE = "#2f33cb";
 export default function GoDeeper() {
   return (
     <Section aria-label="Go deeper — resources" className="relative">
-      <div className="flex max-w-[936px] flex-col gap-12">
+      <div className="flex flex-col gap-8">
         <motion.div {...reveals.heading}>
           <Banner />
         </motion.div>
 
-        <div className="grid grid-cols-1 gap-x-12 gap-y-12 sm:grid-cols-2">
+        <div className="grid grid-cols-2 gap-x-8 gap-y-6 lg:grid-cols-4">
           {RESOURCES.map((r, i) => (
             <motion.div key={r.id} {...reveals.item(i)}>
               <ResourceCard resource={r} />
@@ -88,7 +88,7 @@ export default function GoDeeper() {
 
 function Banner() {
   return (
-    <div className="relative isolate aspect-[2/1] w-full overflow-hidden">
+    <div className="relative isolate aspect-[5/1] w-full overflow-hidden">
       {/* Banner asset bleeds to edges. `?v=3` busts Vercel's edge
           cache so the new asset replaces the old one without a
           same-filename stale-cache miss. */}
@@ -144,7 +144,7 @@ function ResourceCard({ resource }: { resource: Resource }) {
       onPointerMove={onCursorTiltMove}
       onPointerLeave={onCursorTiltLeave}
       style={CURSOR_TILT_SEED}
-      className="group/card relative isolate flex flex-col items-start gap-[26px] rounded-md border border-transparent p-5 motion-safe:transition-[transform,border-color,box-shadow] motion-safe:duration-[500ms] motion-safe:ease-v1-in hover:[--lift:-4px] hover:border-v1-frost/[0.18] hover:shadow-[0_28px_60px_-32px_rgba(0,0,0,0.55)] focus:outline-none focus-visible:ring-2 focus-visible:ring-v1-frost/30"
+      className="group/card relative isolate flex h-full flex-col items-start justify-between gap-8 rounded-md border border-transparent p-4 motion-safe:transition-[transform,border-color,box-shadow] motion-safe:duration-[500ms] motion-safe:ease-v1-in hover:[--lift:-4px] hover:border-v1-frost/[0.18] hover:shadow-[0_28px_60px_-32px_rgba(0,0,0,0.55)] focus:outline-none focus-visible:ring-2 focus-visible:ring-v1-frost/30"
     >
       {/* Cursor sheen — frost wash that tracks the pointer. */}
       <span

--- a/components/v1/sections/AI/Lifecycle.tsx
+++ b/components/v1/sections/AI/Lifecycle.tsx
@@ -402,7 +402,8 @@ function TabBody({ tab }: { tab: Tab }) {
       aria-labelledby={`lifecycle-tab-${tab.id}`}
       className="grid grid-cols-1 gap-12 lg:grid-cols-3 lg:items-center lg:gap-x-12"
     >
-      <div className="flex flex-col items-start gap-8 lg:gap-[72px]">
+      <TabImage tab={tab} />
+      <div className="flex flex-col items-start gap-8 lg:order-first lg:gap-[72px]">
         <h3 className="whitespace-pre-line text-v1-heading-card text-v1-frost">
           {tab.title}
         </h3>
@@ -411,7 +412,6 @@ function TabBody({ tab }: { tab: Tab }) {
           {tab.ctaLabel}
         </ButtonLink>
       </div>
-      <TabImage tab={tab} />
     </div>
   );
 }

--- a/components/v1/sections/AI/UseCases.tsx
+++ b/components/v1/sections/AI/UseCases.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { motion } from "motion/react";
 import { reveals } from "@/utils/v1/reveals";
 import { springs } from "@/utils/v1/springs";
@@ -124,16 +125,16 @@ export default function UseCases({
         {/* Grid + featured card keep their own (tighter) rhythm; only the
             header → content gap is the standard v1-stack (48), set above. */}
         <div className="flex flex-col gap-[29px] lg:gap-[44px]">
+          {/* No SCROLL_REVEAL_STYLE wrapper here — its translate3d
+              breaks position: fixed for the AdvanceClick cursor disk
+              inside. Entrance reveal is owned by the grid below. */}
+          <FeaturedCard useCase={current} onPrev={prev} onNext={next} />
+
           <Grid
             activeId={current.id}
             onSelect={handleSelect}
             cycling={cycling}
           />
-
-          {/* No SCROLL_REVEAL_STYLE wrapper here — its translate3d
-              breaks position: fixed for the AdvanceClick cursor disk
-              inside. Entrance reveal is owned by the grid above. */}
-          <FeaturedCard useCase={current} onPrev={prev} onNext={next} />
         </div>
       </div>
     </Section>
@@ -150,6 +151,9 @@ function FeaturedCard({
   onNext: () => void;
 }) {
   const currentIndex = USE_CASES.findIndex((u) => u.id === useCase.id);
+  const prevIndexRef = useRef(currentIndex);
+  const isWrap = Math.abs(currentIndex - prevIndexRef.current) > 1;
+  useEffect(() => { prevIndexRef.current = currentIndex; }, [currentIndex]);
   const prevIndex = (currentIndex - 1 + USE_CASES.length) % USE_CASES.length;
   const nextIndex = (currentIndex + 1) % USE_CASES.length;
   return (
@@ -202,7 +206,7 @@ function FeaturedCard({
                   className="absolute inset-0 flex items-center justify-center px-20 pb-[60px] pt-[60px] [&>*]:flex [&>*]:max-h-full [&>*]:max-w-full [&>*]:items-center [&>*]:justify-center"
                   initial={false}
                   animate={{ x: `${offset * 100}%` }}
-                  transition={springs.glide}
+                  transition={isWrap ? { duration: 0 } : springs.glide}
                   style={{
                     pointerEvents: isCurrent ? "auto" : "none",
                     willChange: "transform",

--- a/components/v1/sections/BackgroundJobs/HowItWorks.tsx
+++ b/components/v1/sections/BackgroundJobs/HowItWorks.tsx
@@ -58,7 +58,13 @@ export default function HowItWorks() {
           <div className="lg:flex-1">
             <h2
               id="bg-jobs-how-heading"
-              className={cn(V1_SECTION_TITLE, "relative z-10 lg:sticky lg:top-[22vh]")}
+              // Opaque background so the bottom-pinned "That's it." tucks
+              // behind the sticky headline as it scrolls up, instead of
+              // overlapping it. `pb-2` clears the descenders.
+              className={cn(
+                V1_SECTION_TITLE,
+                "relative z-10 bg-v1-canvasBase pb-2 lg:sticky lg:top-[22vh]",
+              )}
             >
               {["Wrap your code.", "Send an event."].map((line, i) => (
                 <motion.span key={i} {...reveals.item(i)} className="block">

--- a/components/v1/sections/BackgroundJobs/Reliability.tsx
+++ b/components/v1/sections/BackgroundJobs/Reliability.tsx
@@ -265,14 +265,14 @@ export default function Reliability() {
                     )}
                   />
                 </span>
-                <span className="flex flex-1 flex-col gap-2">
-                  <span className="text-v1-heading-sm text-v1-frost">
+                <span className="flex flex-1 flex-col gap-1.5">
+                  <span className="font-v1Heading text-[16px] leading-[1.25] tracking-[-0.01em] text-v1-frost">
                     {feature.title}
                   </span>
                   <span
                     className={cn(
-                      "text-v1-body-sm motion-safe:transition-colors motion-safe:duration-300",
-                      isActive ? "text-v1-frost" : "text-v1-frost/60 group-hover/row:text-v1-frost"
+                      "font-v1Body text-[13px] leading-[1.55] motion-safe:transition-colors motion-safe:duration-300",
+                      isActive ? "text-v1-frost" : "text-v1-frost/50 group-hover/row:text-v1-frost/80"
                     )}
                   >
                     {feature.body}

--- a/components/v1/sections/CompareTemporal/DocsCtaPair.tsx
+++ b/components/v1/sections/CompareTemporal/DocsCtaPair.tsx
@@ -7,7 +7,7 @@ import ButtonLink from "@/components/v1/ButtonLink";
  */
 export default function DocsCtaPair() {
   return (
-    <div className="flex flex-shrink-0 flex-col gap-4 sm:flex-row sm:flex-wrap sm:gap-6">
+    <div className="flex flex-shrink-0 flex-col gap-3 sm:flex-row sm:flex-wrap sm:gap-6">
       <ButtonLink
         href="/docs/quick-start?ref=compare-to-temporal"
         variant="primary"

--- a/components/v1/sections/DurableExecution/Observability.tsx
+++ b/components/v1/sections/DurableExecution/Observability.tsx
@@ -4,10 +4,8 @@ import { useState } from "react";
 import { motion } from "motion/react";
 import ButtonLink from "@/components/v1/ButtonLink";
 import GradientFrame from "@/components/v1/sections/shared/GradientFrame";
-import ReelDirectoryRow from "@/components/v1/sections/shared/ReelDirectoryRow";
 import Section from "@/components/v1/sections/shared/Section";
 import SectionHeader from "@/components/v1/sections/shared/SectionHeader";
-import { cn } from "@/utils/v1/cn";
 import { reveals } from "@/utils/v1/reveals";
 
 // "Observability by default." Bordered card with a
@@ -46,11 +44,9 @@ const FEATURES: Feature[] = [
 ];
 
 export default function Observability() {
-  // The five features double as reel-directory selectors: hover spotlight
-  // + salmon dot, with a persistent active row. There's no panel to swap
-  // here, so selection is purely a highlight — "Waterfall Traces" (the
-  // featured item) is active by default.
-  const [selected, setSelected] = useState(0);
+  // The five features are a static, non-interactive list — every row
+  // reads "active" (white title), with a uniform steel bullet and no
+  // selection/hover/click affordance.
   return (
     <Section
       aria-labelledby="de-observability-heading"
@@ -96,38 +92,20 @@ export default function Observability() {
             aligned to the frame's content edge while the hover/active
             background bleeds outward. */}
         <div className="-mx-[22px] mt-20 grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2 lg:grid-cols-3">
-          {FEATURES.map((f, i) => {
-            const isActive = i === selected;
-            return (
-              <motion.div key={f.title} {...reveals.item(i)} className="h-full">
-                <ReelDirectoryRow
-                  isActive={isActive}
-                  onSelect={() => setSelected(i)}
-                >
-                  <span className="flex flex-1 flex-col gap-2">
-                    <span
-                      className={cn(
-                        "flex min-h-10 items-center text-v1-heading-sm motion-safe:transition-colors",
-                        isActive
-                          ? "text-v1-frost"
-                          : "text-v1-frost/70 group-hover/row:text-v1-frost",
-                      )}
-                    >
-                      {f.title}
-                    </span>
-                    <span
-                      className={cn(
-                        "whitespace-pre-line text-v1-body-sm motion-safe:transition-colors",
-                        isActive ? "text-v1-frost" : "text-v1-frost/80",
-                      )}
-                    >
-                      {f.body}
-                    </span>
-                  </span>
-                </ReelDirectoryRow>
-              </motion.div>
-            );
-          })}
+          {FEATURES.map((f, i) => (
+            <motion.div key={f.title} {...reveals.item(i)} className="h-full">
+              {/* Static row — no button/hover/selection and no bullet;
+                  white title so every feature reads "active". */}
+              <div className="flex h-full flex-col gap-2 px-[22px] py-[18px]">
+                <span className="flex min-h-10 items-center text-v1-heading-sm text-v1-frost">
+                  {f.title}
+                </span>
+                <span className="whitespace-pre-line text-v1-body-sm text-v1-frost/80">
+                  {f.body}
+                </span>
+              </div>
+            </motion.div>
+          ))}
         </div>
       </GradientFrame>
     </Section>

--- a/components/v1/sections/QueuesFlowControl/Primitives.tsx
+++ b/components/v1/sections/QueuesFlowControl/Primitives.tsx
@@ -2,7 +2,6 @@
 
 import { motion } from "motion/react";
 import { reveals } from "@/utils/v1/reveals";
-import { springs } from "@/utils/v1/springs";
 import { cn } from "@/utils/v1/cn";
 import { useReelCarousel } from "@/components/v1/sections/shared/useReelCarousel";
 import { AdvanceClick } from "@/components/v1/sections/shared/AdvanceClick";
@@ -102,11 +101,11 @@ export default function Primitives() {
         bodyClassName="max-w-[554px] text-v1-body-sm"
       />
 
-      {/* Directory grid acts as tabs (matches the AI page order:
-          grid above, featured illustration below). */}
-      <Grid activeId={current.id} onSelect={handleSelect} cycling={cycling} />
-
+      {/* Graphic sits directly under the title/subtitle; the directory
+          grid (tabs) follows below it. */}
       <FeaturedCard primitive={current} onPrev={prev} onNext={next} />
+
+      <Grid activeId={current.id} onSelect={handleSelect} cycling={cycling} />
     </Section>
   );
 }
@@ -125,19 +124,6 @@ function FeaturedCard({
   const nextIndex = (currentIndex + 1) % PRIMITIVES.length;
   return (
     <>
-      {/* Mobile nav row — sits ABOVE the card so the label reads as a
-          header for the illustration that follows. Replaces the
-          desktop side-pinned arrow pills, which would overlap the
-          illustration on narrow viewports. */}
-      <MobileReelNav
-        activeTitle={primitive.title}
-        prevTitle={PRIMITIVES[prevIndex].title}
-        nextTitle={PRIMITIVES[nextIndex].title}
-        itemNoun="primitive"
-        onPrev={onPrev}
-        onNext={onNext}
-        className="mb-4 mt-3 flex items-center justify-between gap-3 lg:hidden"
-      />
       <AdvanceClick
         onAdvance={onNext}
         onPrev={onPrev}
@@ -155,11 +141,11 @@ function FeaturedCard({
             <CardContent primitive={primitive} />
           </div>
 
-          {/* Lg+: all cards mounted, slide horizontally on activeId
-              change via translateX (offset * 100%) on springs.glide. */}
+          {/* Lg+: all cards mounted, stacked in place. The active card
+              crossfades in while the others fade out — the graphic stays
+              centered and never slides/moves position on change. */}
           <div className="relative hidden w-full items-center justify-center lg:flex lg:min-h-[535px] lg:px-20 lg:pb-20 lg:pt-[60px]">
-            {PRIMITIVES.map((p, i) => {
-              const offset = i - currentIndex;
+            {PRIMITIVES.map((p) => {
               const isCurrent = p.id === primitive.id;
               return (
                 <motion.div
@@ -167,11 +153,11 @@ function FeaturedCard({
                   aria-hidden={!isCurrent}
                   className="absolute inset-0 flex items-center justify-center px-20 pb-[60px] pt-[60px] [&>*]:flex [&>*]:max-h-full [&>*]:max-w-full [&>*]:items-center [&>*]:justify-center"
                   initial={false}
-                  animate={{ x: `${offset * 100}%` }}
-                  transition={springs.glide}
+                  animate={{ opacity: isCurrent ? 1 : 0 }}
+                  transition={{ duration: 0.35, ease: "easeInOut" }}
                   style={{
                     pointerEvents: isCurrent ? "auto" : "none",
-                    willChange: "transform",
+                    willChange: "opacity",
                   }}
                 >
                   <CardContent primitive={p} />
@@ -194,6 +180,20 @@ function FeaturedCard({
           />
         </GradientFrame>
       </AdvanceClick>
+
+      {/* Mobile nav row — sits BELOW the card (the graphic stays pinned
+          directly under the subtitle so it doesn't shift as you slide).
+          Replaces the desktop side-pinned arrow pills, which would
+          overlap the illustration on narrow viewports. */}
+      <MobileReelNav
+        activeTitle={primitive.title}
+        prevTitle={PRIMITIVES[prevIndex].title}
+        nextTitle={PRIMITIVES[nextIndex].title}
+        itemNoun="primitive"
+        onPrev={onPrev}
+        onNext={onNext}
+        className="mt-4 flex items-center justify-between gap-3 lg:hidden"
+      />
     </>
   );
 }

--- a/components/v1/sections/QueuesFlowControl/ProblemsGrid.tsx
+++ b/components/v1/sections/QueuesFlowControl/ProblemsGrid.tsx
@@ -13,11 +13,10 @@ import SectionHeader from "@/components/v1/sections/shared/SectionHeader";
 // INNGEST" / problem label for the "WITH INNGEST" / solution label. The
 // icons are stipple-art SVGs.
 //
-// Touch devices have no hover, so on mobile each card self-activates
-// while it sits in the central band of the viewport as the user
-// scrolls (mirrors the desktop hover via `data-active` →
-// `group-data-[active=true]:`). Gated below `lg` so desktop keeps
-// pure pointer-hover.
+// Desktop (>= lg): inversion is driven purely by pointer hover.
+// Mobile + tablet (< lg, no reliable hover): the cards auto-cycle — one
+// card is "active" (inverted) at a time, advancing every 2s — so touch
+// users still see the "WITH INNGEST" solution states.
 
 interface Problem {
   id: string;
@@ -96,98 +95,53 @@ export default function ProblemsGrid({
   intro?: React.ReactNode;
   labelledById?: string;
 } = {}) {
-  // Mobile (no hover): the card row nearest the viewport centre is
-  // "active" as the user scrolls. In the 1-col layout that's a single
-  // card; in the 2-col (sm) layout it's the whole side-by-side row, so
-  // a pair never lights unevenly. Disabled at lg+ where pointer hover
-  // drives the inversion instead.
+  // Desktop (>= lg) is hover-only. Below lg the cards auto-cycle — one
+  // active at a time, advancing every 2s — so touch users still see the
+  // "WITH INNGEST" solution states. The cycle only runs while the
+  // section is on screen and the viewport is below lg; otherwise no card
+  // is forced active (activeIndex = null) and hover takes over.
   const sectionRef = useRef<HTMLElement | null>(null);
-  const liRefs = useRef<(HTMLLIElement | null)[]>([]);
-  const [activeIndices, setActiveIndices] = useState<readonly number[]>([]);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
 
   useEffect(() => {
     const section = sectionRef.current;
-    if (!section) return;
-
     const mq = window.matchMedia(`(max-width: ${BREAKPOINTS.lg - 0.02}px)`);
-    let raf = 0;
-    let listening = false;
-    let visible = false;
+    let timer: ReturnType<typeof setInterval> | undefined;
+    let visible = true;
 
-    // rAF-throttled measure of which card row sits nearest the
-    // viewport centre. getBoundingClientRect forces layout, so this
-    // only ever runs while the section itself is on screen (gated by
-    // the IntersectionObserver below) and only below lg.
-    const compute = () => {
-      raf = 0;
-      const viewportCenter = window.innerHeight / 2;
-      // First pass: each card's vertical centre + distance to viewport
-      // centre; track the nearest as the active row's anchor.
-      const centers = liRefs.current.map((el) =>
-        el ? el.getBoundingClientRect().top + el.offsetHeight / 2 : NaN,
-      );
-      let anchor = NaN;
-      let bestDist = Infinity;
-      centers.forEach((c) => {
-        if (Number.isNaN(c)) return;
-        const dist = Math.abs(c - viewportCenter);
-        if (dist < bestDist) {
-          bestDist = dist;
-          anchor = c;
-        }
-      });
-      // Second pass: light every card sharing the anchor's row (same
-      // vertical centre within a 2px tolerance) — one card in 1-col,
-      // the side-by-side pair in 2-col.
-      const next = Number.isNaN(anchor)
-        ? []
-        : centers.flatMap((c, i) => (Math.abs(c - anchor) < 2 ? [i] : []));
-      setActiveIndices((prev) =>
-        prev.length === next.length && prev.every((v, i) => v === next[i])
-          ? prev
-          : next,
-      );
+    const start = () => {
+      if (timer !== undefined) return;
+      setActiveIndex(0);
+      timer = setInterval(() => {
+        setActiveIndex((i) => ((i ?? -1) + 1) % PROBLEMS.length);
+      }, 2000);
     };
-    const onScroll = () => {
-      if (!raf) raf = requestAnimationFrame(compute);
+    const stop = () => {
+      if (timer !== undefined) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+      setActiveIndex(null);
     };
+    const update = () => (mq.matches && visible ? start() : stop());
 
-    const startListening = () => {
-      if (listening) return;
-      listening = true;
-      window.addEventListener("scroll", onScroll, { passive: true });
-      window.addEventListener("resize", onScroll);
-      compute();
-    };
-    const stopListening = () => {
-      if (!listening) return;
-      listening = false;
-      window.removeEventListener("scroll", onScroll);
-      window.removeEventListener("resize", onScroll);
-      if (raf) cancelAnimationFrame(raf);
-      raf = 0;
-      setActiveIndices([]);
-    };
-    const update = () =>
-      mq.matches && visible ? startListening() : stopListening();
-
-    // Cheap gate: only track scroll position while the section is in
-    // (or near) the viewport. The 100px margin starts tracking just
-    // before it scrolls in so the first card is already lit on entry.
-    const io = new IntersectionObserver(
-      ([entry]) => {
-        visible = entry.isIntersecting;
-        update();
-      },
-      { rootMargin: "100px 0px 100px 0px" },
-    );
-    io.observe(section);
+    const io = section
+      ? new IntersectionObserver(
+          ([entry]) => {
+            visible = entry.isIntersecting;
+            update();
+          },
+          { rootMargin: "0px 0px -10% 0px" },
+        )
+      : null;
+    if (section && io) io.observe(section);
     mq.addEventListener("change", update);
+    update();
 
     return () => {
       mq.removeEventListener("change", update);
-      io.disconnect();
-      stopListening();
+      io?.disconnect();
+      if (timer !== undefined) clearInterval(timer);
     };
   }, []);
 
@@ -218,10 +172,7 @@ export default function ProblemsGrid({
               key={p.id}
               problem={p}
               index={i}
-              active={activeIndices.includes(i)}
-              innerRef={(el) => {
-                liRefs.current[i] = el;
-              }}
+              active={activeIndex === i}
             />
           ))}
         </ul>
@@ -230,33 +181,27 @@ export default function ProblemsGrid({
 }
 
 /**
- * One problem card. `group` drives the desktop hover state; on mobile
- * the same inversion is driven by `data-active`, which the parent sets
- * on whichever card sits nearest the viewport centre as the user
- * scrolls. Every `group-hover:` style below is mirrored by a
- * `group-data-[active=true]:` twin so the two triggers stay in lockstep.
+ * One problem card. `group` drives the desktop hover state; below lg the
+ * same inversion is driven by `data-active`, which the parent sets on the
+ * single card in the 2s auto-cycle. Every `group-hover:` style is
+ * mirrored by a `group-data-[active=true]:` twin so both triggers match.
  */
 function ProblemCard({
   problem: p,
   index: i,
   active,
-  innerRef,
 }: {
   problem: Problem;
   index: number;
-  active: boolean;
-  innerRef: (el: HTMLLIElement | null) => void;
+  active?: boolean;
 }) {
   return (
     <motion.li
-      ref={innerRef}
       {...reveals.item(i)}
       data-active={active ? "true" : undefined}
-      // `group` drives the hover state below. On hover (desktop) or
-      // when active (mobile scroll), the caption block inverts (white
-      // bg, black text) while the icon stays in place but brightens —
-      // boosting the white-stipple's effective contrast against the
-      // unchanged dark backdrop.
+      // `group` drives the hover state below. On hover (desktop) or when
+      // active (mobile/tablet auto-cycle), the caption block inverts
+      // (white bg, black text) while the icon stays in place but brightens.
       className="group relative flex list-none flex-col items-stretch gap-10 sm:gap-[60px] lg:gap-[83px]"
     >
       {/* The icon and both label states below are decorative /

--- a/components/v1/sections/ScheduledJobs/Customers.tsx
+++ b/components/v1/sections/ScheduledJobs/Customers.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import ButtonLink from "@/components/v1/ButtonLink";
 import CaseStudiesCarousel, {
   type CaseStudyItem,
 } from "@/components/v1/sections/shared/CaseStudiesCarousel";
@@ -96,13 +95,12 @@ export default function Customers() {
           id={HEADING_ID}
           className="px-6 lg:px-8"
           title="What teams have built with Inngest to handle cron & scheduled jobs"
-          actions={
-            <ButtonLink href="/customers?ref=scheduled-jobs" variant="primary">
-              See all customers →
-            </ButtonLink>
-          }
         />
       }
+      footerCta={{
+        label: "See all customers →",
+        href: "/customers?ref=scheduled-jobs",
+      }}
     />
   );
 }

--- a/components/v1/sections/shared/CaseStudiesCarousel.tsx
+++ b/components/v1/sections/shared/CaseStudiesCarousel.tsx
@@ -214,7 +214,7 @@ export default function CaseStudiesCarousel({
       {footerCta && (
         <motion.div
           {...reveals.item(4)}
-          className="mt-10 flex justify-end px-6 lg:px-8"
+          className="mt-10 flex justify-center px-6 lg:px-8"
         >
           <ButtonLink href={footerCta.href} variant="primary">
             {footerCta.label}

--- a/components/v1/sections/shared/SplitHero.tsx
+++ b/components/v1/sections/shared/SplitHero.tsx
@@ -259,10 +259,14 @@ export default function SplitHero({
           pal.panel,
         )}
       >
+        {/* Grain's baked directional lighting reads as a two-tone split
+            across the full-width mobile panel — hide it below lg so the
+            panel is one flat colour; it returns as texture in the 2/3
+            panel at lg+. */}
         <img
           src="/assets/v1/ai-hero/grain.webp"
           alt=""
-          className="pointer-events-none absolute left-0 top-[-221%] h-[727%] w-[150%] max-w-none mix-blend-soft-light motion-safe:[will-change:transform]"
+          className="pointer-events-none absolute left-0 top-[-221%] hidden h-[727%] w-[150%] max-w-none mix-blend-soft-light motion-safe:[will-change:transform] lg:block"
           style={{ transform: grainShift }}
         />
         {/* Smallish circle keeps repaints cheap; larger sizes were
@@ -270,7 +274,7 @@ export default function SplitHero({
             --mx/--my updates were repainting a much larger region. */}
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0"
+          className="pointer-events-none absolute inset-0 hidden lg:block"
           style={{ background: pal.spotlight }}
         />
       </div>

--- a/components/v1/sections/shared/StippleCtaSection.tsx
+++ b/components/v1/sections/shared/StippleCtaSection.tsx
@@ -137,9 +137,11 @@ export default function StippleCtaSection({
             </motion.p>
             <motion.div
               {...reveals.item(2)}
-              className="flex flex-col items-start gap-5"
+              className="flex w-full flex-col items-start gap-5 sm:w-auto"
             >
-              <div className="flex flex-row items-stretch gap-3 sm:items-center sm:gap-4">
+              {/* Buttons stack full-width on mobile (flex-col + stretch +
+                  w-full), then sit side-by-side, content-width, at sm+. */}
+              <div className="flex w-full flex-col items-stretch gap-3 sm:w-auto sm:flex-row sm:items-center sm:gap-4">
                 {children}
               </div>
               {footnote && (

--- a/components/v1/sections/shared/TestimonialsCarousel.tsx
+++ b/components/v1/sections/shared/TestimonialsCarousel.tsx
@@ -599,7 +599,7 @@ function Quote({
           />
         </div>
         <div
-          className="flex flex-col gap-8 sm:flex-row sm:flex-wrap sm:gap-y-3"
+          className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:gap-y-3"
           style={{ columnGap: "clamp(12px, 1.5vw, 32px)" }}
         >
           <ButtonLink


### PR DESCRIPTION
## Summary
- **Platform pages**: SplitHero mobile flat panel, Observability static features, ProblemsGrid 2s auto-cycle on touch, Primitives crossfade + reorder, full-width mobile CTAs, ScheduledJobs CTA below carousel, BackgroundJobs sticky headline overlap fix
- **AI page**: UseCases graphic above bullets + instant wrap on carousel edges, Lifecycle graphic before copy on mobile, GoDeeper shorter banner + 4-col card layout + balanced spacing
- **Shared**: CaseStudiesCarousel centered footer CTA, TestimonialsCarousel mobile improvements, StippleCtaSection stacked mobile buttons

## Test plan
- [ ] `/platform` — SplitHero shows flat on mobile, ProblemsGrid auto-cycles on touch
- [ ] `/platform/durable-execution` — Observability section is static
- [ ] `/uses/scheduled-jobs` — "See all customers" CTA below carousel
- [ ] `/uses/serverless-node-background-jobs` — "THAT'S IT" no longer overlaps sticky headline
- [ ] `/ai` — UseCases bullets below graphic, carousel wraps without panning through all cards, GoDeeper banner is compact with 4-col cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)