### PR TITLE
fix: remove /contact → /get-in-touch redirect

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -236,13 +236,6 @@ async function redirects() {
   return [
     ...blogRedirects,
     {
-      // General contact page moved to /get-in-touch. Query strings (the
-      // ?ref= CTA tracking) are carried over to the destination by default.
-      source: "/contact",
-      destination: "/get-in-touch",
-      permanent: true,
-    },
-    {
       source: "/workflow-kit",
       destination: "/docs/reference/workflow-kit",
       permanent: false,


### PR DESCRIPTION
Removes the permanent (308) redirect from /contact to /get-in-touch in next.config.mjs. The v1 contact page now lives at /contact directly, so this redirect is no longer needed and was causing /contact CTAs across the redesign to forward users away from the new page.