### PR TITLE
Fix Open Graph images: homepage, dynamic generator, and docs

### DIFF
--- a/app/(v1)/page.tsx
+++ b/app/(v1)/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = generateMetadata({
   title: "Durable Execution for Developers & AI Workflows",
   description:
     "Build reliable background jobs, workflows, and AI agents without extra infrastructure. Automatic retries, flow control, and step-level observability.",
-  image: "/assets/homepage/open-graph-june-2025.png",
+  image: "/assets/homepage/open-graph-2026.png",
 });
 
 const structuredData = [

--- a/pages/api/og.tsx
+++ b/pages/api/og.tsx
@@ -46,7 +46,10 @@ export default async function handler(req: NextApiRequest) {
     const len = (title || "").length;
     const isLongTitle = len > 40;
     const isVeryLongTitle = len > 70;
-    const backgroundImageURL = `${process.env.NEXT_PUBLIC_HOST}/assets/open-graph/og-background-2025.png`;
+    // 2026 salmon background — the logo is baked into the artwork
+    // (top-left); the title overlays bottom-left in white to match the
+    // static homepage card.
+    const backgroundImageURL = `${process.env.NEXT_PUBLIC_HOST}/assets/og-image-2026.png`;
 
     const fontData = await loadInngestCDNFont("Whyte/ABCWhyte-Light.otf");
 
@@ -54,14 +57,15 @@ export default async function handler(req: NextApiRequest) {
       (
         <div
           style={{
-            backgroundColor: "rgb(2,2,2)", // carbon-1000
+            backgroundColor: "rgb(255,87,51)", // salmon fallback
             backgroundImage: `url("${backgroundImageURL}")`,
+            backgroundSize: "cover",
             height: "100%",
             width: "100%",
-            padding: "10% 6%",
+            padding: "64px",
             display: "flex",
             alignItems: "flex-start",
-            justifyContent: "flex-start",
+            justifyContent: "flex-end",
             flexDirection: "column",
             flexWrap: "nowrap",
             fontFamily: "Whyte, sans-serif",
@@ -69,16 +73,14 @@ export default async function handler(req: NextApiRequest) {
         >
           <div
             style={{
-              fontSize: isVeryLongTitle ? 52 : isLongTitle ? 72 : 96,
+              fontSize: isVeryLongTitle ? 56 : isLongTitle ? 72 : 92,
               fontStyle: "normal",
               fontWeight: 300,
               letterSpacing: "-2.4px",
               color: "white",
-              marginTop: isVeryLongTitle ? 100 : isLongTitle ? 116 : 94,
-              padding: "0 0 0 154px",
-              lineHeight: isVeryLongTitle ? 1.3 : isLongTitle ? 1.22 : 1.2,
+              lineHeight: isVeryLongTitle ? 1.15 : isLongTitle ? 1.12 : 1.05,
               whiteSpace: "normal",
-              maxHeight: 400,
+              maxHeight: 420,
               overflow: "hidden",
             }}
           >

--- a/pages/docs/patterns/[category]/[slug]/index.tsx
+++ b/pages/docs/patterns/[category]/[slug]/index.tsx
@@ -75,7 +75,6 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
         description:
           md.subtitle ??
           "Architecture patterns for building reliable AI pipelines, background jobs, and event-driven workflows.",
-        image: "/assets/homepage/open-graph-june-2025.png",
       },
     },
   };

--- a/pages/docs/patterns/[category]/index.tsx
+++ b/pages/docs/patterns/[category]/index.tsx
@@ -39,7 +39,6 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
       meta: {
         title: `${section.name} patterns | Inngest`,
         description: section.description,
-        image: "/assets/homepage/open-graph-june-2025.png",
       },
     },
   };

--- a/pages/docs/patterns/index.tsx
+++ b/pages/docs/patterns/index.tsx
@@ -25,7 +25,6 @@ export async function getStaticProps() {
       meta: {
         title: "Patterns: How to build with Inngest",
         description: META_DESCRIPTION,
-        image: "/assets/homepage/open-graph-june-2025.png",
       },
     },
   };

--- a/utils/social.ts
+++ b/utils/social.ts
@@ -1,7 +1,7 @@
 import { type Metadata } from "next";
 
 // Use the image version to bust social network's caches
-const openGraphImageVersion = 4;
+const openGraphImageVersion = 5;
 
 /*
  * Generates a URL to dynamically generate an open graph image for posts on social media
@@ -46,7 +46,7 @@ export const generateMetadata = ({
     ? image.match(/^\//)
       ? getFullURL(image)
       : image
-    : getFullURL("/assets/og-image-2026.png");
+    : getOpenGraphImageURL({ title });
   const metaTitle = `Inngest - ${title}`;
   const metadata: Metadata = {
     title,


### PR DESCRIPTION
## Summary
Fixes three related Open Graph regressions left over from the 2026 image swap:

1. **Homepage** — `app/(v1)/page.tsx` still passed the old `open-graph-june-2025.png` explicitly, which overrode the layout default. Now points at the new static `open-graph-2026.png` card (text baked in).
2. **Dynamic OG not populating text** — `utils/social.ts` had been wired to return a *static* blank salmon image, so any titled page rendered with no text. Restored the dynamic generator (`getOpenGraphImageURL`) so the page title renders again, and bumped the cache-bust version `4 → 5`.
3. **Docs using the old OG** — the dynamic generator (`pages/api/og.tsx`) still composited onto the old 2025 dark background. Switched to the 2026 salmon background (`og-image-2026.png`, logo baked in) with the title anchored bottom-left in white to mirror the static homepage card. Docs render their title through this same generator (via `DocsLayout`), so this fixes them too.

Also removed three dead hardcoded old-OG-image references from the docs `patterns` pages — `DocsLayout` ignores `meta.image` and always uses the dynamic generator, so they had no runtime effect but were stale/misleading.

## Why
`og-image-2026.png` is the blank salmon + logo artwork meant as the **background** for the dynamic generator (title overlaid). `open-graph-2026.png` is the **static** homepage card with text baked in. A prior change conflated the two — using the blank one as a static replacement, which killed the dynamic title text.

## Reviewer notes
- Verify the OG preview on `/`, a docs page, and a blog/titled page (e.g. via opengraph.xyz or a social debugger) once deployed — the dynamic ones should show salmon + white title text; the homepage should show the baked-in card.
- The `?v=5` bump forces social scrapers to refetch.

## Test plan
- [ ] `/` → static 2026 homepage card
- [ ] any docs page → salmon background + that page's title in white
- [ ] any blog/titled page using `generateMetadata` → dynamic salmon card with title text

🤖 Generated with [Claude Code](https://claude.com/claude-code)