### PR TITLE
fix: sitemap exclusions, robots.txt, and events nav link

### DIFF
--- a/components/v1/nav-config.ts
+++ b/components/v1/nav-config.ts
@@ -151,7 +151,7 @@ const RESOURCES_MENU: NavMenu = {
         },
         {
           label: "Event Schedule",
-          href: "/events",
+          href: "https://luma.com/user/inngest",
           description: "Stay updated on events & workshops",
         },
         {

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -7,5 +7,6 @@ module.exports = {
     "/blog-markdown/*",
     "/docs-markdown/*",
     "/api/*",
+    "*/download-gate-form*",
   ],
 };

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,6 +5,7 @@ Disallow: /*?ref=
 Disallow: /*?*&ref=
 Disallow: /*?redirect_url=
 Disallow: /*?*&redirect_url=
+Disallow: /download-gate-form
 
 # AI Crawlers
 # Inngest welcomes AI crawlers to index our documentation.


### PR DESCRIPTION
Adds */download-gate-form* to sitemap exclusions in next-sitemap.config.js so the form page is not indexed
Adds Disallow: /download-gate-form to public/robots.txt to block crawlers from the form page
Updates "Event Schedule" nav link from /events to https://luma.com/user/inngest
Note: /sf duplicate redirect (checklist #10) was already resolved in a prior merge