### PR TITLE
redirect: /ai/early-access → /ai

### DIFF
--- a/components/v1/nav-config.ts
+++ b/components/v1/nav-config.ts
@@ -151,7 +151,7 @@ const RESOURCES_MENU: NavMenu = {
         },
         {
           label: "Event Schedule",
-          href: "/events",
+          href: "https://luma.com/user/inngest",
           description: "Stay updated on events & workshops",
         },
         {

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -7,5 +7,6 @@ module.exports = {
     "/blog-markdown/*",
     "/docs-markdown/*",
     "/api/*",
+    "*/download-gate-form*",
   ],
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -192,6 +192,7 @@ const permanentRedirects = [
   ["/durable-endpoints", "/platform/durable-execution"],
   ["/platform", "/platform/durable-execution"],
   ["/ai-personalized-documentation", "/docs/ai-dev-tools/agent-skills"],
+  ["/ai/early-access", "/ai"],
   ["/launch-week", "/"],
   // The scheduled-jobs page moved under /uses; preserve the old URL.
   ["/scheduled-jobs", "/uses/scheduled-jobs"],

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,6 +5,7 @@ Disallow: /*?ref=
 Disallow: /*?*&ref=
 Disallow: /*?redirect_url=
 Disallow: /*?*&redirect_url=
+Disallow: /download-gate-form
 
 # AI Crawlers
 # Inngest welcomes AI crawlers to index our documentation.


### PR DESCRIPTION
Retires the /ai/early-access campaign page with a permanent redirect to /ai.

- Adds `/ai/early-access` → `/ai` in `next.config.mjs`
- Consistent with other retired LP redirects in the same block (launch-week, durable-endpoints, platform, etc.)

Base branch: redesign-2026