### PR TITLE
fix: post-launch CTA copy and URL updates

### DIFF
--- a/components/v1/sections/CompareTemporal/CtaBand.tsx
+++ b/components/v1/sections/CompareTemporal/CtaBand.tsx
@@ -14,7 +14,7 @@ import { reveals } from "@/utils/v1/reveals";
  */
 
 const SIGNUP_URL = "/sign-up?ref=compare-to-temporal-cta";
-const CONTACT_URL = "/get-in-touch?ref=compare-to-temporal-cta";
+const CONTACT_URL = "/contact?ref=compare-to-temporal-cta";
 const VIDEO_ID = "khBvrr7YOm8";
 
 const ENTERPRISE_POINTS = [

--- a/components/v1/sections/Customers/CTA.tsx
+++ b/components/v1/sections/Customers/CTA.tsx
@@ -15,13 +15,13 @@ export default function CTA() {
       }
     >
       <ButtonLink href="/sign-up?ref=customers" variant="primary">
-        Create free account
+        Start Free
       </ButtonLink>
       <ButtonLink
-        href="/docs/getting-started/nextjs-quick-start?ref=customers"
+        href="/docs/quick-start?ref=customers"
         variant="secondary"
       >
-        Quick start guide →
+        Quick Start Guide
       </ButtonLink>
     </StippleCtaSection>
   );

--- a/components/v1/sections/DurableExecution/FinalCTA.tsx
+++ b/components/v1/sections/DurableExecution/FinalCTA.tsx
@@ -2,7 +2,7 @@ import ButtonLink from "@/components/v1/ButtonLink";
 import StippleCtaSection from "@/components/v1/sections/shared/StippleCtaSection";
 
 const SIGNUP_URL = "/sign-up?ref=durable-execution-final";
-const CONTACT_URL = "/get-in-touch?ref=durable-execution-final";
+const QUICKSTART_URL = "/docs/quick-start?ref=durable-execution-final";
 
 export default function FinalCTA() {
   return (
@@ -15,8 +15,8 @@ export default function FinalCTA() {
       <ButtonLink href={SIGNUP_URL} variant="primary">
         Start Free
       </ButtonLink>
-      <ButtonLink href={CONTACT_URL} variant="secondary">
-        Talk to the team
+      <ButtonLink href={QUICKSTART_URL} variant="secondary">
+        Quick Start Guide
       </ButtonLink>
     </StippleCtaSection>
   );

--- a/components/v1/sections/Home/Hero.tsx
+++ b/components/v1/sections/Home/Hero.tsx
@@ -149,7 +149,7 @@ export default function Hero() {
               variant="secondary"
               className="pointer-events-auto"
             >
-              Book a 15min Demo
+              Book a demo
             </ButtonLink>
           </div>
         </div>

--- a/components/v1/sections/ScheduledJobs/Customers.tsx
+++ b/components/v1/sections/ScheduledJobs/Customers.tsx
@@ -31,7 +31,7 @@ const STUDIES: CaseStudyItem[] = [
       </>
     ),
     logo: { src: "/assets/v1/logos/outtake.svg", alt: "Outtake", width: 136, height: 24 },
-    cta: { label: "See the example", href: TODO_HREF },
+    cta: { label: "See the example", href: "/customers/outtake" },
   },
   {
     id: "data-sync",
@@ -56,7 +56,7 @@ const STUDIES: CaseStudyItem[] = [
       </>
     ),
     logo: { src: "/assets/v1/logos/resend.svg", alt: "Resend", width: 96, height: 24 },
-    cta: { label: "See the example", href: TODO_HREF },
+    cta: { label: "See the example", href: "/customers/resend" },
   },
   {
     id: "scheduled-content",
@@ -69,7 +69,7 @@ const STUDIES: CaseStudyItem[] = [
       </>
     ),
     logo: { src: "/assets/v1/logos/soundcloud.svg", alt: "SoundCloud", width: 202, height: 24 },
-    cta: { label: "Read the pattern", href: TODO_HREF },
+    cta: { label: "See the example", href: "/customers/soundcloud" },
   },
   {
     id: "trial-lifecycle",


### PR DESCRIPTION
- /compare-to-temporal: Talk to Us → /contact
- / hero: 'Book a 15min Demo' → 'Book a demo'
- /uses/scheduled-jobs: wire up customer CTA URLs (resend, soundcloud, outtake); rename 'Read the pattern' → 'See the example'
- /platform/durable-execution: 'Talk to the team' → 'Quick Start Guide' → /docs/quick-start
- /customers: 'Create free account' → 'Start Free'; Quick Start Guide → /docs/quick-start