### PR TITLE
Scale hero outline stroke down on small screens

### DIFF
--- a/components/v1/sections/Home/Hero.tsx
+++ b/components/v1/sections/Home/Hero.tsx
@@ -126,8 +126,8 @@ export default function Hero() {
           aria-hidden="true"
           className="text-v1-display-hero mt-6 uppercase text-v1-frost lg:mt-[7vh] lg:pr-[100px] lg:-ml-[0.06em] text-left leading-[0.82] !text-[min(8vw,16vh)] tracking-[-0.025em]"
         >
-          <span className="block text-transparent [-webkit-text-stroke:2px_rgb(255,255,255)]">Invisible</span>
-          <span className="block text-transparent [-webkit-text-stroke:2px_rgb(255,255,255)]">Infra.</span>
+          <span className="block text-transparent [-webkit-text-stroke:0.75px_rgb(255,255,255)] md:[-webkit-text-stroke:1px_rgb(255,255,255)] lg:[-webkit-text-stroke:2px_rgb(255,255,255)]">Invisible</span>
+          <span className="block text-transparent [-webkit-text-stroke:0.75px_rgb(255,255,255)] md:[-webkit-text-stroke:1px_rgb(255,255,255)] lg:[-webkit-text-stroke:2px_rgb(255,255,255)]">Infra.</span>
         </p>
 
         <div className="mt-[48px] space-y-[36px] lg:mt-[6vh] lg:space-y-[42px] lg:pl-0">


### PR DESCRIPTION
## Summary
The INVISIBLE / INFRA. outlined headline used a fixed `2px` `-webkit-text-stroke`. As the headline font shrinks on smaller viewports the stroke stays the same width, so the outline reads far too heavy on mobile. Made it responsive:

- **mobile**: `0.75px`
- **md**: `1px`
- **lg+**: `2px` (unchanged)

## Test plan
- [ ] `/` on mobile — INVISIBLE/INFRA outline is thin and legible
- [ ] `/` on desktop — outline unchanged at 2px

🤖 Generated with [Claude Code](https://claude.com/claude-code)