### PR TITLE
seo: internal linking updates across blog posts + web pages

### DIFF
--- a/content/blog/announcing-funding-from-a16z.mdx
+++ b/content/blog/announcing-funding-from-a16z.mdx
@@ -30,6 +30,6 @@ Inngest combines event streams, queues, and durable execution into a single reli
 
 ## The future
 
-With this additional investment, we will continue to invest in the three key areas above as well as [expand the team](/careers) over the coming year.
+With this additional investment, we will continue to invest in the three key areas above as well as [expand the team](/about) over the coming year.
 
 Our focus is enabling _every_ developer to build reliable apps, regardless of language, experience, or infrastructure knowledge. We'll continue to invest in building the world's best reliability layer with an emphasis on developer experience. If you want to learn how Inngest can help your team, [get in touch](/contact?ref=blog-funding-a16z).

--- a/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
+++ b/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
@@ -51,7 +51,7 @@ As models and approaches have improved, agents can take on long-horizon tasks fo
 
 Background agents need a few things to be successful:
 
-**Long-running execution with crash recovery.** The longer something runs, the higher the cost of failure. A 45-minute agent run can't live in a Lambda with a 5-minute timeout. It can't live in memory on a single process. It needs execution that survives restarts, deployments, and infrastructure failures (see: durable execution).
+**Long-running execution with crash recovery.** The longer something runs, the higher the cost of failure. A 45-minute agent run can't live in a Lambda with a 5-minute timeout. It can't live in memory on a single process. It needs execution that survives restarts, deployments, and infrastructure failures (see: [durable execution](/platform/durable-execution)).
 
 **Multi-step observability.** When a background agent produces a bad result 30 minutes into a run, you need to trace every step it took. Every LLM call, tool invocation, decision point, and sub-agent delegation. Cobbling together logs and state isn't going to cut it.
 

--- a/content/blog/building-the-inngest-queue-pt-i-fairness-multi-tenancy.mdx
+++ b/content/blog/building-the-inngest-queue-pt-i-fairness-multi-tenancy.mdx
@@ -135,4 +135,4 @@ There's a ton more nuance to the queue, though at a high level this solves all k
 
 Even though queues are fundamental to how we work, we think that reliability layers like Inngest mean that you never actually need to implement queueing, or even think about how it works.  The system abstracts everything for you declaratively by code, so even the freshest of engineers can productively build reliable systems.
 
-If you found this interesting or you'd like to work on systems like this please reach out to us [by email](/contact), [Twitter](https://twitter.com/inngest), or on our [Discord](/discord). We'd love to hear your thoughts, and [we're hiring](/careers)!
+If you found this interesting or you'd like to work on systems like this please reach out to us [by email](/contact), [Twitter](https://twitter.com/inngest), or on our [Discord](/discord). We'd love to hear your thoughts, and [we're hiring](/about)!

--- a/content/blog/enhanced-observability-traces-and-metrics.mdx
+++ b/content/blog/enhanced-observability-traces-and-metrics.mdx
@@ -15,7 +15,7 @@ At Inngest, we are constantly evolving to meet the needs of developers building 
 
 Managing workflows can get complex, especially with parallel steps, concurrency limits, and multiple functions running simultaneously. Previously, our function run view displayed function steps in a vertical timeline, which often made it difficult to grasp the sequence and relationships between steps.
 
-To address this, we've introduced a dynamic **waterfall view** and **expanded run details**, inspired by OpenTelemetry tracing. These features make it easier than ever to visualize complex workflows and troubleshoot faster. Here's how they enhance your observability:
+To address this, we've introduced a dynamic **waterfall view** and **expanded run details**, inspired by OpenTelemetry tracing. These features make it easier than ever to visualize complex workflows and troubleshoot faster. Here's how they enhance your [observability](/platform/observability):
 
 * **Waterfall visualization**: This new trace view clearly maps out the sequence and timing of function executions, including steps running in parallel. You can now understand the flow of your entire workflow in seconds, simplifying navigation and revealing bottlenecks or inefficiencies at a glance.
 

--- a/content/blog/how-durable-workflow-engines-work.mdx
+++ b/content/blog/how-durable-workflow-engines-work.mdx
@@ -241,7 +241,7 @@ tool that improves how we build products day to day.
 
 ## How durable execution is evolving: Expanding beyond traditional workflows
 
-As durable execution matures, workflow engines are expanding beyond traditional background job processing to support more diverse execution patterns and deployment models.
+As [durable execution](/platform/durable-execution) matures, workflow engines are expanding beyond traditional background job processing to support more diverse execution patterns and deployment models.
 
 ### Real-time and interactive applications
 

--- a/content/blog/how-we-built-insights-ai-with-inngest.mdx
+++ b/content/blog/how-we-built-insights-ai-with-inngest.mdx
@@ -139,7 +139,7 @@ If we were starting over, a few things would change.
 
 **Test model providers earlier.** We assumed OpenAI was the default choice because it's what everyone uses. We should have prototyped with multiple providers from the start. The quality difference between models matters more than we expected.
 
-**Build observability first.** We added detailed logging and tracing partway through. Should have been there from the beginning. When agent responses are bad, you need to see exactly what prompts went in, what came back, and where things went wrong.
+**Build [observability](/platform/observability) first.** We added detailed logging and tracing partway through. Should have been there from the beginning. When agent responses are bad, you need to see exactly what prompts went in, what came back, and where things went wrong.
 
 ## The tools we used
 

--- a/content/blog/insights-query-events-and-runs.mdx
+++ b/content/blog/insights-query-events-and-runs.mdx
@@ -20,7 +20,7 @@ author: Lauren Craigie
 
 - **Grep logs** and write one-off scripts until you get a halfway decent answer.
 - **Write an ETL pipeline** to dump event data into a warehouse, and wait for your transformation tool to finish a run before you can even query it.
-- **Build a dashboard** in BI or AI observability tools, and update that model every time you make a change in your workflow tool.
+- **Build a dashboard** in BI or AI [observability](/platform/observability) tools, and update that model every time you make a change in your workflow tool.
 
 If you have an AI feature, it's even tougher. AI workflows and agents are complex multi-step chains of non-deterministic LLMs, making it really hard to evaluate how these features are performing, *and how much they cost.*
 

--- a/content/blog/introducing-enhanced-traces.mdx
+++ b/content/blog/introducing-enhanced-traces.mdx
@@ -7,7 +7,7 @@ author: Lauren Craigie
 category: product-updates
 ---
 
-Over the past few months, we've shipped a series of backend updates—[Extended Traces](https://www.inngest.com/blog/introducing-extended-traces), the [Constraint API](https://www.inngest.com/blog/announcing-the-constraint-api), [Durable Endpoints](https://www.inngest.com/durable-endpoints), Step Metadata—that each capture richer execution data than we had before. 
+Over the past few months, we've shipped a series of backend updates—[Extended Traces](https://www.inngest.com/blog/introducing-extended-traces), the [Constraint API](https://www.inngest.com/blog/announcing-the-constraint-api), [Durable Endpoints](/platform/durable-execution), Step Metadata—that each capture richer execution data than we had before. 
 
 We're now bringing this data to the front end, to make it even easier to debug your jobs and workflows. Our enhanced Traces view will help you quickly discern the source of slowdowns, and opportunities for optimization.
 

--- a/content/blog/queues-are-no-longer-the-right-abstraction.mdx
+++ b/content/blog/queues-are-no-longer-the-right-abstraction.mdx
@@ -73,7 +73,7 @@ Durable execution is the right abstraction instead of dealing with queues direct
 
 First, **durability**. Durable execution is fault-tolerant execution, guaranteeing that code will run to completion even with failures or restarts. This removes part of the problem above. With durable execution, developers don't have to build out processes to guarantee execution, such as implementing retry logic, handling failures, or persisting state, as these capabilities are provided out of the box by the durable execution runtime.
 
-But durability alone isn't enough. Reliability through durable execution requires **flow control**. Flow control is everything listed above that you have to build out for reliable workflows around queues. While durable execution focuses on guaranteeing the execution of tasks and handling failures, flow control deals with managing how or when the code is executed.
+But durability alone isn't enough. Reliability through durable execution requires **[flow control](/platform/flow-control)**. Flow control is everything listed above that you have to build out for reliable workflows around queues. While durable execution focuses on guaranteeing the execution of tasks and handling failures, flow control deals with managing how or when the code is executed.
 
 Flow control encompasses various aspects such as concurrency control, rate limiting, resource sharing, and prioritization. Let's say you have a processing workflow for transcribing video. What does this entail?
 

--- a/content/blog/rate-limit-debouncing-throttling-explained.mdx
+++ b/content/blog/rate-limit-debouncing-throttling-explained.mdx
@@ -139,7 +139,7 @@ Please find below a takeaway cheatsheet that will help you evaluate the best way
 
 ### Singleton Functions: Exclusive execution control (June 2025)
 
-Since this article was published, Inngest has added **Singleton Functions**—another flow control mechanism that ensures exclusive execution. While rate limiting, throttling, and debouncing control frequency and timing, Singleton Functions ensure mutual exclusion—only one run per key executes at a time:
+Since this article was published, Inngest has added **Singleton Functions**—another [flow control](/platform/flow-control) mechanism that ensures exclusive execution. While rate limiting, throttling, and debouncing control frequency and timing, Singleton Functions ensure mutual exclusion—only one run per key executes at a time:
 
 ```typescript
 const latestDataSync = inngest.createFunction({

--- a/content/blog/run-nextjs-functions-in-the-background.mdx
+++ b/content/blog/run-nextjs-functions-in-the-background.mdx
@@ -232,4 +232,4 @@ When you deploy either a scheduled function or a background job, you'll get full
 
 ## Now go ship something!
 
-Congrats! You now know how you can easily move key logic in your app to be asynchronous and out of the critical path of a request. Background jobs are important for any scaling and performant application that you have so we think this will really help you grow your amazing products.
+Congrats! You now know how you can easily move key logic in your app to be asynchronous and out of the critical path of a request. [Background jobs](/uses/serverless-node-background-jobs) are important for any scaling and performant application that you have so we think this will really help you grow your amazing products.

--- a/content/blog/webinar-recap-durable-endpoints.mdx
+++ b/content/blog/webinar-recap-durable-endpoints.mdx
@@ -9,7 +9,7 @@ primaryCTA: docs
 floatingCTA: true
 ---
 
-Last Friday, we ran a live session on [durable endpoints](https://www.inngest.com/durable-endpoints?ref=webinar-recap-durable-endpoints)—a feature we've been working on since August, and built a fully functional deep research agent from scratch in about 30 minutes. Two API endpoints, no job queue, no worker infrastructure, no state management code. The whole thing ran for four minutes per request without any of that.
+Last Friday, we ran a live session on [durable endpoints](/platform/durable-execution)—a feature we've been working on since August, and built a fully functional deep research agent from scratch in about 30 minutes. Two API endpoints, no job queue, no worker infrastructure, no state management code. The whole thing ran for four minutes per request without any of that.
 
 If you missed it, the recording is on our [YouTube channel](https://youtu.be/FUan8gEpRGI), and the code is [fully open source](https://github.com/inngest/durable-endpoints-webinar). But if you want the cliff notes, read on.
 


### PR DESCRIPTION
P1 - repoint existing links:
- announcing-funding-from-a16z: /careers → /about
- building-the-inngest-queue-pt-i: /careers → /about
- introducing-enhanced-traces: /durable-endpoints → /platform/durable-execution
- webinar-recap-durable-endpoints: /durable-endpoints → /platform/durable-execution

P2 - add new editorial links:
- background-agents: link 'durable execution' → /platform/durable-execution
- enhanced-observability: link 'observability' → /platform/observability
- how-durable-workflow-engines-work: link 'durable execution' → /platform/durable-execution
- how-we-built-insights-ai: link 'observability' → /platform/observability
- insights-query-events-and-runs: link 'observability' → /platform/observability
- queues-are-no-longer-the-right-abstraction: link 'flow control' → /platform/flow-control
- rate-limit-debouncing: link 'flow control' → /platform/flow-control
- run-nextjs-functions-in-background: link 'background jobs' → /uses/serverless-node-background-jobs