### PR TITLE
Fix broken links and add docs CTAs across 5 pages

### DIFF
--- a/components/v1/sections/BackgroundJobs/Reliability.tsx
+++ b/components/v1/sections/BackgroundJobs/Reliability.tsx
@@ -292,7 +292,7 @@ export default function Reliability() {
                 href={feature.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-[22px] pb-2 pt-1 font-v1Label text-[12px] text-v1-frost/40 hover:text-v1-accent-salmon motion-safe:transition-colors motion-safe:duration-200"
+                className="pl-[40px] pr-[22px] pb-2 pt-1 font-v1Label text-[12px] text-v1-frost/40 hover:text-v1-accent-salmon motion-safe:transition-colors motion-safe:duration-200"
               >
                 Read the docs →
               </a>

--- a/components/v1/sections/BackgroundJobs/Reliability.tsx
+++ b/components/v1/sections/BackgroundJobs/Reliability.tsx
@@ -44,6 +44,7 @@ interface Feature {
   id: IllustrationId;
   title: string;
   body: string;
+  href: string;
 }
 
 const FEATURES: Feature[] = [
@@ -51,41 +52,49 @@ const FEATURES: Feature[] = [
     id: "retries",
     title: "Automatic retries",
     body: "Failed steps retry with configurable exponential backoff. Set max attempts per function or per individual step — no boilerplate required.",
+    href: "https://www.inngest.com/docs/guides/error-handling",
   },
   {
     id: "checkpointing",
     title: "Step-level checkpointing",
     body: "When a step fails, only that step retries. Completed steps are memoized — no duplicate side effects from work that already succeeded.",
+    href: "https://www.inngest.com/docs/setup/checkpointing",
   },
   {
     id: "traces",
     title: "Full run traces and logs",
     body: "Every run has a complete trace. See inputs, outputs, timing, and error details for every step — without a separate logging service.",
+    href: "https://www.inngest.com/docs/platform/monitor/traces",
   },
   {
     id: "concurrency",
     title: "Concurrency and throttling",
     body: "Cap parallel executions globally or per-user/tenant with one line of config. Prevent thundering herds and protect downstream services.",
+    href: "https://www.inngest.com/docs/guides/concurrency",
   },
   {
     id: "priority",
     title: "Priority queuing",
     body: "High-priority jobs run first. Assign dynamic priority based on user tier, plan, or any attribute in the event payload.",
+    href: "https://www.inngest.com/docs/guides/priority#configuration-reference",
   },
   {
     id: "replay",
     title: "Bulk replay",
     body: "Deployed a bug? Re-run failed functions in bulk from the dashboard. No dead-letter queues to drain. No scripts to write.",
+    href: "https://www.inngest.com/docs/platform/replay",
   },
   {
     id: "devServer",
     title: "Local dev server",
     body: "Run npx inngest-cli dev for a local UI with real-time traces, event payloads, and step outputs. No cloud account needed.",
+    href: "https://www.inngest.com/docs/local-development",
   },
   {
     id: "typescript",
     title: "TypeScript-native",
     body: "Define event payload types once. End-to-end type safety from the event sender all the way into your function body.",
+    href: "https://www.inngest.com/docs/guides/singleton",
   },
 ];
 
@@ -236,7 +245,7 @@ export default function Reliability() {
         {FEATURES.map((feature) => {
           const isActive = feature.id === active;
           return (
-            <li key={feature.id} className="flex">
+            <li key={feature.id} className="flex flex-col">
               <button
                 type="button"
                 role="tab"
@@ -244,7 +253,7 @@ export default function Reliability() {
                 onClick={() => advance(feature.id)}
                 onPointerMove={onCursorSpotlightMove}
                 style={CURSOR_SPOTLIGHT_SEED}
-                className="group/row relative isolate flex h-full w-full items-start gap-[10px] rounded-md px-[22px] py-[10px] text-left motion-safe:transition-colors motion-safe:duration-300 motion-safe:ease-v1-out hover:bg-v1-frost/[0.035] focus-visible:bg-v1-frost/[0.035]"
+                className="group/row relative isolate flex w-full items-start gap-[10px] rounded-md px-[22px] py-[10px] text-left motion-safe:transition-colors motion-safe:duration-300 motion-safe:ease-v1-out hover:bg-v1-frost/[0.035] focus-visible:bg-v1-frost/[0.035]"
               >
                 <span
                   aria-hidden="true"
@@ -279,6 +288,14 @@ export default function Reliability() {
                   </span>
                 </span>
               </button>
+              <a
+                href={feature.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-[22px] pb-2 pt-1 font-v1Label text-[12px] text-v1-frost/40 hover:text-v1-accent-salmon motion-safe:transition-colors motion-safe:duration-200"
+              >
+                Read the docs →
+              </a>
             </li>
           );
         })}

--- a/components/v1/sections/CompareTemporal/DesignedForAI.tsx
+++ b/components/v1/sections/CompareTemporal/DesignedForAI.tsx
@@ -396,7 +396,7 @@ export default function DesignedForAI() {
                       href={slide.href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="px-[22px] pb-2 pt-1 font-v1Label text-[13px] text-v1-frost/50 hover:text-v1-accent-salmon motion-safe:transition-colors motion-safe:duration-200"
+                      className="pl-[40px] pr-[22px] pb-2 pt-1 font-v1Label text-[13px] text-v1-frost/50 hover:text-v1-accent-salmon motion-safe:transition-colors motion-safe:duration-200"
                     >
                       Read the docs →
                     </Link>

--- a/components/v1/sections/CompareTemporal/DesignedForAI.tsx
+++ b/components/v1/sections/CompareTemporal/DesignedForAI.tsx
@@ -1,7 +1,11 @@
 "use client";
 
+import Link from "next/link";
+import { motion } from "motion/react";
 import { cn } from "@/utils/v1/cn";
+import { reveals } from "@/utils/v1/reveals";
 import ReelCarousel from "@/components/v1/sections/shared/ReelCarousel";
+import ReelDirectoryRow from "@/components/v1/sections/shared/ReelDirectoryRow";
 import { useReelCarousel } from "@/components/v1/sections/shared/useReelCarousel";
 import Section from "@/components/v1/sections/shared/Section";
 import SectionHeader from "@/components/v1/sections/shared/SectionHeader";
@@ -25,6 +29,7 @@ interface Slide {
   id: string;
   title: string;
   blurb: string;
+  href?: string;
   code?: string;
   /** Render the per-user "Queued Runs" bar chart instead of a code box. */
   chart?: boolean;
@@ -38,6 +43,7 @@ const SLIDES: Slide[] = [
     title: "Step memoization",
     blurb:
       "Completed steps aren’t re-executed on retry. Temporal retries the whole activity — there’s no per-step cache.",
+    href: "https://www.inngest.com/docs/learn/versioning#step-based-memoization",
     code: `const summary = await
 step.run('summarize', async () => {
 return llm.complete(transcript) })
@@ -49,6 +55,7 @@ return llm.complete(transcript) })
     title: "Human-in-the-loop",
     blurb:
       "A native primitive in Inngest. In Temporal, its an assembly of Signals, channels, and Slectors – pattern, not platform.",
+    href: "https://www.inngest.com/docs/ai-patterns/human-in-the-loop",
     code: `const decision
 = await step.waitForEvent('review', {
 event: 'agent/reviewed',
@@ -61,6 +68,7 @@ Selector, and handler — all manual.`,
     title: "Per-user concurrency and rate limiting",
     blurb:
       "Temporal has no built-in rate limiting. Concurrency is worker-level, not per-user. Both require custom code.",
+    href: "https://www.inngest.com/docs/guides/concurrency",
     chart: true,
   },
   {
@@ -68,6 +76,7 @@ Selector, and handler — all manual.`,
     title: "Step-level observability",
     blurb:
       "— queue delay, step timing, flow control — so you know exactly what happened, and why.",
+    href: "https://www.inngest.com/docs/platform/monitor/observability-metrics",
     segments: true,
   },
 ];
@@ -340,36 +349,62 @@ export default function DesignedForAI() {
           >
             {(slide) => <SlideVisual slide={slide} />}
           </ReelCarousel.Panel>
-          {/* 2×2 feature grid / slide selectors. */}
-          <ReelCarousel.Directory<Slide>
-            className="mt-[44px]"
-            columnsClass="grid-cols-1 sm:grid-cols-2"
-            gapClass="gap-x-4 gap-y-8"
-            dotAnchorClassName=""
-          >
-            {({ item, isActive }) => (
-              <span className="flex flex-1 flex-col gap-2">
-                <span
-                  className={cn(
-                    "flex min-h-[40px] items-center text-v1-heading-sm motion-safe:transition-colors",
-                    isActive
-                      ? "text-v1-frost"
-                      : "text-v1-frost/70 group-hover/row:text-v1-frost",
-                  )}
+          {/* 2×2 feature grid / slide selectors. Custom grid (instead of
+              ReelCarousel.Directory) so each cell can hold both the
+              interactive button and a "Read the docs →" anchor as
+              siblings — anchors cannot be nested inside buttons. */}
+          <ul className="mt-[44px] grid list-none grid-cols-1 items-stretch gap-x-4 gap-y-8 pl-0 sm:grid-cols-2">
+            {SLIDES.map((slide, i) => {
+              const isActive = i === controller.active;
+              return (
+                <motion.li
+                  key={slide.id}
+                  {...reveals.item(i)}
+                  className="flex list-none flex-col"
                 >
-                  {item.title}
-                </span>
-                <span
-                  className={cn(
-                    "text-v1-body-sm motion-safe:transition-colors",
-                    isActive ? "text-v1-frost" : "text-v1-frost/80",
+                  <ReelDirectoryRow
+                    isActive={isActive}
+                    cycling={controller.cycling}
+                    onSelect={() => controller.select(i)}
+                    onHoverEnter={controller.pause}
+                    onHoverLeave={controller.resume}
+                    dotAnchorClassName=""
+                  >
+                    <span className="flex flex-1 flex-col gap-2">
+                      <span
+                        className={cn(
+                          "flex min-h-[40px] items-center text-v1-heading-sm motion-safe:transition-colors",
+                          isActive
+                            ? "text-v1-frost"
+                            : "text-v1-frost/70 group-hover/row:text-v1-frost",
+                        )}
+                      >
+                        {slide.title}
+                      </span>
+                      <span
+                        className={cn(
+                          "text-v1-body-sm motion-safe:transition-colors",
+                          isActive ? "text-v1-frost" : "text-v1-frost/80",
+                        )}
+                      >
+                        {slide.blurb}
+                      </span>
+                    </span>
+                  </ReelDirectoryRow>
+                  {slide.href && (
+                    <Link
+                      href={slide.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="px-[22px] pb-2 pt-1 font-v1Label text-[13px] text-v1-frost/50 hover:text-v1-accent-salmon motion-safe:transition-colors motion-safe:duration-200"
+                    >
+                      Read the docs →
+                    </Link>
                   )}
-                >
-                  {item.blurb}
-                </span>
-              </span>
-            )}
-          </ReelCarousel.Directory>
+                </motion.li>
+              );
+            })}
+          </ul>
         </ReelCarousel>
       </div>
     </Section>

--- a/components/v1/sections/DurableExecution/CaseStudies.tsx
+++ b/components/v1/sections/DurableExecution/CaseStudies.tsx
@@ -14,31 +14,31 @@ const STUDIES: CaseStudyItem[] = [
     id: "ai-agents-rag",
     title: "AI Agents and RAG",
     body: "Use Inngest to build AI agents and RAG.",
-    cta: { label: CTA_LABEL, href: "/uses/ai-agents-rag?ref=durable-execution" },
+    cta: { label: "See example", href: "/docs/examples/ai-agents-and-rag" },
   },
   {
     id: "email-sequence",
     title: "Email sequence",
     body: "Build a dynamic drip campaign based on a user's behavior.",
-    cta: { label: CTA_LABEL, href: "/uses/email-sequence?ref=durable-execution" },
+    cta: { label: "See example", href: "/docs/examples/email-sequence" },
   },
   {
     id: "scheduling-one-off",
     title: "Scheduling a one-off function",
     body: "Schedule a function to run at a specific time.",
-    cta: { label: CTA_LABEL, href: "/uses/scheduled-jobs?ref=durable-execution" },
+    cta: { label: "See example", href: "/docs/examples/scheduling-one-off-function" },
   },
   {
     id: "realtime",
     title: "Realtime",
     body: "Use Realtime to stream updates from one to multiple Inngest functions or to implement a Human in the Loop mechanism.",
-    cta: { label: CTA_LABEL, href: "/uses/realtime?ref=durable-execution" },
+    cta: { label: "Read the docs", href: "/docs/features/realtime" },
   },
   {
     id: "durable-endpoints",
     title: "Durable endpoints",
     body: "Make any API endpoint durable with automatic retries.",
-    cta: { label: CTA_LABEL, href: "/uses/durable-endpoints?ref=durable-execution" },
+    cta: { label: "Read the docs", href: "/docs/learn/durable-endpoints" },
   },
 ];
 

--- a/components/v1/sections/DurableExecution/Hero.tsx
+++ b/components/v1/sections/DurableExecution/Hero.tsx
@@ -26,7 +26,7 @@ export default function Hero() {
         "Inngest lets you make every function durable without",
         "leaving your codebase."
       ]}
-      docsHref="/docs?ref=durable-execution"
+      docsHref="/docs/learn/how-functions-are-executed?ref=durable-execution"
       signupHref="/sign-up?ref=durable-execution"
       canvas={({ isDesktop }) =>
         isDesktop && (

--- a/components/v1/sections/DurableExecution/Observability.tsx
+++ b/components/v1/sections/DurableExecution/Observability.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { motion } from "motion/react";
 import ButtonLink from "@/components/v1/ButtonLink";
 import GradientFrame from "@/components/v1/sections/shared/GradientFrame";
@@ -100,20 +99,23 @@ export default function Observability() {
             background bleeds outward. */}
         <div className="-mx-[22px] mt-20 grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2 lg:grid-cols-3">
           {FEATURES.map((f, i) => (
-            <motion.div key={f.title} {...reveals.item(i)} className="h-full">
+            <motion.div key={f.title} {...reveals.item(i)} className="flex h-full flex-col">
               {/* Static row — no button/hover/selection and no bullet;
                   white title so every feature reads "active". */}
-              <Link
-                href={f.href}
-                className="group flex h-full flex-col gap-2 px-[22px] py-[18px]"
-              >
-                <span className="flex min-h-10 items-center text-v1-heading-sm text-v1-frost group-hover:text-v1-accent-salmon motion-safe:transition-colors motion-safe:duration-200">
+              <div className="flex flex-1 flex-col gap-2 px-[22px] py-[18px]">
+                <span className="flex min-h-10 items-center text-v1-heading-sm text-v1-frost">
                   {f.title}
                 </span>
                 <span className="whitespace-pre-line text-v1-body-sm text-v1-frost/80">
                   {f.body}
                 </span>
-              </Link>
+              </div>
+              <a
+                href={f.href}
+                className="px-[22px] pb-[18px] font-v1Label text-[13px] text-v1-frost/40 hover:text-v1-accent-salmon motion-safe:transition-colors motion-safe:duration-200"
+              >
+                Read the docs →
+              </a>
             </motion.div>
           ))}
         </div>

--- a/components/v1/sections/DurableExecution/Observability.tsx
+++ b/components/v1/sections/DurableExecution/Observability.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { motion } from "motion/react";
 import ButtonLink from "@/components/v1/ButtonLink";
 import GradientFrame from "@/components/v1/sections/shared/GradientFrame";
@@ -18,28 +19,34 @@ import { reveals } from "@/utils/v1/reveals";
 interface Feature {
   title: string;
   body: string;
+  href: string;
 }
 
 const FEATURES: Feature[] = [
   {
     title: "Waterfall Traces",
     body: "Functions traced automatically, in parallel",
+    href: "/docs/platform/monitor/traces",
   },
   {
     title: "Metrics dashboard",
     body: "System health at the environment level",
+    href: "/docs/platform/monitor/observability-metrics#function-metrics",
   },
   {
     title: "Run search",
     body: "Find the exact run for any user, org,\nor error pattern",
+    href: "/docs/platform/monitor/inspecting-function-runs#searching-function-runs",
   },
   {
     title: "Replay",
     body: "Deploy a fix and re-run in bulk—\nno dead-letter queues",
+    href: "/docs/platform/replay",
   },
   {
     title: "Insights",
     body: "Query event and run data with SQL.\nNo ETL needed",
+    href: "/docs/platform/monitor/insights",
   },
 ];
 
@@ -96,14 +103,17 @@ export default function Observability() {
             <motion.div key={f.title} {...reveals.item(i)} className="h-full">
               {/* Static row — no button/hover/selection and no bullet;
                   white title so every feature reads "active". */}
-              <div className="flex h-full flex-col gap-2 px-[22px] py-[18px]">
-                <span className="flex min-h-10 items-center text-v1-heading-sm text-v1-frost">
+              <Link
+                href={f.href}
+                className="group flex h-full flex-col gap-2 px-[22px] py-[18px]"
+              >
+                <span className="flex min-h-10 items-center text-v1-heading-sm text-v1-frost group-hover:text-v1-accent-salmon motion-safe:transition-colors motion-safe:duration-200">
                   {f.title}
                 </span>
                 <span className="whitespace-pre-line text-v1-body-sm text-v1-frost/80">
                   {f.body}
                 </span>
-              </div>
+              </Link>
             </motion.div>
           ))}
         </div>

--- a/components/v1/sections/Observability/Hero.tsx
+++ b/components/v1/sections/Observability/Hero.tsx
@@ -25,7 +25,7 @@ export default function Hero() {
         "provides deep insight into context at the step level—",
         "so you can fix fast.",
       ]}
-      docsHref="/docs?ref=observability"
+      docsHref="/docs/platform/monitor/observability-metrics?ref=observability"
       signupHref="/sign-up?ref=observability"
       canvas={({ isDesktop }) =>
         isDesktop && (

--- a/components/v1/sections/ScheduledJobs/Customers.tsx
+++ b/components/v1/sections/ScheduledJobs/Customers.tsx
@@ -43,7 +43,7 @@ const STUDIES: CaseStudyItem[] = [
       </>
     ),
     logo: { src: "/assets/customers/tripadvisor.svg", alt: "Tripadvisor", width: 157, height: 24 },
-    cta: { label: "Read the pattern", href: TODO_HREF },
+    cta: { label: "Read the pattern", href: "/docs/guides/clerk-webhook-events#creating-a-function-to-sync-a-new-user-to-a-database" },
   },
   {
     id: "user-reminders",
@@ -81,7 +81,7 @@ const STUDIES: CaseStudyItem[] = [
       </>
     ),
     logo: { src: "/assets/customers/zamp-logo.svg", alt: "Zamp", width: 157, height: 24 },
-    cta: { label: "See the example", href: TODO_HREF },
+    cta: { label: "See the example", href: "/docs/patterns/schedule/running-at-specific-times" },
   },
 ];
 

--- a/components/v1/sections/ScheduledJobs/Customers.tsx
+++ b/components/v1/sections/ScheduledJobs/Customers.tsx
@@ -43,7 +43,7 @@ const STUDIES: CaseStudyItem[] = [
       </>
     ),
     logo: { src: "/assets/customers/tripadvisor.svg", alt: "Tripadvisor", width: 157, height: 24 },
-    cta: { label: "Read the pattern", href: "/docs/guides/clerk-webhook-events#creating-a-function-to-sync-a-new-user-to-a-database" },
+    cta: { label: "Read the docs", href: "/docs/guides/clerk-webhook-events#creating-a-function-to-sync-a-new-user-to-a-database" },
   },
   {
     id: "user-reminders",
@@ -81,7 +81,7 @@ const STUDIES: CaseStudyItem[] = [
       </>
     ),
     logo: { src: "/assets/customers/zamp-logo.svg", alt: "Zamp", width: 157, height: 24 },
-    cta: { label: "See the example", href: "/docs/patterns/schedule/running-at-specific-times" },
+    cta: { label: "Read the docs", href: "/docs/patterns/schedule/running-at-specific-times" },
   },
 ];
 


### PR DESCRIPTION
## What changed

### /uses/scheduled-jobs
- "Trial & subscription lifecycle" card now links to `/docs/patterns/schedule/running-at-specific-times`
- "Data sync & imports" card now links to `/docs/guides/clerk-webhook-events#creating-a-function-to-sync-a-new-user-to-a-database`

### /platform/durable-execution
- "Observability by default" section: all 5 feature items (Waterfall Traces, Metrics dashboard, Run search, Replay, Insights) now link to their respective docs pages and turn orange on hover
- "What teams are building" carousel: updated CTA text and links on all 5 cards (See example / Read the docs)

### /platform/observability
- Hero "Read the Docs" button now links to `/docs/platform/monitor/observability-metrics` instead of `/docs`

### /compare-to-temporal
- "Designed for AI" section: added "Read the docs →" link below each of the 4 feature cards

### /uses/serverless-node-background-jobs
- "Everything production apps require" section: added "Read the docs →" link below each of the 8 feature cards

## Notes
The "Read the docs →" links on the carousel/tab sections (compare-to-temporal and background-jobs) are rendered as siblings outside the tab buttons rather than inside them — anchors can't be nested inside `<button>` elements per HTML spec.