### PR TITLE
[codex] Fix Fey customer wordmark

### DIFF
--- a/components/v1/sections/Customers/data.ts
+++ b/components/v1/sections/Customers/data.ts
@@ -133,7 +133,7 @@ export const STORIES: StoryCard[] = [
   {
     id: "fey",
     brand: "Fey",
-    logo: "/assets/customers/fey/fey-icon.svg",
+    logo: "/assets/customers/fey/fey-icon-name.svg",
     tags: ["AI"],
     title: "Orchestrating complex financial data pipelines",
     body: "50x faster and 50x cheaper. How Fey leverages Inngest in data-intensive processes.",

--- a/content/customers/fey.mdx
+++ b/content/customers/fey.mdx
@@ -3,7 +3,7 @@ title: >-
   50x faster and 50x cheaper. How Fey leverages Inngest in data-intensive
   processes.
 companyName: Fey
-logo: /assets/customers/fey/fey-icon.svg
+logo: /assets/customers/fey/fey-icon-name.svg
 logoScale: 2
 quote:
   text: >-


### PR DESCRIPTION
## Summary

- Update the Fey customer-story card to use the existing Fey wordmark asset instead of the icon-only logo.
- Update the Fey customer story frontmatter so the individual customer page shows the wordmark too.

## Why

Fey was missing its visible brand name on the `/customers` card and the `/customers/fey` page because both surfaces referenced `fey-icon.svg`, which only contains the mark. Other site surfaces already use `fey-icon-name.svg`.

## Validation

- `pnpm exec prettier --check components/v1/sections/Customers/data.ts content/customers/fey.mdx`
- `git diff --check`
- Verified locally in the in-app browser at `http://localhost:3002/customers` and `http://localhost:3002/customers/fey`.

<img width="378" height="305" alt="Screenshot 2026-06-11 at 12 34 10 PM" src="https://github.com/user-attachments/assets/ab0fec0c-55b4-427a-a53f-72876577b009" />
