### PR TITLE
feat(seo): add X-Robots-Tag noindex headers to LLM markdown routes

### DIFF
--- a/app/(llms)/blog-markdown/[slug]/route.ts
+++ b/app/(llms)/blog-markdown/[slug]/route.ts
@@ -99,13 +99,17 @@ export async function GET(
     const markdownBody = await convertMdxToMarkdown(content);
     const output = `${frontmatterLines.join("\n")}\n\n${markdownBody}`;
 
-    return new Response(output, {
-      headers: {
-        "Content-Type": "text/markdown;charset=UTF-8",
-        "Cache-Control": "s-maxage=3600, stale-while-revalidate",
-        "Link": `<${HOST}/blog/${sanitizedSlug}>; rel="canonical"`,
-      },
+    const headers = new Headers({
+      "Content-Type": "text/markdown;charset=UTF-8",
+      "Cache-Control": "s-maxage=3600, stale-while-revalidate",
+      "Link": `<${HOST}/blog/${sanitizedSlug}>; rel="canonical"`,
     });
+    // Block traditional search engines from indexing the LLM markdown mirror pages
+    // to prevent duplicate content issues. AI crawlers are still welcome.
+    headers.append("X-Robots-Tag", "googlebot: noindex, nofollow");
+    headers.append("X-Robots-Tag", "bingbot: noindex, nofollow");
+
+    return new Response(output, { headers });
   } catch (error) {
     console.error(`[blog-markdown] Failed to process post "${sanitizedSlug}":`, error);
     return new Response("Failed to read post", {

--- a/app/(llms)/docs-markdown/[[...slug]]/route.ts
+++ b/app/(llms)/docs-markdown/[[...slug]]/route.ts
@@ -105,12 +105,16 @@ export async function GET(
 
     // Return as plain text for easy copying. Disable caching so this always runs
     // dynamically and returns fresh content from the docs.
-    return new Response(processedContent, {
-      headers: {
-        "Content-Type": "text/markdown;charset=UTF-8",
-        "Link": `<${canonicalUrl}>; rel="canonical"`,
-      },
+    const headers = new Headers({
+      "Content-Type": "text/markdown;charset=UTF-8",
+      "Link": `<${canonicalUrl}>; rel="canonical"`,
     });
+    // Block traditional search engines from indexing the LLM markdown mirror pages
+    // to prevent duplicate content issues. AI crawlers are still welcome.
+    headers.append("X-Robots-Tag", "googlebot: noindex, nofollow");
+    headers.append("X-Robots-Tag", "bingbot: noindex, nofollow");
+
+    return new Response(processedContent, { headers });
   } catch (error) {
     console.error("Failed to process document:", error);
     return new Response("Failed to read document", { status: 500, statusText: "Failed to read document" });


### PR DESCRIPTION
## What
Adds `X-Robots-Tag` response headers to the `/docs-markdown/` and `/blog-markdown/` route handlers to block Googlebot and Bingbot from indexing these pages.

## Why
These routes serve lightweight markdown mirrors of our docs/blog intended for AI crawlers. Without noindex headers, Google treats them as near-duplicate, low-styling versions of the main HTML pages and drops them into "Crawled - currently not indexed", wasting crawl budget.

## Notes
- Uses `Headers.append()` to set multiple `X-Robots-Tag` headers (one per bot), since a plain object cannot have duplicate keys
- Both routes already set a `Link: <canonical>` header pointing to the real page — this adds the noindex layer on top
- ⚠️ A follow-up PR (`pat/seo-robots-txt-llm-block`) adds `Disallow` rules in `robots.txt` for these directories — that PR should only be merged ~2 weeks after this one ships, to give Googlebot time to re-crawl and register the noindex before being blocked