### PR TITLE
content: add topic tags to all 168 blog posts

### DIFF
--- a/.cursor/commands/new-blog-post.md
+++ b/.cursor/commands/new-blog-post.md
@@ -6,6 +6,9 @@ Take any file, like a .md or .doc file, or raw text input, and create a new mark
 
 - Slugify the title for the filename. Only use lower-case characters and hyphens. DO NOT use dates, special characters, or spaces.
 - Write the frontmatter metadata using the @AGENTS.md as a guide.
+- Add a `tags` field with one or more topics from this list (pick all that apply):
+  - `"AI & Agents"`, `"Background Jobs & Scheduling"`, `"Company & Product News"`, `"Durable Execution"`, `"Engineering"`, `"Incidents & Security"`, `"Integrations & Partners"`, `"Next.js & Frameworks"`, `"Observability & Debugging"`, `"Queues & Flow Control"`, `"Realtime"`, `"SDKs & Languages"`, `"Tutorials & Guides"`, `"Workflows & Orchestration"`
+  - If a new topic is needed, add it here and also update the list in `AGENTS.md`.
 - Ensure all internal links are relative to the domain, not including `http://www.inngest.com`.
 - Use Ref Tags (e.g., `?ref=blog-introducing-checkpointing`) on internal links for marketing attribution. The ref tag should be in the format of `blog-<slugified-title>`.
 

--- a/components/v1/sections/Learn/ResourceExplorer.tsx
+++ b/components/v1/sections/Learn/ResourceExplorer.tsx
@@ -23,8 +23,8 @@ export default function ResourceExplorer({ posts }: { posts: PostCard[] }) {
     setSearch,
     resourceTypes,
     setResourceTypes,
-    topic,
-    setTopic,
+    topics,
+    setTopics,
     sort,
     setSort,
     allTopics,
@@ -78,13 +78,14 @@ export default function ResourceExplorer({ posts }: { posts: PostCard[] }) {
             }))}
           />
           <div className="hidden min-[380px]:block">
-            <SingleSelectDropdown
+            <MultiSelectDropdown
               label="Topics"
               trailing="filter"
               triggerClassName={FILTER_TRIGGER}
               iconVariant="large"
-              value={topic}
-              onChange={setTopic}
+              values={topics}
+              onChange={setTopics}
+              allValue="ALL"
               options={allTopics.map((t) => ({
                 value: t,
                 label: t === "ALL" ? "All" : t,

--- a/components/v1/sections/Learn/useLearnFilters.ts
+++ b/components/v1/sections/Learn/useLearnFilters.ts
@@ -10,7 +10,7 @@ export function useLearnFilters(posts: PostCard[]) {
   const [search, setSearch] = useState("");
   // Empty array = "All". Otherwise the set of specific types to show.
   const [resourceTypes, setResourceTypes] = useState<PostCard["type"][]>([]);
-  const [topic, setTopic] = useState<"ALL" | string>("ALL");
+  const [topics, setTopics] = useState<string[]>([]);
   const [sort, setSort] = useState<SortKey>("date-desc");
 
   const allTopics = useMemo(() => {
@@ -25,7 +25,7 @@ export function useLearnFilters(posts: PostCard[]) {
       .filter((p) => {
         if (resourceTypes.length > 0 && !resourceTypes.includes(p.type))
           return false;
-        if (topic !== "ALL" && !p.tags.includes(topic)) return false;
+        if (topics.length > 0 && !topics.some((t) => p.tags.includes(t))) return false;
         if (q) {
           const haystack = `${p.title} ${p.subtitle} ${p.tags.join(" ")}`.toLowerCase();
           if (!haystack.includes(q)) return false;
@@ -38,15 +38,15 @@ export function useLearnFilters(posts: PostCard[]) {
         const bT = b.date ? new Date(b.date).getTime() : 0;
         return sort === "date-asc" ? aT - bT : bT - aT;
       });
-  }, [posts, search, resourceTypes, topic, sort]);
+  }, [posts, search, resourceTypes, topics, sort]);
 
   return {
     search,
     setSearch,
     resourceTypes,
     setResourceTypes,
-    topic,
-    setTopic,
+    topics,
+    setTopics,
     sort,
     setSort,
     allTopics,

--- a/content/blog/2022-07-load-testing-event-queue.md
+++ b/content/blog/2022-07-load-testing-event-queue.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Workflows & Orchestration", "Tutorials & Guides", "Engineering"]
 focus: false
 heading: "Load testing an event-driven message queue"
 subtitle: How to quickly run load tests on event-driven queues via K6

--- a/content/blog/2023-10-27-fn-metrics-release.md
+++ b/content/blog/2023-10-27-fn-metrics-release.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Observability & Debugging"]
 heading: "New in observability: Function Metrics"
 subtitle: "Better observability into function runs"
 image: /assets/blog/fn-metrics/feature-image.png

--- a/content/blog/2023-11-29-metrics-with-timescale.md
+++ b/content/blog/2023-11-29-metrics-with-timescale.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Observability & Debugging", "Engineering"]
 focus: false
 heading: Building Metrics with TimescaleDB
 subtitle: How we built better observability into Inngest

--- a/content/blog/2023-12-22-2023-wrapped.mdx
+++ b/content/blog/2023-12-22-2023-wrapped.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 focus: false
 heading: "2023 Wrapped"
 subtitle: Over the past twelve months, we've shipped a lot and improved the DX across the board, our team has grown three-fold, and we were able to raise a seed round.

--- a/content/blog/2024-01-12-extending-the-range-of-your-astro-app.mdx
+++ b/content/blog/2024-01-12-extending-the-range-of-your-astro-app.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Background Jobs & Scheduling", "Tutorials & Guides", "Next.js & Frameworks"]
 focus: false
 heading: "Adding workflows to an Astro app with Inngest"
 subtitle: Learn how to extend the range of your Astro app with long-running processes, and when to do so.

--- a/content/blog/2024-08-16-incident-report.mdx
+++ b/content/blog/2024-08-16-incident-report.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Incidents & Security"]
 focus: false
 heading: "Incident report for August 16, 2024 - Function execution outage"
 subtitle: A full report on the incident that caused function execution to fail on August 16, 2024 UTC.

--- a/content/blog/2024-10-queue-retros.mdx
+++ b/content/blog/2024-10-queue-retros.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Incidents & Security"]
 focus: false
 featured: false
 heading: October 2024 queue retrospective

--- a/content/blog/2025-06-23-python-v0.5.mdx
+++ b/content/blog/2025-06-23-python-v0.5.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "SDKs & Languages"]
 heading: "Python SDK v0.5: AI, Pydantic, and more"
 image: /assets/blog/2025-06-23-python-v0.5/featured-image.png
 showSubtitle: true

--- a/content/blog/2025-10-24-october-incident-report.mdx
+++ b/content/blog/2025-10-24-october-incident-report.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Incidents & Security"]
 focus: false
 featured: false
 heading: October 2025 incident report

--- a/content/blog/2026-03-09-how-to-fix-nextjs-ai-route-failures.mdx
+++ b/content/blog/2026-03-09-how-to-fix-nextjs-ai-route-failures.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Tutorials & Guides", "Next.js & Frameworks"]
 heading: "How to Fix Next.js AI Route Failures (Without Restarting from Zero)"
 subtitle: "Add step-level durability to your Next.js AI routes so failures don't restart from zero—each step is independently retryable and memoized."
 image: /assets/blog/2026-03-09-how-to-fix-nextjs-ai-route-failures/featured-image.png

--- a/content/blog/2026-04-17-incident-report-for-april-15-2026.md
+++ b/content/blog/2026-04-17-incident-report-for-april-15-2026.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Background Jobs & Scheduling", "Incidents & Security"]
 focus: false
 heading: "Incident report for April 15, 2026 - Function scheduling and execution delays"
 subtitle: A full report on the incident that caused significant delays in function scheduling and execution for all customers.

--- a/content/blog/5-lessons-learned-from-taking-next-js-app-router-to-production.md
+++ b/content/blog/5-lessons-learned-from-taking-next-js-app-router-to-production.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Tutorials & Guides", "Next.js & Frameworks"]
 heading: "5 Lessons Learned From Taking Next.js App Router to Production"
 subtitle: "What did we learn from building and shipping our new app with the Next.js 13 App Router?"
 image: "/assets/blog/5-lessons-learned-from-taking-next-js-app-router-to-production/featured-image.png"

--- a/content/blog/accidentally-quadratic-evaluating-trillions-of-event-matches-in-real-time.mdx
+++ b/content/blog/accidentally-quadratic-evaluating-trillions-of-event-matches-in-real-time.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Realtime", "Engineering"]
 heading: 'Accidentally Quadratic: Evaluating trillions of event matches in real-time'
 subtitle: Building the expression engine that powers ephemeral event matching.
 showSubtitle: true

--- a/content/blog/after-the-agent-signs-in.mdx
+++ b/content/blog/after-the-agent-signs-in.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Integrations & Partners"]
 heading: "After the Agent Signs In"
 subtitle: "Orchestration has been the undefined pillar of Agent Experience. Stripe Projects just made it core infrastructure."
 showSubtitle: true

--- a/content/blog/agent-memory-mem0.mdx
+++ b/content/blog/agent-memory-mem0.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents"]
 heading: "Empowering Agents with Memory"
 image: /assets/blog/agent-memory-mem0/mem0-cover.png
 showSubtitle: false

--- a/content/blog/agentic-workflow-example.mdx
+++ b/content/blog/agentic-workflow-example.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Tutorials & Guides", "Next.js & Frameworks"]
 heading: "Agentic workflow example: importing CRM contacts with Next.js and OpenAI o1"
 subtitle: A reimagined contacts importer leveraging the power of reasoning models with Inngest
 showSubtitle: true

--- a/content/blog/agentkit-useagent-realtime-hook.mdx
+++ b/content/blog/agentkit-useagent-realtime-hook.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Workflows & Orchestration", "Realtime"]
 heading: "Introducing useAgent: One Hook to Stream Durable AI Workflows to the Frontend"
 image: /assets/blog/agentkit-use-agent/cover.png
 subtitle: "Multi-agent setups are hard to build. So we built useAgent: a one-line code for streaming real-time, multi-step backend workflows to the frontend."

--- a/content/blog/ai-agents-inngest-durable-steps.mdx
+++ b/content/blog/ai-agents-inngest-durable-steps.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Tutorials & Guides", "Next.js & Frameworks"]
 heading: "How to Build a Durable AI Agent with Inngest"
 subtitle: "Use Inngest's step primitives to build resilient, observable AI agents without a heavyweight framework."
 image: "/assets/blog/ai-agents-inngest-durable-steps/featured-image.jpg"

--- a/content/blog/ai-in-production-managing-capacity-with-flow-control.mdx
+++ b/content/blog/ai-in-production-managing-capacity-with-flow-control.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "AI & Agents"]
 heading: 'AI in production: Managing capacity with flow control'
 subtitle: What do you need to take your LLM based product from demo to production?
 showSubtitle: true

--- a/content/blog/ai-in-production-report-2026.mdx
+++ b/content/blog/ai-in-production-report-2026.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Observability & Debugging"]
 heading: "AI in Production: The 2026 Benchmark Report"
 subtitle: "We surveyed 130 backend, full-stack, and AI engineers about what it takes to run reliable AI workflows in production. We wanted to know what's causing failures, and which infrastructure choices—across orchestration, observability, evals, and agent frameworks—actually reduce the burden of reliability."
 showSubtitle: true

--- a/content/blog/ai-orchestration-with-agentkit-step-ai.mdx
+++ b/content/blog/ai-orchestration-with-agentkit-step-ai.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration"]
 heading: "Introducing AgentKit and step.ai:  orchestrating AI with confidence"
 subtitle: "The easiest way to build production-ready AI workflows with AgentKit and step.ai"
 showSubtitle: true

--- a/content/blog/ai-personalization-and-the-future-of-developer-docs.md
+++ b/content/blog/ai-personalization-and-the-future-of-developer-docs.md
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Tutorials & Guides", "SDKs & Languages"]
 heading: "AI Personalization and the Future of Developer Docs"
 subtitle: "Providing developer-specific examples to help developers learn how to use the Inngest SDK. The beginning of AI-personalized learning flows for users."
 image: /assets/blog/openai-durable-functions-with-inngest/featured-image.png

--- a/content/blog/announcing-batch-keys.mdx
+++ b/content/blog/announcing-batch-keys.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Company & Product News"]
 heading: "Announcing: Batch Keys"
 image: /assets/blog/announcing-batch-keys/featured-image.png
 showSubtitle: true

--- a/content/blog/announcing-connect.mdx
+++ b/content/blog/announcing-connect.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 heading: "Introducing Connect: Run low-latency Inngest Functions on servers"
 image: /assets/blog/announcing-connect/featured-image.png
 showSubtitle: false

--- a/content/blog/announcing-defer.mdx
+++ b/content/blog/announcing-defer.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Company & Product News"]
 heading: "Introducing defer(): Giving Follow-Up Work the Context it Never Had"
 image: /assets/blog/announcing-defers/featured-image.png
 showSubtitle: false

--- a/content/blog/announcing-function-runs-search.mdx
+++ b/content/blog/announcing-function-runs-search.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Observability & Debugging", "Company & Product News"]
 heading: "Announcing: Function runs search"
 subtitle: Instantly search across all your Function runs with advanced queries filtering on events and function runs properties.
 showSubtitle: true

--- a/content/blog/announcing-funding-from-a16z.mdx
+++ b/content/blog/announcing-funding-from-a16z.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Integrations & Partners", "Company & Product News"]
 heading: Inngest raises $6.1M led by a16z
 subtitle: Accelerating development of the reliability layer for modern applications
 showSubtitle: true

--- a/content/blog/announcing-inngest-seed-financing.mdx
+++ b/content/blog/announcing-inngest-seed-financing.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Integrations & Partners", "Company & Product News"]
 heading: Inngest raises $3M from GGV to build the reliable workflow platform for every developer
 subtitle: New round led by Glenn Solomon of GGV Capital, including Guillermo Rauch and Tom Preston-Werner
 image: /assets/blog/seed-financing/featured-image.png?v1

--- a/content/blog/announcing-inngest-series-a.mdx
+++ b/content/blog/announcing-inngest-series-a.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Observability & Debugging", "Company & Product News"]
 heading: "Iteration is the new product moat"
 image: /assets/blog/announcing-inngest-series-a/cover.jpg
 showSubtitle: false

--- a/content/blog/announcing-metrics-export.mdx
+++ b/content/blog/announcing-metrics-export.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Observability & Debugging", "Company & Product News"]
 heading: "Introducing: Metrics exports to Datadog, Grafana and more"
 image: /assets/blog/announcing-metrics-export/featured-image.png
 showSubtitle: true

--- a/content/blog/announcing-pcxi-hackathon.mdx
+++ b/content/blog/announcing-pcxi-hackathon.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Integrations & Partners", "Company & Product News"]
 heading: Announcing Summer PCXI Hackathon
 subtitle: "Win $2,500 in a thrilling two-week hackathon using the PCXI stack: Prisma, Xata, Clerk, Inngest 🎉"
 image: /assets/blog/announcing-summer-pxci-hackathon/featured-image-light-2x1.png

--- a/content/blog/announcing-realtime.mdx
+++ b/content/blog/announcing-realtime.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Realtime", "Company & Product News"]
 heading: "Developer Preview: Realtime"
 image: /assets/blog/announcing-realtime/featured-image.png
 showSubtitle: false

--- a/content/blog/announcing-replay-the-death-of-the-dead-letter-queue.mdx
+++ b/content/blog/announcing-replay-the-death-of-the-dead-letter-queue.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Company & Product News"]
 heading: "Announcing: Inngest Replay"
 subtitle: The death of the dead-letter queue.
 showSubtitle: true

--- a/content/blog/announcing-step-fetch.mdx
+++ b/content/blog/announcing-step-fetch.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 heading: "Introducing: step.fetch()"
 image: /assets/blog/announcing-step-fetch/featured-image.png
 showSubtitle: true

--- a/content/blog/announcing-the-constraint-api.mdx
+++ b/content/blog/announcing-the-constraint-api.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Queues & Flow Control", "Engineering", "Company & Product News"]
 heading: "The Constraint API: Scaling flow control beyond millions of RPS"
 image: /assets/blog/constraint-api/featured-image.png
 showSubtitle: true

--- a/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
+++ b/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Background Jobs & Scheduling", "Tutorials & Guides"]
 heading: Background agents are here. Your orchestration isn't ready.
 subtitle: Every six months, the "right" way to build an AI agent changes. How can you design for the next rewrite?
 image: /assets/blog/background-agents-are-here/featured-image-gold.png

--- a/content/blog/background-jobs-realtime-nextjs.mdx
+++ b/content/blog/background-jobs-realtime-nextjs.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Realtime", "Background Jobs & Scheduling", "Tutorials & Guides", "Next.js & Frameworks"]
 heading: How to add background jobs with real-time updates to a Next.js application
 subtitle: Learn how to implement background jobs in Next.js using Inngest.
 image: "/assets/blog/background-jobs-realtime-nextjs/featured-image.jpg"

--- a/content/blog/banger-video-rendering-pipeline.mdx
+++ b/content/blog/banger-video-rendering-pipeline.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Background Jobs & Scheduling", "Tutorials & Guides"]
 heading: A Deep Dive into a Video Rendering Pipeline
 showSubtitle: true
 subtitle: Banger.Show is a video app maker that heavily relies on background data processing

--- a/content/blog/branch-environments.mdx
+++ b/content/blog/branch-environments.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Company & Product News"]
 heading: "Introducing Branch Environments: Full-Stack Testing for Every Branch with Inngest"
 subtitle: Modern workflow for your business-critical code
 image: /assets/blog/branch-environments/featured-image.png

--- a/content/blog/build-more-reliable-workflows-with-events.mdx
+++ b/content/blog/build-more-reliable-workflows-with-events.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Observability & Debugging"]
 heading: "Building More Reliable Workflows With Events"
 subtitle: Run critical code with guarantees and observability
 image: /assets/blog/build-more-reliable-workflows-with-events.jpg

--- a/content/blog/build-self-learning-agent.mdx
+++ b/content/blog/build-self-learning-agent.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Engineering"]
 heading: "I built a self-improving agent. It taught itself to cheat."
 subtitle: "I built a self-improving agent on Inngest, then learned the hard part wasn't retraining prompts, but stopping the system from gaming its own evaluation."
 showSubtitle: true

--- a/content/blog/building-a-discord-pr-collab-tool-in-an-hour.mdx
+++ b/content/blog/building-a-discord-pr-collab-tool-in-an-hour.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Tutorials & Guides", "Integrations & Partners"]
 heading: "Building a Discord PR collaboration tool in an hour"
 subtitle: How we built a reliable webhook based PR collaboration tool in less time your average company's sprint planning meeting
 image: "/assets/blog/discordbot.jpg"

--- a/content/blog/building-a-multi-model-ai-support-agent.mdx
+++ b/content/blog/building-a-multi-model-ai-support-agent.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Realtime", "Tutorials & Guides"]
 heading: "Building a Multi-Model AI Support Agent"
 image: /assets/blog/building-a-multi-model-ai-support-agent/cover.png
 showSubtitle: false

--- a/content/blog/building-a-realtime-websocket-app-using-sveltekit.md
+++ b/content/blog/building-a-realtime-websocket-app-using-sveltekit.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Realtime", "Tutorials & Guides", "Next.js & Frameworks"]
 focus: false
 heading: "Building a real-time websocket app using SvelteKit"
 subtitle: Our experience building https://typedwebhook.tools in 2 days using SvelteKit.

--- a/content/blog/building-agentic-workflows-that-can-query.mdx
+++ b/content/blog/building-agentic-workflows-that-can-query.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Tutorials & Guides"]
 heading: "Building Agentic Workflows That Query Millions of Rows: A Real-World Guide with AgentKit"
 image: /assets/blog/building-agentic-workflows-that-can-query/header.jpg
 showSubtitle: false

--- a/content/blog/building-an-event-driven-queue.md
+++ b/content/blog/building-an-event-driven-queue.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Workflows & Orchestration", "Tutorials & Guides"]
 focus: false
 heading: "Building an event-driven queue based on common standards"
 subtitle: The design decisions and architecture for a next-gen queuing platform

--- a/content/blog/building-auth-workflows-with-clerk-integration.mdx
+++ b/content/blog/building-auth-workflows-with-clerk-integration.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Tutorials & Guides", "Integrations & Partners"]
 heading: Building auth workflows with Clerk and Inngest
 subtitle: How to trigger Inngest functions with Clerk events in the new integration
 showSubtitle: true

--- a/content/blog/building-durable-agents.mdx
+++ b/content/blog/building-durable-agents.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Tutorials & Guides"]
 heading: "Building Durable AI Agents: A Guide to Context Engineering"
 image: /assets/blog/building-durable-agents/cover.png
 showSubtitle: false

--- a/content/blog/building-educational-typescript-tooling.mdx
+++ b/content/blog/building-educational-typescript-tooling.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["SDKs & Languages"]
 focus: false
 heading: "Building educational TypeScript tooling"
 subtitle: Create inituitive TypeScript libraries; don't make your user open the docs.

--- a/content/blog/building-the-inngest-queue-pt-i-fairness-multi-tenancy.mdx
+++ b/content/blog/building-the-inngest-queue-pt-i-fairness-multi-tenancy.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Engineering"]
 heading: How we built a fair multi-tenant queuing system
 subtitle: Building the Inngest queue - Part I
 showSubtitle: true

--- a/content/blog/building-webhooks-that-scale.md
+++ b/content/blog/building-webhooks-that-scale.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Background Jobs & Scheduling", "Integrations & Partners", "Engineering"]
 focus: false
 heading: "Building Webhooks That Scale"
 subtitle: Lessons learned scaling webhooks to millions of requests a day

--- a/content/blog/bulk-cancellation-api.mdx
+++ b/content/blog/bulk-cancellation-api.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 heading: Bulk cancellation API
 subtitle: Cancel a time range of functions using the REST API.
 image: /assets/blog/bulk-cancellation-api/featured-image.png

--- a/content/blog/bulk-cancellation.mdx
+++ b/content/blog/bulk-cancellation.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 heading: "Bulk cancellation UI: the latest addition to Inngest's recovery tool suite"
 subtitle: Handle incidents
 showSubtitle: true

--- a/content/blog/completing-the-jamstack.mdx
+++ b/content/blog/completing-the-jamstack.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Next.js & Frameworks", "Company & Product News"]
 heading: "Completing the Jamstack: What's needed in 2022?"
 subtitle: "Where the Jamstack is today and what is left to complete the vision."
 image: /assets/blog/completing-the-jamstack/featured-image.png

--- a/content/blog/context-engineering-in-practice.mdx
+++ b/content/blog/context-engineering-in-practice.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Tutorials & Guides"]
 heading: "Context Engineering in Practice: Building an AI Research Assistant"
 image: /assets/blog/context-engineering-in-practice/cover.png
 showSubtitle: false

--- a/content/blog/context-engineering-is-software-engineering-for-llms.mdx
+++ b/content/blog/context-engineering-is-software-engineering-for-llms.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration"]
 heading: "Context engineering is just software engineering for LLMs"
 image: /assets/blog/context-engineering-is-software-engineering-for-llms/cover.jpg
 showSubtitle: false

--- a/content/blog/cross-language-support-with-new-sdks.mdx
+++ b/content/blog/cross-language-support-with-new-sdks.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Background Jobs & Scheduling", "SDKs & Languages"]
 heading: "Cross-language support and new Inngest SDKs: Python, Go, with more to come"
 subtitle: "The Inngest SDKs provide a language- and cloud-agnostic way to create fault-tolerant, long-running functions with built-in flow control."
 showSubtitle: true

--- a/content/blog/cursor-agentkit-e2b.mdx
+++ b/content/blog/cursor-agentkit-e2b.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Tutorials & Guides", "Next.js & Frameworks", "Integrations & Partners"]
 focus: false
 heading: "Tutorial: Replicating Cursor's Agent mode with E2B and AgentKit"
 subtitle: Learn how to build the famous Cursor Agent mode with our AI Agent framework

--- a/content/blog/cve-2026-42047.mdx
+++ b/content/blog/cve-2026-42047.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["SDKs & Languages", "Incidents & Security"]
 focus: false
 heading: "Security vulnerability in v3 TypeScript SDK"
 subtitle: "CVE-2026-42047"

--- a/content/blog/debouncing-in-queuing-systems-optimizing-efficiency-in-async-workflows.mdx
+++ b/content/blog/debouncing-in-queuing-systems-optimizing-efficiency-in-async-workflows.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Workflows & Orchestration"]
 heading: "Debouncing in Queueing Systems: Optimizing Efficiency in Asynchronous Workflows"
 subtitle: Explore backend message queuing systems, implementing debouncing in Postgres, and simplifying the process with Inngest.
 showSubtitle: true

--- a/content/blog/deepseek-r1-step-ai.mdx
+++ b/content/blog/deepseek-r1-step-ai.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents"]
 focus: false
 heading: "DeepSeek-R1 in practice with step.ai"
 subtitle: A deep dive into DeepSeek-R1's Multi-Lingual and Agentic RAG Capabilities

--- a/content/blog/digitalocean-marketplace.mdx
+++ b/content/blog/digitalocean-marketplace.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Integrations & Partners", "Company & Product News"]
 heading: "Inngest is now available on the DigitalOcean Marketplace"
 image: /assets/blog/digital-ocean-marketplace/cover.png
 subtitle: "Developers shouldn't be slowed down by infrastructure. By integrating with DigitalOcean, developers can now go from prototype to millions of users without any infrastructure work."

--- a/content/blog/discussing-10-years-of-orchestration-challenges.mdx
+++ b/content/blog/discussing-10-years-of-orchestration-challenges.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Integrations & Partners"]
 heading: "Discussing 10 years of orchestration challenges with Erik Munson, founding engineer at Day AI, ex-HubSpot, and Netflix Engineer"
 image: /assets/blog/discussing-10-years-of-orchestration-challenges/cover-v2.jpg
 showSubtitle: false

--- a/content/blog/durable-execution-key-to-harnessing-ai-agents.mdx
+++ b/content/blog/durable-execution-key-to-harnessing-ai-agents.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Workflows & Orchestration"]
 heading: "Durable Execution: The Key to Harnessing AI Agents in Production"
 subtitle: "AI Agents introduce multiple points of failure that traditional retry logic cannot handle. Durable execution provides the automatic state persistence, retries, and workflow resumption that make agents production-ready."
 image: /assets/blog/durable-execution-key-to-harnessing-ai-agents/featured-image.png

--- a/content/blog/durable-functions-a-visual-javascript-primer.mdx
+++ b/content/blog/durable-functions-a-visual-javascript-primer.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Tutorials & Guides"]
 heading: "What are Durable Functions? A visual JavaScript primer"
 image: /assets/blog/durable-functions-a-visual-javascript-primer/featured-image.png
 showSubtitle: false

--- a/content/blog/edge-event-api-beta.mdx
+++ b/content/blog/edge-event-api-beta.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 heading: "Edge Event API Beta: Lower latency from everywhere"
 subtitle: Targeting sub 100ms response times from anywhere in the world
 showSubtitle: true

--- a/content/blog/eliminating-latency-ai-workflows.mdx
+++ b/content/blog/eliminating-latency-ai-workflows.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Workflows & Orchestration", "Tutorials & Guides"]
 heading: "Eliminating latency in AI workflows: How to avoid the durability tradeoff"
 subtitle: "Every durable execution system adds some latency between steps. It's the tax we pay for reliability. Here's how to eliminate it."
 image: /assets/blog/eliminating-latency-ai-workflows/featured-image.png

--- a/content/blog/enhanced-observability-traces-and-metrics.mdx
+++ b/content/blog/enhanced-observability-traces-and-metrics.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Observability & Debugging"]
 heading: "Enhanced observability with Inngest: Waterfall trace view and advanced monitoring"
 subtitle: A new era for monitoring durable functions
 showSubtitle: true

--- a/content/blog/etl-via-inngest.mdx
+++ b/content/blog/etl-via-inngest.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Background Jobs & Scheduling"]
 heading: "Every app you've built is an ETL pipeline"
 subtitle: (you just didn't call it that)
 showSubtitle: true

--- a/content/blog/event-batching.mdx
+++ b/content/blog/event-batching.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control"]
 heading: "Introducing Event Batching: Handling data at scale"
 subtitle: Providing a way to handle high load events, and processing them in bulk
 image: /assets/blog/event-batching/main.png

--- a/content/blog/event-driven-infrastructure-inventory-inngest-netbox.mdx
+++ b/content/blog/event-driven-infrastructure-inventory-inngest-netbox.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Integrations & Partners"]
 heading: "Event-driven infrastructure inventory with Inngest and NetBox"
 subtitle: "As we scale our datacenter footprint, we consolidated Ansible, libvirt, and NetBox inventory sync into a single Go app—using Inngest events instead of scattered coordination logic."
 showSubtitle: true

--- a/content/blog/explicit-apis-vs-magic-directives.mdx
+++ b/content/blog/explicit-apis-vs-magic-directives.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Queues & Flow Control", "Workflows & Orchestration"]
 heading: "Explicit APIs vs Magic Directives"
 image: /assets/blog/explicit-apis/cover.png
 showSubtitle: true

--- a/content/blog/five-lessons-for-context-engineering.mdx
+++ b/content/blog/five-lessons-for-context-engineering.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents"]
 heading: "Five Critical Lessons for Context Engineering"
 image: /assets/blog/five-lessons-for-context-engineering/cover.png
 showSubtitle: true

--- a/content/blog/fixing-multi-tenant-queueing-concurrency-problems.mdx
+++ b/content/blog/fixing-multi-tenant-queueing-concurrency-problems.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control"]
 heading: Fixing noisy neighbor problems in multi-tenant queueing systems
 subtitle: Ensuring fairness and consistent performance for all users with concurrency controls
 showSubtitle: true

--- a/content/blog/hanging-promises-for-control-flow.mdx
+++ b/content/blog/hanging-promises-for-control-flow.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["SDKs & Languages"]
 heading: "You can't cancel a JavaScript promise (except sometimes you can)"
 subtitle: "A promise that never resolves is a surprisingly clean way to interrupt an async function."
 image: /assets/blog/hanging-promises-for-control-flow/featured-image.jpg

--- a/content/blog/how-durable-workflow-engines-work.mdx
+++ b/content/blog/how-durable-workflow-engines-work.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Queues & Flow Control", "Workflows & Orchestration"]
 heading: "How a durable workflow engine works:  you might not need a queue"
 subtitle: Breaking down how a durable workflow engine works, and how event-driven workflow engines improve DX.
 image: /assets/blog/durable-workflow-engines.png

--- a/content/blog/how-i-built-an-mtg-deck-analyzer-with-tanstack-start-and-inngest.mdx
+++ b/content/blog/how-i-built-an-mtg-deck-analyzer-with-tanstack-start-and-inngest.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Queues & Flow Control", "Realtime", "Tutorials & Guides", "Next.js & Frameworks"]
 heading: "How I Built an MTG Deck Analyzer with TanStack Start and Inngest"
 subtitle: "I was looking for a side project to test some real concurrency. A Commander deck analyzer turned out to be the perfect excuse. Here's how I used Inngest's durable functions and Realtime to fan out parallel steps and stream results live to the UI."
 showSubtitle: true

--- a/content/blog/how-to-build-a-production-ai-image-generation-pipeline-with-fal-ai-and-inngest.mdx
+++ b/content/blog/how-to-build-a-production-ai-image-generation-pipeline-with-fal-ai-and-inngest.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "AI & Agents", "Workflows & Orchestration", "Observability & Debugging", "Tutorials & Guides", "Integrations & Partners"]
 heading: "How to Build a Production AI Image Generation Pipeline with fal.ai and Inngest"
 subtitle: "fal.ai runs hundreds of models at scale. Inngest orchestrates the workflow around them — retries, async coordination, per-user fairness, and observability. Here's how the two work together to build a full media pipeline."
 image: /assets/blog/how-to-build-a-production-ai-image-generation-pipeline-with-fal-ai-and-inngest/featured-image.png

--- a/content/blog/how-to-solve-nextjs-timeouts.mdx
+++ b/content/blog/how-to-solve-nextjs-timeouts.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Tutorials & Guides", "Next.js & Frameworks"]
 heading: "How to solve Next.js timeouts"
 subtitle: Solving Next.js timeout issues isn't only about increasing the timeout but also using the right tools for the job.
 showSubtitle: true

--- a/content/blog/how-we-built-insights-ai-with-inngest.mdx
+++ b/content/blog/how-we-built-insights-ai-with-inngest.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Observability & Debugging", "Engineering"]
 heading: "How we built Insights AI with Inngest"
 subtitle: "How we shipped Insights AI, what we learned about building agentic features, and why dogfooding your own infrastructure actually works."
 image: /assets/blog/how-we-built-insights-ai-with-inngest/featured-image.png

--- a/content/blog/how-we-used-inngest-queues-to-build-inngest-native-cron-scheduler.mdx
+++ b/content/blog/how-we-used-inngest-queues-to-build-inngest-native-cron-scheduler.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Queues & Flow Control", "Background Jobs & Scheduling", "Engineering"]
 heading: "How we used Inngest Queues to build Inngest's native Cron Scheduler"
 subtitle: How we improved reliability of our cron scheduler by rebuilding it on top of our own durable queue primitives.
 image: "/assets/blog/cron-scheduler-queues/featured-image.jpg"

--- a/content/blog/import-ecommerce-api-data-in-seconds.mdx
+++ b/content/blog/import-ecommerce-api-data-in-seconds.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Tutorials & Guides", "Next.js & Frameworks", "Integrations & Partners"]
 heading: How to import 1000s of items from any E-commerce API in seconds with serverless functions
 subtitle: Import data from Shopify, WooCommerce or BigCommerce APIs reliably and quickly
 image: /assets/blog/import-ecommerce-data.png?v=2

--- a/content/blog/improved-error-handling.mdx
+++ b/content/blog/improved-error-handling.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["SDKs & Languages"]
 heading: Improved error handling in Inngest SDKs
 subtitle: Using native language primitives to handle failed steps
 showSubtitle: true

--- a/content/blog/inngest-1-0-announcing-self-hosting-support.mdx
+++ b/content/blog/inngest-1-0-announcing-self-hosting-support.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Company & Product News"]
 heading: Announcing Inngest self-hosting
 subtitle: The easiest way to self-host durable execution.
 showSubtitle: true

--- a/content/blog/inngest-add-super-powers-to-serverless-functions.mdx
+++ b/content/blog/inngest-add-super-powers-to-serverless-functions.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Next.js & Frameworks", "Company & Product News"]
 heading: Inngest - Add Superpowers To Serverless Functions
 subtitle: Introducing the next version of Inngest!
 image: /assets/blog/inngest-announcement-april-2023/featured-image.png

--- a/content/blog/inngest-ai-dev-tools.mdx
+++ b/content/blog/inngest-ai-dev-tools.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Integrations & Partners"]
 heading: "Inngest, meet your coding agent"
 subtitle: "Official Inngest plugins and skills for Claude Code, Codex, Cursor, and whatever agent you already use."
 showSubtitle: true

--- a/content/blog/inngest-replit-vibe-code-ai-agents.mdx
+++ b/content/blog/inngest-replit-vibe-code-ai-agents.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Integrations & Partners", "Company & Product News"]
 heading: "Announcing Inngest + Replit: Vibe code your agents"
 image: /assets/blog/replit-cover.jpg
 subtitle: "Replit’s agent builder is powered by Inngest. Novice builders can now vibe code durable, complex agents quickly. Not a vibe coder? Read on to learn exactly how Replit built on top of Inngest, so you can do the same."

--- a/content/blog/inngest-stripe-projects-ship-durable-apps-without-leaving-the-terminal.mdx
+++ b/content/blog/inngest-stripe-projects-ship-durable-apps-without-leaving-the-terminal.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Integrations & Partners"]
 heading: "Inngest + Stripe Projects: Ship Durable Apps Without Leaving the Terminal"
 subtitle: "Inngest is an official launch partner for Stripe Projects—a new agent-first protocol for standing up production stacks without hopping between dashboards, digging around docs, or copying keys."
 showSubtitle: true

--- a/content/blog/insights-ai.mdx
+++ b/content/blog/insights-ai.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Observability & Debugging"]
 heading: "Meet Insights AI, Your Inngest Production Assistant"
 image: /assets/blog/insights-ai/cover.jpg
 subtitle: Ask Insights any question about your production events and workflow runs.

--- a/content/blog/insights-query-events-and-runs.mdx
+++ b/content/blog/insights-query-events-and-runs.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Observability & Debugging"]
 heading: "Introducing Inngest Insights: Query Your Events and Runs Without Extra Plumbing"
 image: /assets/blog/insights-query-events-and-runs/cover.png
 subtitle: We were tired of writing custom metrics and grepping logs every time we wanted to know what happened in a run. So, we built Insights, now in beta for all Inngest users.

--- a/content/blog/insights-schema-explorer-shared-queries.mdx
+++ b/content/blog/insights-schema-explorer-shared-queries.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Observability & Debugging"]
 heading: "Insights just got more powerful: Schema explorer and shared queries"
 image: /assets/blog/insights-schema-explorer-shared-queries/cover.jpg
 showSubtitle: false

--- a/content/blog/interactive-clis-with-bubbletea.md
+++ b/content/blog/interactive-clis-with-bubbletea.md
@@ -1,4 +1,5 @@
 ---
+tags: ["SDKs & Languages", "Engineering"]
 heading: "Rapidly building interactive CLIs in Go with Bubbletea"
 subtitle: Our product is just different enough to make our CLI require really good interactivity.  We bundle an interactive event browser in our CLI.  Here's how it's built.
 image: "/assets/blog/interactive-clis-with-bubbletea.jpg?v=2022-04-28"

--- a/content/blog/introducing-checkpointing.mdx
+++ b/content/blog/introducing-checkpointing.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Workflows & Orchestration"]
 heading: "Introducing Checkpointing: Near-zero latency for durable workflows"
 image: /assets/blog/introducing-checkpointing/cover.jpg
 showSubtitle: false

--- a/content/blog/introducing-cli-replays.md
+++ b/content/blog/introducing-cli-replays.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 focus: false
 heading: "Introducing CLI Replays"
 subtitle: Battle-test your local code with real production events.

--- a/content/blog/introducing-dark-mode.mdx
+++ b/content/blog/introducing-dark-mode.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 heading: Introducing dark mode
 subtitle: Dark mode is here. Customize your Inngest experience your way.
 image: /assets/blog/introducing-dark-mode/featured-image.png

--- a/content/blog/introducing-durable-endpoints.mdx
+++ b/content/blog/introducing-durable-endpoints.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Workflows & Orchestration"]
 heading: "Introducing Durable Endpoints: Durability beyond workflows"
 image: /assets/blog/introducing-durable-endpoints/cover.png
 showSubtitle: false

--- a/content/blog/introducing-enhanced-traces.mdx
+++ b/content/blog/introducing-enhanced-traces.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Observability & Debugging"]
 heading: "Introducing: Enhanced Traces"
 subtitle: "We're bringing richer execution data to the front end, making it easier to debug your jobs and workflows with enhanced Traces."
 image: /assets/blog/introducing-enhanced-traces/featured-image.png

--- a/content/blog/introducing-extended-traces.mdx
+++ b/content/blog/introducing-extended-traces.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Observability & Debugging"]
 heading: "Introducing: Extended Traces"
 image: /assets/blog/introducing-extended-traces/cover.png
 showSubtitle: false

--- a/content/blog/introducing-inngest-dev-server.md
+++ b/content/blog/introducing-inngest-dev-server.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration"]
 heading: "Introducing Inngest DevServer"
 subtitle: "The first tool purposely designed for event-driven asynchronous system local development"
 image: "/assets/blog/introducing-inngest-dev-server/featured-image.jpg"

--- a/content/blog/introducing-inngest.md
+++ b/content/blog/introducing-inngest.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration"]
 # focus sets this blog post as the blog focus.  The latest post will be focused if there's
 # > 1 focus post.
 focus: false

--- a/content/blog/introducing-workflow-kit.mdx
+++ b/content/blog/introducing-workflow-kit.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration"]
 heading: "Introducing Workflow Kit by Inngest"
 subtitle: The fastest way to build workflow UIs
 showSubtitle: true

--- a/content/blog/kafka-achilles.mdx
+++ b/content/blog/kafka-achilles.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Realtime"]
 heading: "Kafka's Achilles, it wasn't designed for application queuing"
 image: /assets/blog/kafka-achilles/cover.jpg
 showSubtitle: false

--- a/content/blog/launch-week-day-1-unbreakable-apis.mdx
+++ b/content/blog/launch-week-day-1-unbreakable-apis.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Queues & Flow Control", "Observability & Debugging"]
 heading: "Introducing Step.Run Everywhere: Build Unbreakable APIs"
 image: /assets/blog/launch-week-day-1-unbreakable-apis/cover.png
 showSubtitle: false

--- a/content/blog/launch-week-recap.mdx
+++ b/content/blog/launch-week-recap.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["SDKs & Languages", "Company & Product News"]
 heading: "Launch Week Recap"
 subtitle: "A look at all the releases of the past week: from Replay and per-step error handling to new SKDs and integrations."
 showSubtitle: true

--- a/content/blog/lead-enrichment-pipeline-durable-execution-inngest.mdx
+++ b/content/blog/lead-enrichment-pipeline-durable-execution-inngest.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Queues & Flow Control", "AI & Agents", "Tutorials & Guides"]
 heading: "How to make your lead enrichment pipeline durable"
 subtitle: "Learn how to build a scalable, multi-step lead enrichment and qualification pipeline using Inngest's durable execution and concurrency controls. Handles tens of thousands of leads per day across multiple enrichment providers, LLM scoring, and CRM writes—without queue sprawl or provisioning overhead."
 showSubtitle: true

--- a/content/blog/lifecycle-emails-with-resend.mdx
+++ b/content/blog/lifecycle-emails-with-resend.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Tutorials & Guides", "Next.js & Frameworks", "Integrations & Partners"]
 heading: "Sending customer lifecycle emails with Resend and Inngest"
 subtitle: "How to Send Effective and Reliable Emails in your Next.js Applications with Resend & Inngest"
 image: "/assets/blog/lifcycle-emails-resend/customer-lifecycle-emails-with-resend-inngest.png"

--- a/content/blog/message-bus-vs-queues.md
+++ b/content/blog/message-bus-vs-queues.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control"]
 heading: "Message queue vs message bus: the practical differences"
 subtitle: We explore the difference between queueing systems and message busses
 image: "/assets/blog/queue-vs-bus.png"

--- a/content/blog/migrating-across-clouds-with-zero-downtime.mdx
+++ b/content/blog/migrating-across-clouds-with-zero-downtime.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration"]
 heading: "Migrating long running workflows across clouds with zero downtime"
 subtitle: "How the Inngest system is designed to help you migrate across clouds with minimal effort."
 showSubtitle: true

--- a/content/blog/migrating-from-vite-to-nextjs.mdx
+++ b/content/blog/migrating-from-vite-to-nextjs.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Tutorials & Guides", "Next.js & Frameworks"]
 heading: "Migrating from Vite to Next.js"
 subtitle: A how-to guide
 image: /assets/blog/migrating-from-vite-to-nextjs/featured-image.png

--- a/content/blog/migrating-off-nextjs-tanstack-start.mdx
+++ b/content/blog/migrating-off-nextjs-tanstack-start.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Next.js & Frameworks", "Engineering"]
 heading: "Reducing local dev time by 83%: Why we migrated off Next.js"
 subtitle: "We care a lot about developer experience. But it's hard to build beautiful experiences for customers, while grinding through 10-12 second page load times. Here's how—and why—our team migrated from Next.js to Tanstack Start."
 image: /assets/blog/migrating-off-nextjs-tanstack-start/featured-image.png

--- a/content/blog/modern-serverless-job-scheduler.mdx
+++ b/content/blog/modern-serverless-job-scheduler.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Background Jobs & Scheduling", "Next.js & Frameworks"]
 heading: "Modern serverless job schedulers"
 subtitle: "Almost all developers use job schedulers stuck in the past.  This post explores our modern system that improves dev UX with better tooling"
 image: "/assets/blog/serverless-job-scheduler.jpg"

--- a/content/blog/multi-tenant-ai-platform-flow-control.mdx
+++ b/content/blog/multi-tenant-ai-platform-flow-control.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "AI & Agents", "Tutorials & Guides"]
 heading: "Your multi-tenant AI platform fails without flow control"
 subtitle: "If you're building a platform where every customer request will hit the same OpenAI bill, you need the ability to slice and shape concurrency at a per-tenant level."
 showSubtitle: true

--- a/content/blog/mux-migrating-video-collections.mdx
+++ b/content/blog/mux-migrating-video-collections.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Tutorials & Guides", "Integrations & Partners"]
 heading: Migrating videos across platforms reliably - A look into Mux's Truckload project
 showSubtitle: false
 subtitle: Dave Kiss shares his takeaways from building Truckload, a project which simplifies heavy video migration between hosting platforms.

--- a/content/blog/neon-postgres-database-triggers-for-durable-functions.mdx
+++ b/content/blog/neon-postgres-database-triggers-for-durable-functions.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Integrations & Partners"]
 heading: "Neon + Inngest: Trigger durable functions from database changes"
 subtitle: A new integration for Postgres database events
 showSubtitle: true

--- a/content/blog/next-generation-ai-workflows.mdx
+++ b/content/blog/next-generation-ai-workflows.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Tutorials & Guides"]
 heading: "MEGA SEO: Building the next generation of blogging with AI workflows"
 subtitle: Joe Adams from MEGA SEO shares how Inngest enabled them to build AI workflows that would have been difficult or impossible to achieve with SQS.
 showSubtitle: false

--- a/content/blog/nextjs-serverless-vs-durable-functions.mdx
+++ b/content/blog/nextjs-serverless-vs-durable-functions.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Queues & Flow Control", "Workflows & Orchestration", "Background Jobs & Scheduling", "Next.js & Frameworks"]
 heading: "Next.js Serverless Functions vs Durable Functions"
 image: /assets/blog/nextjs-serverless-vs-durable-functions/featured-image-2.png
 showSubtitle: true

--- a/content/blog/nextjs-trpc-inngest.md
+++ b/content/blog/nextjs-trpc-inngest.md
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Tutorials & Guides", "Next.js & Frameworks"]
 heading: "Building an Event Driven Video Processing Workflow with Next.js, tRPC, and Inngest"
 subtitle: "How Badass Courses built a self-service video publishing workflow for Kent C. Dodds with AI generated transcripts and subtitles."
 image: "/assets/blog/nextjs-trpc-inngest/epic-web-kent-c-dodds.png"

--- a/content/blog/no-lost-updates-python-asyncio.mdx
+++ b/content/blog/no-lost-updates-python-asyncio.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "SDKs & Languages"]
 heading: "What Python's asyncio primitives get wrong about shared state"
 subtitle: "We tried Event, Condition, and Queue. Each one gets closer but still breaks under real concurrency. Here's the observable pattern that finally works."
 showSubtitle: true

--- a/content/blog/no-workers-necessary-nodejs-express.mdx
+++ b/content/blog/no-workers-necessary-nodejs-express.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Background Jobs & Scheduling", "Next.js & Frameworks"]
 heading: No workers necessary - Simple background jobs with Node and Express
 subtitle: Skip the queue and workers.
 image: /assets/blog/no-workers-necessary-nodejs/featured-image.jpg

--- a/content/blog/node-worker-threads.mdx
+++ b/content/blog/node-worker-threads.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Next.js & Frameworks", "SDKs & Languages", "Engineering"]
 heading: "Node.js worker threads are problematic, but they work great for us"
 subtitle: "Worker threads solve real problems, but they come with constraints that Go, Rust, and Python developers would never expect. Here's what we learned moving Inngest Connect's internals off the main thread."
 showSubtitle: true

--- a/content/blog/open-source-event-driven-queue.md
+++ b/content/blog/open-source-event-driven-queue.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Workflows & Orchestration", "Next.js & Frameworks", "Company & Product News"]
 heading: "Open sourcing Inngest"
 subtitle: "The open source, serverless event-driven platform for developers."
 image: "/assets/blog/open-source-event-driven-queue.jpg"

--- a/content/blog/opentelemetry-nodejs-tracing-express-inngest.mdx
+++ b/content/blog/opentelemetry-nodejs-tracing-express-inngest.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Observability & Debugging", "Tutorials & Guides", "Next.js & Frameworks"]
 heading: "How to Implement OpenTelemetry Tracing in Your Node.js Application"
 image: /assets/blog/opentelemetry-nodejs-tracing-express-inngest/cover.png
 showSubtitle: false

--- a/content/blog/principles-of-durable-execution.mdx
+++ b/content/blog/principles-of-durable-execution.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution"]
 heading: The Principles of Durable Execution Explained
 subtitle: Learn what Durable Execution is, how it works, and why it's beneficial to your system.
 image: /assets/blog/principles-of-durable-execution/featured-image.png

--- a/content/blog/principles-of-production-ai.mdx
+++ b/content/blog/principles-of-production-ai.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration"]
 heading: "The Principles of Production AI"
 subtitle: How LLM evaluations, guardrails, and orchestration shape safe and reliable AI experiences.
 showSubtitle: true

--- a/content/blog/product-updates-feb-08.md
+++ b/content/blog/product-updates-feb-08.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 heading: "Product updates:  Feb 8, 2022"
 subtitle: What's fresh out of the oven recently, and what's cooking?  Here's our bi-weekly product deep dive.
 image: "/assets/blog/product-updates.jpg"

--- a/content/blog/product-updates-jan-18.md
+++ b/content/blog/product-updates-jan-18.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 heading: "Product updates:  Jan 18, 2022"
 subtitle: What's fresh out of the oven recently, and what's cooking?  Here's our bi-weekly product deep dive.
 date: 2022-01-19

--- a/content/blog/programmable-event-systems-an-introduction.md
+++ b/content/blog/programmable-event-systems-an-introduction.md
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Next.js & Frameworks"]
 heading: "Programmable event platforms"
 subtitle: Programmable event platforms allow you to build serverless event-driven systems in minutes.  Here's an introduction to them.
 date: 2022-01-10

--- a/content/blog/python-errors-as-values.mdx
+++ b/content/blog/python-errors-as-values.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["SDKs & Languages"]
 heading: "Python errors as values: Comparing useful patterns from Go and Rust"
 subtitle: Safer error handling, inspired by Go and Rust
 image: /assets/blog/python-errors-as-values/featured-image.png

--- a/content/blog/python-realtime.mdx
+++ b/content/blog/python-realtime.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Workflows & Orchestration", "Realtime", "SDKs & Languages", "Company & Product News"]
 heading: "Realtime meets reliability in Python, now in Inngest"
 image: /assets/blog/python-realtime/cover.png
 subtitle: "We've released realtime support for Python, enabling developers to build interactive applications that push updates from durable workflows to the browser."

--- a/content/blog/queues-are-no-longer-the-right-abstraction.mdx
+++ b/content/blog/queues-are-no-longer-the-right-abstraction.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control"]
 heading: Queues aren't the right abstraction
 subtitle: Why you shouldn't directly use message queues in 2024
 showSubtitle: true

--- a/content/blog/rate-limit-debouncing-throttling-explained.mdx
+++ b/content/blog/rate-limit-debouncing-throttling-explained.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control"]
 heading: "Understanding the Differences Between Rate Limiting, Debouncing, and Throttling"
 image: /assets/blog/rate-limit-debouncing-throttling-explained/featured-image.png
 showSubtitle: true

--- a/content/blog/redis-stateful-caching.mdx
+++ b/content/blog/redis-stateful-caching.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Engineering", "Company & Product News"]
 heading: "How We Cut Redis Read Operations by 67% with a Stateful Caching Proxy"
 subtitle: "We reduced pressure on our sharded Redis cluster by introducing a gRPC proxy that caches immutable run state and routes consistently by run ID."
 image: /assets/blog/redis-stateful-caching/featured-image.png

--- a/content/blog/redwood-handler.mdx
+++ b/content/blog/redwood-handler.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Tutorials & Guides", "Next.js & Frameworks", "Company & Product News"]
 heading: Deploying event-driven functions to RedwoodJS
 subtitle: Announcing our new RedwoodJS handler.
 image: "/assets/blog/redwood-handler/header.png"

--- a/content/blog/reimagining-information-architecture.mdx
+++ b/content/blog/reimagining-information-architecture.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 heading: "Inngest's new design: Our process in rethinking our information architecture"
 image: /assets/blog/reimagining-information-architecture/featured-image.png
 showSubtitle: false

--- a/content/blog/reinntroducing-inngest.mdx
+++ b/content/blog/reinntroducing-inngest.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News"]
 heading: "(Re)Inntroducing Inngest: Our Brand transformation"
 image: /assets/blog/reinntroducing-inngest/feature-image.png
 showSubtitle: false

--- a/content/blog/release-v0-5-0.md
+++ b/content/blog/release-v0-5-0.md
@@ -4,7 +4,7 @@ subtitle: This release contains exciting new functionality, including replay and
 date: 2022-07-26
 dateUpdated: 2026-01-07
 image: "/assets/blog/release-v0.5.0.jpg"
-tags: release-notes
+tags: ["Company & Product News"]
 ---
 
 > **📢 Latest version:** This blog post covers Inngest v0.5.0 from July 2022. For information about the latest version of Inngest, including self-hosting support and recent features, see [**Announcing Inngest self-hosting (v1.0)**](/blog/inngest-1-0-announcing-self-hosting-support).

--- a/content/blog/release-v0-5-2.md
+++ b/content/blog/release-v0-5-2.md
@@ -3,7 +3,7 @@ heading: "Inngest: OS v0.5.2 released"
 subtitle: Our next release improving rollbacks and developer UX
 date: 2022-08-09
 image: "/assets/blog/release-v0.5.0.jpg"
-tags: release-notes
+tags: ["Company & Product News"]
 ---
 
 [Inngest v0.5.2 is here](https://github.com/inngest/inngest/releases)! This patch introduces a few new pieces of functionality, as well as various fixes and improvements. The key pieces are:

--- a/content/blog/releasing-ts-sdk-2-0.mdx
+++ b/content/blog/releasing-ts-sdk-2-0.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Tutorials & Guides", "SDKs & Languages", "Company & Product News"]
 heading: Introducing Inngest TypeScript SDK v2.0
 subtitle: Learn about the exciting new features in v2.0 and how to upgrade.
 image: /assets/blog/releasing-ts-sdk-2-0/sdk-v-2.png

--- a/content/blog/releasing-ts-sdk-3.mdx
+++ b/content/blog/releasing-ts-sdk-3.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Tutorials & Guides", "SDKs & Languages", "Company & Product News"]
 heading: Introducing Inngest TypeScript SDK v3.0
 subtitle: Learn about the exciting new features in v3.0 and how to upgrade.
 image: /assets/blog/sdk-v-3.png

--- a/content/blog/render-hacker-news-ai-agent.mdx
+++ b/content/blog/render-hacker-news-ai-agent.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Tutorials & Guides"]
 focus: false
 heading: "Tutorial: Custom Hacker News summaries in your inbox"
 subtitle: Build an AI Agent with Inngest and Render

--- a/content/blog/run-nextjs-functions-in-the-background.mdx
+++ b/content/blog/run-nextjs-functions-in-the-background.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Background Jobs & Scheduling", "Tutorials & Guides", "Next.js & Frameworks", "Integrations & Partners"]
 heading: "Run Next.js functions in the background with events and schedules on Vercel and Netlify"
 subtitle: "Learn how to use Next.js api functions and run them as you would a message queue or a cron job."
 image: "/assets/blog/run-nextjs-functions-in-the-background/featured-image.jpg"

--- a/content/blog/running-chained-llms-typescript-in-production.mdx
+++ b/content/blog/running-chained-llms-typescript-in-production.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Tutorials & Guides", "SDKs & Languages"]
 heading: "Running chained LLMs with TypeScript in production"
 subtitle: "Build production-ready zero-infra LLM backends using TypeScript in minutes"
 image: "/assets/blog/chained-llms.jpg"

--- a/content/blog/semi-autonomous-ai-agents.mdx
+++ b/content/blog/semi-autonomous-ai-agents.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Integrations & Partners"]
 heading: "Semi-Autonomous AI Agents and Collaborative Multiplayer Asynchronous Workflows"
 subtitle: "Use Inngest and PartyKit to Power Up Your OpenAI Chatbots."
 image: "/assets/blog/semi-autonomous-ai-agents/semi-autonomous-ai-agents.png"

--- a/content/blog/sharding-at-inngest.mdx
+++ b/content/blog/sharding-at-inngest.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Engineering"]
 heading: "Sharding high-throughput Redis without downtime"
 image: /assets/blog/sharding-inngest/featured-image.png
 showSubtitle: true

--- a/content/blog/should-engineers-do-customer-support.mdx
+++ b/content/blog/should-engineers-do-customer-support.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Engineering", "Company & Product News"]
 heading: "Should Engineers Do Customer Support? How We Built Our Support Rotation System"
 image: /assets/blog/should-engineers-do-customer-support/Ana-blog post (final)-2.png
 subtitle: "When you're building developer tools, the line between building the product, using it and supporting it doesn't exist. The question isn't whether engineers should do support. It's how to make it work for you."

--- a/content/blog/simple-testable-step-functions.mdx
+++ b/content/blog/simple-testable-step-functions.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration"]
 heading: "Locally testable step functions made simple"
 subtitle: "We're excited to release support for step functions which can run any language, all locally testable."
 image: "/assets/blog/step-fns-hero.png"

--- a/content/blog/simplifying-queues-modern-kafka-alternative.mdx
+++ b/content/blog/simplifying-queues-modern-kafka-alternative.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Workflows & Orchestration"]
 heading: Simplify your queues with Inngest, the modern Kafka alternative
 subtitle: Build reliable event-driven workflows with a streamlined developer experience
 image: /assets/blog/simplifying-queues-modern-kafka-alternative/featured-image.png

--- a/content/blog/soc2-compliant.mdx
+++ b/content/blog/soc2-compliant.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Company & Product News", "Incidents & Security"]
 heading: Inngest is SOC 2 Type II compliant
 subtitle: Our commitment to security and privacy for our company and platform
 image: /assets/blog/soc2-compliant/featured-image.png

--- a/content/blog/step-ai-for-serverless-ai-applications.mdx
+++ b/content/blog/step-ai-for-serverless-ai-applications.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Next.js & Frameworks"]
 heading: "step.ai: the quickest way to build reliable AI applications on Serverless while saving on compute"
 subtitle: "Combining step.run() and step.ai.infer() is the best toolset to build reliable AI applications on Serverless while saving on compute."
 showSubtitle: false

--- a/content/blog/svix-integration.mdx
+++ b/content/blog/svix-integration.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Integrations & Partners"]
 heading: "Svix + Inngest: Reliable Webhook Delivery and Execution"
 subtitle: Svix customers can now quickly integrate with Inngest
 showSubtitle: true

--- a/content/blog/synchronizing-financial-data-from-plaid-and-stripe.mdx
+++ b/content/blog/synchronizing-financial-data-from-plaid-and-stripe.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Tutorials & Guides", "Integrations & Partners"]
 heading: "Finta's Automated Financial Synchronization powered by Plaid, Stripe and Inngest"
 showSubtitle: true
 subtitle: Learn how Finta builds and optimizes data pipelines.

--- a/content/blog/three-patterns-you-need-for-agentic-systems.md
+++ b/content/blog/three-patterns-you-need-for-agentic-systems.md
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents"]
 heading: "Three sub-agent patterns you need for your agentic system"
 subtitle: "Every agentic system that actually ships ends up needing three delegation patterns: one that blocks, one that fires and forgets, and one that runs later."
 image: /assets/blog/three-patterns-you-need-for-agentic-systems/blog-banner.png

--- a/content/blog/too-many-javascript-schema-libraries-support-only-one.mdx
+++ b/content/blog/too-many-javascript-schema-libraries-support-only-one.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["SDKs & Languages"]
 heading: "There are too many JavaScript schema libraries, so support only one"
 subtitle: What Standard Schema is, and what we learned adopting it in our TypeScript SDK.
 showSubtitle: true

--- a/content/blog/typescript-sdk-v4.0.mdx
+++ b/content/blog/typescript-sdk-v4.0.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["SDKs & Languages"]
 heading: "TypeScript SDK v4: Rewritten Middleware, Composable Triggers, Faster Steps"
 image: /assets/blog/typescript-sdk-v4/featured-image.png
 showSubtitle: true

--- a/content/blog/typescript-types-as-api.mdx
+++ b/content/blog/typescript-types-as-api.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Tutorials & Guides", "SDKs & Languages"]
 heading: "Typescript For Apps Vs Typescript For SDKs"
 subtitle: "I thought I was good at TypeScript. Refactoring the Inngest SDK proved I was okay at best—and that changed how I think about types forever."
 image: /assets/blog/typescript-types-as-api/featured-image.jpg

--- a/content/blog/user-built-windmill-internal-ops-agent.mdx
+++ b/content/blog/user-built-windmill-internal-ops-agent.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Integrations & Partners"]
 heading: "User Built: How Windmill Built a Durable Internal Ops Agent with Inngest"
 subtitle: "How Windmill replaced brittle n8n flows with a durable internal ops agent—Pim—powered by Inngest Connect, context-first design, and a focused toolset."
 image: /assets/blog/windmill-pim-internal-ops-agent/featured-image.jpg

--- a/content/blog/user-defined-workflows-sanity-nextjs.mdx
+++ b/content/blog/user-defined-workflows-sanity-nextjs.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Workflows & Orchestration", "Next.js & Frameworks", "Integrations & Partners"]
 heading: "User-Defined Workflows in Next.js with Sanity and Inngest"
 subtitle: "Get your workflows up and running quickly with Sanity and Inngest in Next.js"
 image: "/assets/blog/user-defined-workflows.png"

--- a/content/blog/vercel-cloudflare-wait-until.mdx
+++ b/content/blog/vercel-cloudflare-wait-until.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Background Jobs & Scheduling", "Integrations & Partners"]
 heading: What is waitUntil (Vercel, Cloudflare) and when should I use it?
 subtitle: What is it, when to use it, and when not to use it
 image: /assets/blog/vercel-cloudflare-wait-until/featured-image.png

--- a/content/blog/vercel-integration.mdx
+++ b/content/blog/vercel-integration.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Background Jobs & Scheduling", "Integrations & Partners", "Company & Product News"]
 heading: "Vercel + Inngest: The fastest way to ship background functions"
 subtitle: "Announcing our new Vercel integration."
 image: "/assets/blog/vercel-integration/featured-image.jpg"

--- a/content/blog/vercel-long-running-background-functions.mdx
+++ b/content/blog/vercel-long-running-background-functions.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Background Jobs & Scheduling", "Tutorials & Guides", "Integrations & Partners"]
 heading: Long-running background functions on Vercel
 subtitle: How to run business critical jobs for minutes, hours or days
 image: /assets/blog/vercel-long-running-background-functions/featured-image.png

--- a/content/blog/vercel-partner-marketplace.mdx
+++ b/content/blog/vercel-partner-marketplace.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Integrations & Partners", "Company & Product News"]
 heading: Inngest is now on Vercel Marketplace
 subtitle: Making it easier than ever to get started with Inngest for all Vercel developers
 image: "/assets/blog/vercel-partner-marketplace/featured-image.png"

--- a/content/blog/weaviate-ai-workflows.md
+++ b/content/blog/weaviate-ai-workflows.md
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Workflows & Orchestration", "Tutorials & Guides", "Integrations & Partners"]
 focus: false
 heading: "Building Agentic Workflows with Inngest"
 subtitle: Combine Weaviate and Inngest step.ai API to build AI workflows

--- a/content/blog/webinar-recap-durable-endpoints.mdx
+++ b/content/blog/webinar-recap-durable-endpoints.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Queues & Flow Control", "AI & Agents"]
 heading: "We Built a Production-Ready Deep Research Agent Live. Here's How It Works."
 subtitle: "Last Friday, we ran a live session on durable endpoints and built a fully functional deep research agent from scratch in about 30 minutes. Two API endpoints, no job queue, no worker infrastructure, no state management code."
 image: /assets/blog/we-built-a-production-ready-deep-research-agent-live-heres-how-it-works/featured-image.png

--- a/content/blog/what-to-expect-when-youre-expecting-to-scale-asynchronous-workflows.mdx
+++ b/content/blog/what-to-expect-when-youre-expecting-to-scale-asynchronous-workflows.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control", "Workflows & Orchestration"]
 heading: "What to expect when you're expecting... to scale asynchronous workflows."
 subtitle: "Everyone needs retries. Not everyone needs priority queuing—yet. Here’s what 50,000 users taught me about when teams need to solve which problems, and why."
 image: "/assets/blog/expect-async-workflow-scale/featured-image.png"

--- a/content/blog/when-a-queue-isnt-enough.mdx
+++ b/content/blog/when-a-queue-isnt-enough.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "Queues & Flow Control"]
 heading: "When a queue isn't enough"
 subtitle: "Queuing and durable execution are two layers of the same problem. In this post we’ll look at solutions dedicated to each, and when each are most appropriate for what you’re building."
 image: /assets/blog/when-a-queue-isnt-enough/featured-image.png

--- a/content/blog/why-we-built-a-support-bot-that-investigates-tickets.mdx
+++ b/content/blog/why-we-built-a-support-bot-that-investigates-tickets.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["AI & Agents", "Engineering"]
 heading: "Why we built a support bot that investigates tickets before drafting a reply"
 subtitle: "Support questions need evidence, not guesses. We built a bot that reads the live thread, searches the docs, finds similar historical tickets, and only then drafts a response."
 image: /assets/blog/why-we-built-a-support-bot-that-investigates-tickets/header.jpg

--- a/content/blog/why-your-queue-is-slowing-you-down.mdx
+++ b/content/blog/why-your-queue-is-slowing-you-down.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Queues & Flow Control"]
 heading: 5 Reasons Why Your Queue is Slowing You Down
 subtitle: Common pitfalls of traditional queues and how Inngest can help
 image: /assets/blog/why-your-queue-is-slowing-you-down/featured-image-v2.png

--- a/content/blog/your-agent-needs-a-harness-not-a-framework.mdx
+++ b/content/blog/your-agent-needs-a-harness-not-a-framework.mdx
@@ -1,4 +1,5 @@
 ---
+tags: ["Durable Execution", "AI & Agents", "Workflows & Orchestration", "Next.js & Frameworks"]
 heading: "Your Agent Needs a Harness, Not a Framework"
 subtitle: "Agent runtimes don't need yet another framework — they need a durable, event-driven harness that connects tools, memory, and models on production-grade infrastructure."
 image: /assets/blog/your-agent-needs-a-harness-not-a-framework/featured-image.png

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,11 +7,27 @@ Disallow: /*?redirect_url=
 Disallow: /*?*&redirect_url=
 Disallow: /download-gate-form
 
+# Block traditional search engines from LLM markdown mirror pages.
+# These are lightweight markdown versions of our docs/blog intended for AI
+# crawlers only. Blocking prevents duplicate content issues and crawl budget waste.
+# NOTE: Deploy this block only after the X-Robots-Tag noindex headers (in the
+# /docs-markdown/ and /blog-markdown/ route handlers) have been live for ~2 weeks.
+# If Googlebot is blocked before it can re-crawl and see the noindex directive,
+# affected URLs will remain stuck in GSC "Crawled - currently not indexed".
+User-agent: Googlebot
+Disallow: /docs-markdown/
+Disallow: /blog-markdown/
+
+User-agent: Bingbot
+Disallow: /docs-markdown/
+Disallow: /blog-markdown/
+
 # AI Crawlers
 # Inngest welcomes AI crawlers to index our documentation.
 # See also: /llms.txt, /llms-full.txt, /ai.txt
 
 User-agent: GPTBot
+User-agent: OAI-SearchBot
 User-agent: ChatGPT-User
 User-agent: ClaudeBot
 User-agent: PerplexityBot


### PR DESCRIPTION
Adds `tags` frontmatter to all blog posts to power the Topics filter on /blog.

Previously, the Topics dropdown was effectively empty (only 2 old release-notes posts had tags). This populates all 168 posts with curated topic assignments across 14 categories:

AI & Agents, Background Jobs & Scheduling, Company & Product News, Durable Execution, Engineering, Incidents & Security, Integrations & Partners, Next.js & Frameworks, Observability & Debugging, Queues & Flow Control, Realtime, SDKs & Languages, Tutorials & Guides, Workflows & Orchestration

Also updates `.cursor/commands/new-blog-post.md` to require topic tags on all new posts going forward.