### PR TITLE
fix: convert v4 docs reference redirects from 302 → 301 and collapse two-hop chains

### DIFF
--- a/components/v1/sections/BackgroundJobs/Reliability.tsx
+++ b/components/v1/sections/BackgroundJobs/Reliability.tsx
@@ -94,7 +94,7 @@ const FEATURES: Feature[] = [
     id: "typescript",
     title: "TypeScript-native",
     body: "Define event payload types once. End-to-end type safety from the event sender all the way into your function body.",
-    href: "https://www.inngest.com/docs/guides/singleton",
+    href: "https://www.inngest.com/docs/reference/typescript/v4/intro",
   },
 ];
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -105,75 +105,74 @@ const permanentRedirects = [
     "/docs/reference/typescript/functions/metadata",
   ],
 
-  // TypeScript SDK versioned docs - landing page redirect
-  [
-    "/docs/reference/typescript/v4",
-    "/docs/reference/typescript/v4/client/create",
-  ],
-  // Legacy short paths - redirect to versionless TypeScript docs
-  ["/docs/reference/client/create", "/docs/reference/typescript/client/create"],
-  ["/docs/reference/events/send", "/docs/reference/typescript/events/send"],
+  // TypeScript SDK versioned docs - landing page redirects (301 permanent)
+  ["/docs/reference/typescript", "/docs/reference/typescript/intro"],
+  ["/docs/reference/typescript/v4", "/docs/reference/typescript/v4/intro"],
+  ["/docs/reference/typescript/v3", "/docs/reference/typescript/v3/intro"],
+  // Legacy short paths - redirect directly to v4 TypeScript docs (collapsed from two-hop chain)
+  ["/docs/reference/client/create", "/docs/reference/typescript/v4/client/create"],
+  ["/docs/reference/events/send", "/docs/reference/typescript/v4/events/send"],
   [
     "/docs/reference/functions/create",
-    "/docs/reference/typescript/functions/create",
+    "/docs/reference/typescript/v4/functions/create",
   ],
   [
     "/docs/reference/functions/debounce",
-    "/docs/reference/typescript/functions/debounce",
+    "/docs/reference/typescript/v4/functions/debounce",
   ],
   [
     "/docs/reference/functions/handling-failures",
-    "/docs/reference/typescript/functions/handling-failures",
+    "/docs/reference/typescript/v4/functions/handling-failures",
   ],
   [
     "/docs/reference/functions/rate-limit",
-    "/docs/reference/typescript/functions/rate-limit",
+    "/docs/reference/typescript/v4/functions/rate-limit",
   ],
   [
     "/docs/reference/functions/run-priority",
-    "/docs/reference/typescript/functions/run-priority",
+    "/docs/reference/typescript/v4/functions/run-priority",
   ],
   [
     "/docs/reference/functions/singleton",
-    "/docs/reference/typescript/functions/singleton",
+    "/docs/reference/typescript/v4/functions/singleton",
   ],
   [
     "/docs/reference/functions/step-invoke",
-    "/docs/reference/typescript/functions/step-invoke",
+    "/docs/reference/typescript/v4/functions/step-invoke",
   ],
   [
     "/docs/reference/functions/step-run",
-    "/docs/reference/typescript/functions/step-run",
+    "/docs/reference/typescript/v4/functions/step-run",
   ],
   [
     "/docs/reference/functions/step-send-event",
-    "/docs/reference/typescript/functions/step-send-event",
+    "/docs/reference/typescript/v4/functions/step-send-event",
   ],
   [
     "/docs/reference/functions/step-sleep-until",
-    "/docs/reference/typescript/functions/step-sleep-until",
+    "/docs/reference/typescript/v4/functions/step-sleep-until",
   ],
   [
     "/docs/reference/functions/step-sleep",
-    "/docs/reference/typescript/functions/step-sleep",
+    "/docs/reference/typescript/v4/functions/step-sleep",
   ],
   [
     "/docs/reference/functions/step-wait-for-event",
-    "/docs/reference/typescript/functions/step-wait-for-event",
+    "/docs/reference/typescript/v4/functions/step-wait-for-event",
   ],
   [
     "/docs/reference/functions/step-wait-for-signal",
-    "/docs/reference/typescript/functions/step-wait-for-signal",
+    "/docs/reference/typescript/v4/functions/step-wait-for-signal",
   ],
-  ["/docs/reference/serve", "/docs/reference/typescript/serve"],
-  ["/docs/reference/testing", "/docs/reference/typescript/testing"],
+  ["/docs/reference/serve", "/docs/reference/typescript/v4/serve"],
+  ["/docs/reference/testing", "/docs/reference/typescript/v4/testing"],
   [
     "/docs/reference/middleware/lifecycle",
-    "/docs/reference/typescript/middleware/lifecycle",
+    "/docs/reference/typescript/v4/middleware/lifecycle",
   ],
   [
     "/docs/reference/middleware/examples",
-    "/docs/reference/typescript/middleware/examples",
+    "/docs/reference/typescript/v4/middleware/examples",
   ],
   [
     "/docs/reference/typescript/migrations/v3-to-v4",
@@ -290,129 +289,6 @@ async function redirects() {
       permanent: true,
     },
 
-    // Reference intros
-    {
-      source: "/docs/reference/typescript",
-      destination: "/docs/reference/typescript/intro",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/typescript/v4",
-      destination: "/docs/reference/typescript/v4/intro",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/typescript/v3",
-      destination: "/docs/reference/typescript/v3/intro",
-      permanent: false,
-    },
-
-    // Legacy short paths - redirect to versionless TypeScript docs
-    {
-      source: "/docs/reference/client/create",
-      destination: "/docs/reference/typescript/client/create",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/events/send",
-      destination: "/docs/reference/typescript/events/send",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/create",
-      destination: "/docs/reference/typescript/functions/create",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/debounce",
-      destination: "/docs/reference/typescript/functions/debounce",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/handling-failures",
-      destination: "/docs/reference/typescript/functions/handling-failures",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/rate-limit",
-      destination: "/docs/reference/typescript/functions/rate-limit",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/run-priority",
-      destination: "/docs/reference/typescript/functions/run-priority",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/singleton",
-      destination: "/docs/reference/typescript/functions/singleton",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-invoke",
-      destination: "/docs/reference/typescript/functions/step-invoke",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-run",
-      destination: "/docs/reference/typescript/functions/step-run",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-send-event",
-      destination: "/docs/reference/typescript/functions/step-send-event",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-sleep-until",
-      destination: "/docs/reference/typescript/functions/step-sleep-until",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-sleep",
-      destination: "/docs/reference/typescript/functions/step-sleep",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-wait-for-event",
-      destination: "/docs/reference/typescript/functions/step-wait-for-event",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-wait-for-signal",
-      destination: "/docs/reference/typescript/functions/step-wait-for-signal",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/serve",
-      destination: "/docs/reference/typescript/serve",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/testing",
-      destination: "/docs/reference/typescript/testing",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/middleware/lifecycle",
-      destination: "/docs/reference/typescript/middleware/lifecycle",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/middleware/examples",
-      destination: "/docs/reference/typescript/middleware/examples",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/typescript/migrations/v3-to-v4",
-      destination: "/docs/reference/typescript/v4/migrations/v3-to-v4",
-      permanent: false,
-    },
-    {
-      source: "/docs/sdk/migration",
-      destination: "/docs/reference/typescript/v3/migrations/v2-to-v3",
-      permanent: false,
-    },
     ...permanentRedirects.map(([source, destination]) => ({
       source,
       destination,


### PR DESCRIPTION
## What

Fixes SEO-impacting temporary redirects on all TypeScript SDK reference paths, 
including those added in the Feb 27 v4 docs migration.

## Why

302 (temporary) redirects don't reliably pass link equity — Google may continue 
indexing old URLs instead of the canonical v4 pages. All of these paths are 
permanent migrations and should be 301s.

## Changes

- **Removed** the duplicate `permanent: false` block from the `redirects()` function 
  body — these 23 entries were shadowing the `permanent: true` versions in 
  `permanentRedirects`, so the 302s were always winning
- **Collapsed two-hop chains**: old paths were 302ing to versionless 
  `/docs/reference/typescript/*` URLs, which were then internally rewritten to 
  `/docs/reference/typescript/v4/*`. Destinations now point directly to v4 in one hop
- **Fixed** `/docs/reference/typescript/v4` destination from `/client/create` → `/intro`
- **Added** `/docs/reference/typescript` and `/docs/reference/typescript/v3` as 
  explicit 301s (were 302-only before, no permanent counterpart existed)