### PR TITLE
Fix nonexistent CLI command names in debug-functions blog post

### DIFF
--- a/content/blog/debug-functions-terminal-cli-v2-rest-api.mdx
+++ b/content/blog/debug-functions-terminal-cli-v2-rest-api.mdx
@@ -18,7 +18,7 @@ The new commands live under `inngest-cli api`. Set your API key with `INNGEST_AP
 
 ```bash
 # Get a run summary
-npx inngest-cli@latest api --prod get-run 01KTCTWT8XDEGWDMVX3Q9M69ND
+npx inngest-cli@latest api --prod get-function-run 01KTCTWT8XDEGWDMVX3Q9M69ND
 
 # Pull the full step trace
 npx inngest-cli@latest api --prod get-function-trace 01KTCTWT8XDEGWDMVX3Q9M69ND --include-output
@@ -27,7 +27,7 @@ npx inngest-cli@latest api --prod get-function-trace 01KTCTWT8XDEGWDMVX3Q9M69ND 
 npx inngest-cli@latest api --prod get-event-runs 01KTCTWSZJEKAFEDA4F9GYHFQW --limit 5
 
 # Invoke a function directly
-npx inngest-cli@latest api invoke-function-by-slug my-app-my-function --data '{"message": "hello"}'
+npx inngest-cli@latest api invoke-function my-app my-app-my-function --data '{"message": "hello"}'
 ```
 
 The CLI targets your local dev server by default. Add `--prod` to hit Inngest Cloud. Output is compact JSON, pipeable to `jq`.
@@ -40,7 +40,7 @@ npx inngest-cli@latest api --prod get-function-trace 01KTCTWT8XDEGWDMVX3Q9M69ND 
   | jq '[.data.rootSpan.children[] | select(.status == "FAILED")]'
 
 # Test your fix locally
-npx inngest-cli@latest api invoke-function-by-slug my-app-process-order \
+npx inngest-cli@latest api invoke-function my-app my-app-process-order \
   --data '{"orderId": "test-123"}'
 ```
 
@@ -57,10 +57,10 @@ Add a block to your `CLAUDE.md` or `.cursorrules`:
 
 Use the Inngest CLI to inspect function runs and traces:
 
-- Get a run: `npx inngest-cli@latest api --prod get-run <run_id>`
+- Get a run: `npx inngest-cli@latest api --prod get-function-run <run_id>`
 - Get a trace: `npx inngest-cli@latest api --prod get-function-trace <run_id> --include-output`
 - Get runs from an event: `npx inngest-cli@latest api --prod get-event-runs <event_id> --include-output`
-- Invoke locally: `npx inngest-cli@latest api invoke-function-by-slug <slug> --data '{...}'`
+- Invoke locally: `npx inngest-cli@latest api invoke-function <app_id> <function_id> --data '{...}'`
 
 Output is JSON. Use jq to filter.
 ```


### PR DESCRIPTION
The blog post [Debug functions from the terminal with new CLI commands and v2 REST API](https://www.inngest.com/blog/debug-functions-terminal-cli-v2-rest-api) references two CLI commands that don't exist. This PR fixes all 5 occurrences (2× `get-run`, 3× `invoke-function-by-slug`), including the `CLAUDE.md` snippet that readers are encouraged to copy into their agent configs verbatim.

## `get-run` → `get-function-run`

The command name is generated from the v2 API RPC method name, and the RPC is `GetFunctionRun`, not `GetRun`:

- The CLI's own test asserts the generated name: [`cmd/apiv2cli/cmd_test.go#L45`](https://github.com/inngest/inngest/blob/49c6a844b4f149b176a222820c856752b8eb1e76/cmd/apiv2cli/cmd_test.go#L45)
  ```go
  require.Equal(t, "get-function-run", endpointCommandName("GetFunctionRun"))
  ```
- The RPC definition: [`proto/api/v2/service.proto#L942-L944`](https://github.com/inngest/inngest/blob/49c6a844b4f149b176a222820c856752b8eb1e76/proto/api/v2/service.proto#L942-L944) (`GET /runs/{run_id}`)

## `invoke-function-by-slug <slug>` → `invoke-function <app-id> <function-id>`

There is no `InvokeFunctionBySlug` RPC and no `invoke-function-by-slug` command — a [code search across `inngest/inngest`](https://github.com/search?q=repo%3Ainngest%2Finngest+%22invoke-function-by-slug%22&type=code) returns zero results. The actual command is `invoke-function`, and it takes **two** positional path params (`app_id` and `function_id`), not a single slug:

- Test assertions: [`cmd/apiv2cli/cmd_test.go#L35-L37`](https://github.com/inngest/inngest/blob/49c6a844b4f149b176a222820c856752b8eb1e76/cmd/apiv2cli/cmd_test.go#L35-L37)
  ```go
  require.Equal(t, http.MethodPost, byName["invoke-function"].method)
  require.Equal(t, "/apps/{app_id}/functions/{function_id}/invoke", byName["invoke-function"].path)
  require.Equal(t, []string{"app_id", "function_id"}, byName["invoke-function"].pathParams)
  ```
- The RPC definition: [`proto/api/v2/service.proto#L1110-L1112`](https://github.com/inngest/inngest/blob/49c6a844b4f149b176a222820c856752b8eb1e76/proto/api/v2/service.proto#L1110-L1112) (`POST /apps/{app_id}/functions/{function_id}/invoke`)

Example values follow the proto's own field examples (`app_id: "my-app"`, `function_id: "my-app-hello-world"`).

## Why it matters

The post pitches these exact commands for pasting into `CLAUDE.md` / `.cursorrules` so coding agents can debug from real execution data — but an agent following the snippet as written will fail on two of the four commands. Since the `api` subcommand surface is auto-generated from the proto definitions, the published command set is exactly what the proto defines; the post just drifted from it.
