### PR TITLE
fix: make docs migration redirects permanent

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -105,82 +105,87 @@ const permanentRedirects = [
     "/docs/reference/typescript/functions/metadata",
   ],
 
-  // TypeScript SDK versioned docs - landing page redirect
+  // TypeScript SDK versioned docs - landing page redirects (301 permanent)
+  ["/docs/reference/typescript", "/docs/reference/typescript/intro"],
+  ["/docs/reference/typescript/v4", "/docs/reference/typescript/v4/intro"],
+  ["/docs/reference/typescript/v3", "/docs/reference/typescript/v3/intro"],
+  // Legacy short paths - redirect directly to v4 TypeScript docs (collapsed from two-hop chain)
   [
-    "/docs/reference/typescript/v4",
+    "/docs/reference/client/create",
     "/docs/reference/typescript/v4/client/create",
   ],
-  // Legacy short paths - redirect to versionless TypeScript docs
-  ["/docs/reference/client/create", "/docs/reference/typescript/client/create"],
-  ["/docs/reference/events/send", "/docs/reference/typescript/events/send"],
+  ["/docs/reference/events/send", "/docs/reference/typescript/v4/events/send"],
   [
     "/docs/reference/functions/create",
-    "/docs/reference/typescript/functions/create",
+    "/docs/reference/typescript/v4/functions/create",
   ],
   [
     "/docs/reference/functions/debounce",
-    "/docs/reference/typescript/functions/debounce",
+    "/docs/reference/typescript/v4/functions/debounce",
   ],
   [
     "/docs/reference/functions/handling-failures",
-    "/docs/reference/typescript/functions/handling-failures",
+    "/docs/reference/typescript/v4/functions/handling-failures",
   ],
   [
     "/docs/reference/functions/rate-limit",
-    "/docs/reference/typescript/functions/rate-limit",
+    "/docs/reference/typescript/v4/functions/rate-limit",
   ],
   [
     "/docs/reference/functions/run-priority",
-    "/docs/reference/typescript/functions/run-priority",
+    "/docs/reference/typescript/v4/functions/run-priority",
   ],
   [
     "/docs/reference/functions/singleton",
-    "/docs/reference/typescript/functions/singleton",
+    "/docs/reference/typescript/v4/functions/singleton",
   ],
   [
     "/docs/reference/functions/step-invoke",
-    "/docs/reference/typescript/functions/step-invoke",
+    "/docs/reference/typescript/v4/functions/step-invoke",
   ],
   [
     "/docs/reference/functions/step-run",
-    "/docs/reference/typescript/functions/step-run",
+    "/docs/reference/typescript/v4/functions/step-run",
   ],
   [
     "/docs/reference/functions/step-send-event",
-    "/docs/reference/typescript/functions/step-send-event",
+    "/docs/reference/typescript/v4/functions/step-send-event",
   ],
   [
     "/docs/reference/functions/step-sleep-until",
-    "/docs/reference/typescript/functions/step-sleep-until",
+    "/docs/reference/typescript/v4/functions/step-sleep-until",
   ],
   [
     "/docs/reference/functions/step-sleep",
-    "/docs/reference/typescript/functions/step-sleep",
+    "/docs/reference/typescript/v4/functions/step-sleep",
   ],
   [
     "/docs/reference/functions/step-wait-for-event",
-    "/docs/reference/typescript/functions/step-wait-for-event",
+    "/docs/reference/typescript/v4/functions/step-wait-for-event",
   ],
   [
     "/docs/reference/functions/step-wait-for-signal",
-    "/docs/reference/typescript/functions/step-wait-for-signal",
+    "/docs/reference/typescript/v4/functions/step-wait-for-signal",
   ],
-  ["/docs/reference/serve", "/docs/reference/typescript/serve"],
-  ["/docs/reference/testing", "/docs/reference/typescript/testing"],
+  ["/docs/reference/serve", "/docs/reference/typescript/v4/serve"],
+  ["/docs/reference/testing", "/docs/reference/typescript/v4/testing"],
   [
     "/docs/reference/middleware/lifecycle",
-    "/docs/reference/typescript/middleware/lifecycle",
+    "/docs/reference/typescript/v4/middleware/lifecycle",
   ],
   [
     "/docs/reference/middleware/examples",
-    "/docs/reference/typescript/middleware/examples",
+    "/docs/reference/typescript/v4/middleware/examples",
   ],
   [
     "/docs/reference/typescript/migrations/v3-to-v4",
     "/docs/reference/typescript/v4/migrations/v3-to-v4",
   ],
   ["/docs/sdk/migration", "/docs/reference/typescript/v3/migrations/v2-to-v3"],
-  ["/patterns/cancelling-scheduled-functions", "/docs/guides/cancel-running-functions"],
+  [
+    "/patterns/cancelling-scheduled-functions",
+    "/docs/guides/cancel-running-functions",
+  ],
   ["/patterns/running-code-on-a-schedule", "/docs/guides/scheduled-functions"],
 
   // New IA: platform + use-case pages replacing legacy landing pages, plus
@@ -290,129 +295,6 @@ async function redirects() {
       permanent: true,
     },
 
-    // Reference intros
-    {
-      source: "/docs/reference/typescript",
-      destination: "/docs/reference/typescript/intro",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/typescript/v4",
-      destination: "/docs/reference/typescript/v4/intro",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/typescript/v3",
-      destination: "/docs/reference/typescript/v3/intro",
-      permanent: false,
-    },
-
-    // Legacy short paths - redirect to versionless TypeScript docs
-    {
-      source: "/docs/reference/client/create",
-      destination: "/docs/reference/typescript/client/create",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/events/send",
-      destination: "/docs/reference/typescript/events/send",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/create",
-      destination: "/docs/reference/typescript/functions/create",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/debounce",
-      destination: "/docs/reference/typescript/functions/debounce",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/handling-failures",
-      destination: "/docs/reference/typescript/functions/handling-failures",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/rate-limit",
-      destination: "/docs/reference/typescript/functions/rate-limit",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/run-priority",
-      destination: "/docs/reference/typescript/functions/run-priority",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/singleton",
-      destination: "/docs/reference/typescript/functions/singleton",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-invoke",
-      destination: "/docs/reference/typescript/functions/step-invoke",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-run",
-      destination: "/docs/reference/typescript/functions/step-run",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-send-event",
-      destination: "/docs/reference/typescript/functions/step-send-event",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-sleep-until",
-      destination: "/docs/reference/typescript/functions/step-sleep-until",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-sleep",
-      destination: "/docs/reference/typescript/functions/step-sleep",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-wait-for-event",
-      destination: "/docs/reference/typescript/functions/step-wait-for-event",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/functions/step-wait-for-signal",
-      destination: "/docs/reference/typescript/functions/step-wait-for-signal",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/serve",
-      destination: "/docs/reference/typescript/serve",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/testing",
-      destination: "/docs/reference/typescript/testing",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/middleware/lifecycle",
-      destination: "/docs/reference/typescript/middleware/lifecycle",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/middleware/examples",
-      destination: "/docs/reference/typescript/middleware/examples",
-      permanent: false,
-    },
-    {
-      source: "/docs/reference/typescript/migrations/v3-to-v4",
-      destination: "/docs/reference/typescript/v4/migrations/v3-to-v4",
-      permanent: false,
-    },
-    {
-      source: "/docs/sdk/migration",
-      destination: "/docs/reference/typescript/v3/migrations/v2-to-v3",
-      permanent: false,
-    },
     ...permanentRedirects.map(([source, destination]) => ({
       source,
       destination,
@@ -465,7 +347,8 @@ async function redirects() {
     // OOH campaign - SF car wrap (AI Engineer World's Fair 2026)
     {
       source: "/sf",
-      destination: "/?utm_medium=ooh&utm_source=car-wrap-sf&utm_campaign=aiewf-2026",
+      destination:
+        "/?utm_medium=ooh&utm_source=car-wrap-sf&utm_campaign=aiewf-2026",
       permanent: false,
     },
   ];


### PR DESCRIPTION
## Summary

This PR ships the docs redirect SEO fix from Pat’s analysis: the v4 docs migration/reference redirects were using `permanent: false`, which made them temporary 302 redirects. That was causing SEO issues and, in some cases, redirect chains through the versionless TypeScript docs rewrite.

This updates the affected docs migration redirects to permanent 301s and collapses legacy short paths directly to their final `/docs/reference/typescript/v4/...` destinations.

## Context

- Pat’s original work/branch: https://github.com/inngest/website/tree/pat/fix-302-to-301-redirects
- Notion project brief: https://app.notion.com/p/37db64753bbd80dabf8ad5760ebce791
- Linear ticket: https://linear.app/inngest/issue/DEV-429/ship-301-redirects-for-v4-docs-migration-paths
- Redirect review sheet: https://docs.google.com/spreadsheets/d/1Fr1gqDn63btmVLCkMzX3rdJm5lMAz52nCxEDnB9242E/edit?usp=sharing

## Changes

- Moves the v4 docs reference redirect set into `permanentRedirects` so they return 301s.
- Removes the duplicate temporary redirect block from `redirects()`.
- Points legacy reference URLs directly at final v4 docs paths, for example:
  - `/docs/reference/functions/create`
  - `/docs/reference/events/send`
  - `/docs/reference/serve`
- Keeps the v3 migration redirect pointing at its final v3 migration destination.

## Validation

- Ran a config-level redirect sanity check against `next.config.mjs`
  - verified 24 docs migration redirects are permanent
  - verified affected legacy paths are single-hop redirects
- Ran `pnpm exec prettier --check next.config.mjs`
- Ran `git diff --check`

## Follow-up

After deploy, we should submit the affected URLs in Google Search Console URL Inspection as part of DEV-429.