### PR TITLE
Add events and queue depth to pricing page

### DIFF
--- a/components/v1/sections/Pricing/plans.ts
+++ b/components/v1/sections/Pricing/plans.ts
@@ -80,6 +80,8 @@ export const PLANS: Plan[] = [
     features: [
       { value: "50k", text: "executions" },
       { value: "5", text: "concurrent executions" },
+      { value: "500k", text: "events" },
+      { value: "100k", text: "queue depth" },
       { value: "50", text: "realtime connections" },
       { text: "Basic tracing, metrics, and alerts" },
     ],
@@ -116,6 +118,8 @@ export const PLANS: Plan[] = [
     features: [
       { value: "1M+", text: "executions" },
       { value: "100+", text: "concurrent executions" },
+      { value: "5M+", text: "events" },
+      { value: "1M+", text: "queue depth" },
       { value: "1000", text: "realtime connections" },
       { text: "Granular tracing, metrics, alerts + 7 day trace retention" },
       { text: "Increased throughput" },
@@ -152,6 +156,8 @@ export const PLANS: Plan[] = [
     features: [
       { value: "Custom", text: "executions" },
       { value: "Custom", text: "concurrent executions" },
+      { value: "Custom", text: "events" },
+      { value: "Custom", text: "queue depth" },
       { value: "Custom", text: "realtime connections" },
       { text: "Advanced tracing, metrics, alerts + 90 day trace retention" },
       { text: "Dedicated Slack channel" },
@@ -288,11 +294,21 @@ export const FEATURES: Feature[] = [
     section: "events",
     infoUrl: "/docs/guides/sending-events-from-functions?ref=pricing-comparison-table",
     plans: {
-      [PLAN_NAMES.hobby]: "100k/mo included",
+      [PLAN_NAMES.hobby]: "500k/mo included",
       [PLAN_NAMES.pro]: {
         value: "5m/mo included",
         description: "then $0.5 per 1m",
       },
+      [PLAN_NAMES.enterprise]: "Custom",
+    },
+  },
+  {
+    name: "Queue depth",
+    description: "Maximum events queued awaiting execution",
+    section: "events",
+    plans: {
+      [PLAN_NAMES.hobby]: "100k included",
+      [PLAN_NAMES.pro]: "1m included",
       [PLAN_NAMES.enterprise]: "Custom",
     },
   },


### PR DESCRIPTION
## Summary

- Add **events** and **queue depth** bullets to Hobby, Pro, and Enterprise plan cards on `/pricing`.
- Update the plan features comparison table: Hobby events increased to `500k/mo included`, and a new **Queue depth** row under the Events section.

## Test plan

- [ ] Preview `/pricing` and confirm new bullets appear in all three plan cards
- [ ] Expand the **Events** section in the plan features table and verify Events + Queue depth rows
- [ ] Confirm Hobby shows 500k events / 100k queue depth, Pro shows 5M+ events / 1M+ queue depth, Enterprise shows Custom for both


Made with [Cursor](https://cursor.com)