### PR TITLE
fix: refresh Next.js quick start SEO

### DIFF
--- a/pages/docs/getting-started/nextjs-quick-start.mdx
+++ b/pages/docs/getting-started/nextjs-quick-start.mdx
@@ -1,12 +1,17 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = `Get started with Inngest in this ten-minute Next.js tutorial`
+export const metaTitle = "Inngest Next.js Quick Start"
+export const description = `Build durable background jobs and workflows in Next.js with Inngest. Add the SDK, serve functions from the App Router or Pages Router, and trigger your first function.`
 
 # Next.js Quick Start
 
-This tutorial walks you through adding Inngest to a Next.js app. By the end, you'll have a working function that runs in the background, triggered by an event, with full visibility into its execution in the Inngest Dev Server.
+This tutorial walks you through adding Inngest to a Next.js app using the App Router or Pages Router. By the end, you'll have a durable function that runs in the background, is triggered by an event, and shows its full execution history in the Inngest Dev Server.
+
+Use this guide when you want to run background jobs, durable workflows, or AI steps from your Next.js application without managing a separate queue or worker.
 
 The guide takes about ten minutes. You'll need an existing Next.js project, or you can create one as part of the setup below.
+
+_Last updated: June 16, 2026._
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a docs-specific `metaTitle` for the Next.js quick start so the SERP title targets `Inngest Next.js` intent instead of relying only on the page H1.
- Rewrite the meta description around durable background jobs/workflows in Next.js, App Router, Pages Router, and triggering the first function.
- Refresh the opening copy with the same intent language and add a visible `Last updated: June 16, 2026` signal.

## Why

This is part of Pat's June 2026 docs SEO recommendations. DEV-431 identifies `/docs/getting-started/nextjs-quick-start` as the confirmed #1 click-loss page after the dev-server page was reclassified as a redirect:

- Clicks: 1,968 now, down 1,585 (-45%)
- CTR: 1.05% now vs. 1.57% previous
- Queries `inngest next js` and `inngest nextjs` are down roughly 52-54%

## Tracking

- Linear: [DEV-431 — Refresh Next.js quick start for SEO CTR recovery](https://linear.app/inngest/issue/DEV-431/refresh-nextjs-quick-start-for-seo-ctr-recovery)
- Notion source: [/docs SEO optimization recommendations (June 2026)](https://app.notion.com/p/37db64753bbd80dabf8ad5760ebce791)
- Slack update: [#dev-rel-docs message](https://inngest.slack.com/archives/C068B3TL06L/p1781640976894559)
- Related meta-sweep review: [DEV-430](https://linear.app/inngest/issue/DEV-430/review-proposed-docs-meta-titles-and-descriptions)

## Validation

- `pnpm exec prettier --check pages/docs/getting-started/nextjs-quick-start.mdx`
- `git diff --check`