### PR TITLE
fix: apply docs metadata sweep

### DIFF
--- a/pages/docs/ai-dev-tools/agent-skills.mdx
+++ b/pages/docs/ai-dev-tools/agent-skills.mdx
@@ -3,9 +3,7 @@ import { Callout, CodeGroup } from "shared/Docs/mdx";
 
 import { CodeBracketIcon, ComputerDesktopIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 
-
-export const metaTitle = "AI Coding Agent Plugins & Skills | Inngest Docs"
-export const description = "Install Inngest plugins and skills for Claude Code, Codex, Cursor, and other AI coding agents so they can write, test, and debug durable functions correctly."
+export const description = "Install Inngest plugins and skills for Claude Code, Codex, Cursor, and other AI coding agents so they can write, test, and debug durable functions."
 
 # AI Coding Agent Plugins and Skills
 

--- a/pages/docs/ai-dev-tools/agent-skills.mdx
+++ b/pages/docs/ai-dev-tools/agent-skills.mdx
@@ -3,7 +3,9 @@ import { Callout, CodeGroup } from "shared/Docs/mdx";
 
 import { CodeBracketIcon, ComputerDesktopIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 
-export const description = "Install Inngest plugins and skills for Claude Code, Codex, Cursor, and other AI coding agents so they can write, test, and debug durable functions."
+
+export const metaTitle = "AI Coding Agent Plugins & Skills | Inngest Docs"
+export const description = "Install Inngest plugins and skills for Claude Code, Codex, Cursor, and other AI coding agents so they can write, test, and debug durable functions correctly."
 
 # AI Coding Agent Plugins and Skills
 

--- a/pages/docs/ai-dev-tools/mcp.mdx
+++ b/pages/docs/ai-dev-tools/mcp.mdx
@@ -3,9 +3,7 @@ import { Callout, CodeGroup } from "shared/Docs/mdx";
 
 import { BookOpenIcon, CodeBracketIcon, ComputerDesktopIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 
-
-export const metaTitle = "Model Context Protocol (MCP) Integration | Inngest Docs"
-export const description = "Connect AI coding agents to your Inngest Dev Server via MCP. List functions, send events, and inspect runs from Claude Code, Cursor, or any MCP-compatible tool."
+export const description = "Integrate AI development tools with Inngest using Model Context Protocol (MCP). Test functions, monitor execution, and debug workflows with Claude Code, Cursor, and other AI assistants."
 
 # Model Context Protocol (MCP) Integration
 

--- a/pages/docs/ai-dev-tools/mcp.mdx
+++ b/pages/docs/ai-dev-tools/mcp.mdx
@@ -3,7 +3,9 @@ import { Callout, CodeGroup } from "shared/Docs/mdx";
 
 import { BookOpenIcon, CodeBracketIcon, ComputerDesktopIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 
-export const description = "Integrate AI development tools with Inngest using Model Context Protocol (MCP). Test functions, monitor execution, and debug workflows with Claude Code, Cursor, and other AI assistants."
+
+export const metaTitle = "Model Context Protocol (MCP) Integration | Inngest Docs"
+export const description = "Connect AI coding agents to your Inngest Dev Server via MCP. List functions, send events, and inspect runs from Claude Code, Cursor, or any MCP-compatible tool."
 
 # Model Context Protocol (MCP) Integration
 

--- a/pages/docs/ai-patterns/agent-tool-loops.mdx
+++ b/pages/docs/ai-patterns/agent-tool-loops.mdx
@@ -1,4 +1,6 @@
-export const description = "Build a durable AI agent loop with Inngest where each LLM call and tool execution is a retriable, checkpointed step."
+
+export const metaTitle = "Build a Durable AI Agent Tool Loop | Inngest Docs"
+export const description = "Build a fault-tolerant AI agent loop where every LLM call and tool execution is a checkpointed, retriable step. Survive failures without losing progress."
 
 # Build an Agent Tool Loop
 

--- a/pages/docs/ai-patterns/cli-for-coding-agents.mdx
+++ b/pages/docs/ai-patterns/cli-for-coding-agents.mdx
@@ -1,4 +1,6 @@
-export const description = "Give your coding agent access to Inngest runs, traces, and function invocation using the CLI and REST API."
+
+export const metaTitle = "Inngest CLI for Coding Agents | Inngest Docs"
+export const description = "Use the Inngest CLI with AI coding agents to test, trigger, and debug durable functions from the terminal during local development."
 
 # Use the CLI with coding agents
 

--- a/pages/docs/ai-patterns/human-in-the-loop.mdx
+++ b/pages/docs/ai-patterns/human-in-the-loop.mdx
@@ -1,4 +1,6 @@
-export const description = `Create AI workflows that pause for human input before continuing. Use Inngest's "waitForEvent" to build decoupled flows.`
+
+export const metaTitle = "Human-in-the-Loop AI Workflows | Inngest Docs"
+export const description = "Pause AI workflows for human review using step.waitForEvent(). Build auditable pipelines that resume automatically when a decision or approval is received."
 
 # Human-in-the-loop (HITL)
 

--- a/pages/docs/ai-patterns/sub-agent-delegation.mdx
+++ b/pages/docs/ai-patterns/sub-agent-delegation.mdx
@@ -1,4 +1,6 @@
-export const description = "Expand your agentic system by delegating tasks to sub-agents. Sub-agents allow tasks to have their own context windows, tools, and token budgets."
+
+export const metaTitle = "Sub-Agent Delegation | Inngest Docs"
+export const description = "Delegate tasks to specialized sub-agents in your AI system, each with its own context window, tools, and token budget. Scale multi-agent pipelines with Inngest."
 
 # Delegate Tasks to Sub-Agents
 

--- a/pages/docs/apps/cloud.mdx
+++ b/pages/docs/apps/cloud.mdx
@@ -1,6 +1,8 @@
 import { Callout, ButtonCol, ButtonDeploy } from "src/shared/Docs/mdx";
 
-export const description = "Learn how to sync Inngest Apps after a deploy"
+
+export const metaTitle = "Sync Your Inngest App After Deploy | Inngest Docs"
+export const description = "Learn how to sync your Inngest app with the platform after each deploy, so your functions are always up to date in production and branch environments."
 
 # Syncing an Inngest App
 After deploying your code to a hosting platform, it is time to go to production and inform Inngest about your apps and functions. Check what [Inngest Apps](/docs/apps) are if you haven't done it yet.

--- a/pages/docs/apps/index.mdx
+++ b/pages/docs/apps/index.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup, Callout } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Inngest Apps | Environments, Syncing & Event Keys"
+export const description = "Understand Inngest apps: how they map to your codebase, connect to environments, sync after deploys, and use event keys to send and receive events."
+
 # Inngest Apps
 
 

--- a/pages/docs/cli.mdx
+++ b/pages/docs/cli.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = "Use the Inngest CLI to inspect runs, fetch traces, and invoke functions from your terminal or coding agent."
+
+export const metaTitle = "Inngest CLI | Inngest Docs"
+export const description = "Start the Dev Server, manage local development, and run commands to test and debug your Inngest functions from the terminal."
 
 # Inngest CLI
 

--- a/pages/docs/deploy/cloudflare.mdx
+++ b/pages/docs/deploy/cloudflare.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Deploy Inngest to Cloudflare Pages | Inngest Docs"
+export const description = "Host Inngest functions on Cloudflare Pages. Set up the serve handler, configure environment variables, and deploy your durable workflows to the edge."
+
 # Cloudflare Pages
 
 

--- a/pages/docs/deploy/digital-ocean.mdx
+++ b/pages/docs/deploy/digital-ocean.mdx
@@ -1,5 +1,8 @@
 import { Callout, ButtonDeploy, CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Deploy Inngest to DigitalOcean | Inngest Docs"
+export const description = "Run Inngest functions on DigitalOcean. Configure your serve endpoint, set environment variables, and connect your DigitalOcean app to the Inngest platform."
+
 # DigitalOcean
 
 Inngest functions can be deployed to DigitalOcean's Functions, App Platform, or Droplets.

--- a/pages/docs/deploy/netlify.mdx
+++ b/pages/docs/deploy/netlify.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Deploy Inngest to Netlify | Inngest Docs"
+export const description = "Host Inngest functions on Netlify. Set up the serve handler, configure your Netlify function endpoint, and connect to Inngest for durable background jobs."
+
 # Netlify
 
 We provide a Netlify build plugin, [netlify-plugin-inngest](https://www.npmjs.com/package/netlify-plugin-inngest), that allows you to automatically sync any found apps whenever your site is deployed to Netlify.

--- a/pages/docs/deploy/render.mdx
+++ b/pages/docs/deploy/render.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Deploy Inngest to Render | Inngest Docs"
+export const description = "Run Inngest background functions on Render. Configure the serve endpoint, set required environment variables, and sync your app with the Inngest platform."
+
 # Render
 
 [Render](https://render.com) lets you easily deploy and scale full stack applications. You can deploy your Inngest functions on Render using any web framework, including [Next.js](https://docs.render.com/deploy-nextjs-app), [Express](https://docs.render.com/deploy-node-express-app), and [FastAPI](https://docs.render.com/deploy-fastapi).

--- a/pages/docs/deploy/vercel.mdx
+++ b/pages/docs/deploy/vercel.mdx
@@ -1,5 +1,8 @@
 import { Callout, GuideSelector, GuideSection, ButtonDeploy, Tip } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Deploy Inngest to Vercel | Inngest Docs"
+export const description = "Host Inngest functions on Vercel serverless functions alongside your existing API routes. Supports Next.js App Router, Pages Router, and Express-style handlers."
+
 # Vercel
 
 Inngest enables you to host your functions on Vercel using their [serverless functions platform](https://vercel.com/docs/concepts/functions/serverless-functions). This allows you to deploy your Inngest functions right alongside your existing website and API functions running on Vercel.

--- a/pages/docs/events/creating-an-event-key.mdx
+++ b/pages/docs/events/creating-an-event-key.mdx
@@ -1,5 +1,8 @@
 import { Callout } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Create an Inngest Event Key | Inngest Docs"
+export const description = "Generate and manage Event Keys to authenticate event ingestion from your app or third-party services. Scope keys to specific environments for security."
+
 # Creating an Event Key
 
 “Event Keys” are unique keys that allow applications to send (aka publish) events to Inngest. When using Event Keys with the [Inngest SDK](/docs/events), you can configure the `Inngest` client in 2 ways:

--- a/pages/docs/events/index.mdx
+++ b/pages/docs/events/index.mdx
@@ -1,8 +1,6 @@
 import { CodeGroup, Callout, LanguageSelector, LanguageSection, Note } from "src/shared/Docs/mdx";
 
-
-export const metaTitle = "Sending Events to Inngest | SDK & HTTP Reference"
-export const description = "Send events to Inngest using the TypeScript, Python, or Go SDK, or via HTTP from any language. Learn payload format, batching, and environment routing."
+export const description = 'Learn how to send events with the Inngest SDK, set the Event Key, and send events from other languages via HTTP.';
 
 # Sending events
 

--- a/pages/docs/events/index.mdx
+++ b/pages/docs/events/index.mdx
@@ -1,6 +1,8 @@
 import { CodeGroup, Callout, LanguageSelector, LanguageSection, Note } from "src/shared/Docs/mdx";
 
-export const description = 'Learn how to send events with the Inngest SDK, set the Event Key, and send events from other languages via HTTP.';
+
+export const metaTitle = "Sending Events to Inngest | SDK & HTTP Reference"
+export const description = "Send events to Inngest using the TypeScript, Python, or Go SDK, or via HTTP from any language. Learn payload format, batching, and environment routing."
 
 # Sending events
 

--- a/pages/docs/examples/ai-agents-and-rag.mdx
+++ b/pages/docs/examples/ai-agents-and-rag.mdx
@@ -3,7 +3,9 @@ import { Example } from 'src/shared/Docs/Examples';
 
 import { BookOpenIcon, VideoCameraIcon, MicrophoneIcon } from "@heroicons/react/24/outline";
 
-export const description = "Learn how to use Inngest for AI automated workflows, AI agents, and RAG."
+
+export const metaTitle = "Build AI Agents and RAG Workflows with Inngest"
+export const description = "Learn how to build durable AI agent loops and retrieval-augmented generation (RAG) pipelines with Inngest, with automatic retries and step-based checkpointing."
 
 # AI Agents and RAG
 

--- a/pages/docs/examples/cleanup-after-function-cancellation.mdx
+++ b/pages/docs/examples/cleanup-after-function-cancellation.mdx
@@ -2,7 +2,9 @@ import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 
 import { RiBracesFill, RiErrorWarningFill } from "@remixicon/react";
 
-export const description = "Create a function that executes after a function run has been cancelled via event, REST API, or bulk cancellation.";
+
+export const metaTitle = "Run Cleanup Logic After Function Cancellation | Inngest Docs"
+export const description = "Execute cleanup code when an Inngest function run is cancelled, whether via event, REST API, or bulk cancellation, using the onCancel lifecycle handler."
 
 # Cleanup after function cancellation
 

--- a/pages/docs/examples/durable-endpoints.mdx
+++ b/pages/docs/examples/durable-endpoints.mdx
@@ -3,7 +3,9 @@ import { CodeGroup, CardGroup, Card } from "src/shared/Docs/mdx";
 import { RiNextjsFill } from "@remixicon/react";
 import { CodeBracketIcon } from "@heroicons/react/24/outline";
 
-export const description = "Learn how to use Inngest Durable Endpoints to make any HTTP handler durable with automatic retries and step orchestration."
+
+export const metaTitle = "Durable Endpoints Example | Inngest Docs"
+export const description = "Turn any HTTP handler into a durable, observable workflow with automatic retries and step checkpointing. Full working example with TypeScript."
 
 # Durable Endpoints
 

--- a/pages/docs/examples/email-sequence.mdx
+++ b/pages/docs/examples/email-sequence.mdx
@@ -4,7 +4,9 @@ import { Example } from 'src/shared/Docs/Examples';
 import { BookOpenIcon, VideoCameraIcon, PencilSquareIcon } from "@heroicons/react/24/outline";
 
 
-export const description = "See how to implement an email sequence with Inngest"
+
+export const metaTitle = "Build an Email Drip Sequence with Inngest"
+export const description = "Implement a behavior-driven email sequence using Inngest. Trigger emails based on user actions, sleep between sends, and cancel if the user unsubscribes."
 
 # Email Sequence
 

--- a/pages/docs/examples/fetch-run-status-and-output.mdx
+++ b/pages/docs/examples/fetch-run-status-and-output.mdx
@@ -1,7 +1,9 @@
 import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 import { RiBracesFill } from "@remixicon/react";
 
-export const description = "See how to fetch the run status and output of a function in Inngest."
+
+export const metaTitle = "Fetch Run Status and Output via API | Inngest Docs"
+export const description = "Poll or fetch the status and output of an Inngest function run using the REST API. Useful for external systems that need to wait on a background job result."
 
 # Fetch run status and output
 

--- a/pages/docs/examples/fetch.mdx
+++ b/pages/docs/examples/fetch.mdx
@@ -1,7 +1,9 @@
 import { CodeGroup, CardGroup, Card, VersionBadge, Callout } from "src/shared/Docs/mdx";
 
 
-export const description = "Make durable HTTP requests within an Inngest function.";
+
+export const metaTitle = "Durable HTTP Requests with step.fetch() | Inngest Docs"
+export const description = "Make retryable, checkpointed HTTP requests inside Inngest functions using step.fetch(). Survive transient failures without re-running prior steps."
 
 # Fetch: performing API requests or fetching data <VersionBadge version="TypeScript only" />
 

--- a/pages/docs/examples/index.mdx
+++ b/pages/docs/examples/index.mdx
@@ -2,6 +2,8 @@ import { CardGroup, Card } from "src/shared/Docs/mdx";
 import { EnvelopeIcon, Cog6ToothIcon } from "@heroicons/react/24/outline";
 import { RiBracesFill, RiCalendarScheduleFill, RiErrorWarningFill, RiArrowDownDoubleFill, RiWifiFill, RiBarChart2Fill, RiShieldCheckFill } from "@remixicon/react";
 
+export const metaTitle = "Inngest Examples | Patterns, Integrations & Use Cases"
+export const description = "Browse code examples for Inngest: AI agents, email sequences, webhook integrations, scheduled jobs, durable HTTP, real-time streaming, and OpenTelemetry."
 export const hidePageSidebar = true;
 
 # Examples

--- a/pages/docs/examples/middleware/cloudflare-workers-environment-variables.mdx
+++ b/pages/docs/examples/middleware/cloudflare-workers-environment-variables.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Cloudflare Env Variables via Middleware | Inngest Docs"
+export const metaTitle = "Cloudflare Workers: Env Variables via Middleware | Inngest Docs"
 export const description = "Access Cloudflare Workers environment bindings and context inside Inngest functions using middleware for dependency injection."
 
 # Cloudflare Workers environment variables and context

--- a/pages/docs/examples/middleware/cloudflare-workers-environment-variables.mdx
+++ b/pages/docs/examples/middleware/cloudflare-workers-environment-variables.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Cloudflare Env Variables via Middleware | Inngest Docs"
+export const description = "Access Cloudflare Workers environment bindings and context inside Inngest functions using middleware for dependency injection."
+
 # Cloudflare Workers environment variables and context
 
 Cloudflare Workers does not set environment variables a global object like Node.js does with `process.env`. Workers [binds environment variables](https://developers.cloudflare.com/workers/configuration/environment-variables/) to the worker's special `fetch` event handler thought a specific `env` argument.

--- a/pages/docs/examples/open-telemetry.mdx
+++ b/pages/docs/examples/open-telemetry.mdx
@@ -1,7 +1,9 @@
 import { CodeGroup, CardGroup, Card, VersionBadge, Callout } from "src/shared/Docs/mdx";
 
 
-export const description = "Enrich your Inngest Traces with your application's OpenTelemetry traces";
+
+export const metaTitle = "OpenTelemetry Integration with Inngest | Inngest Docs"
+export const description = "Enrich Inngest function traces with your application's OpenTelemetry spans. Set up the ExtendedTraces middleware for end-to-end distributed tracing."
 
 # Set up OpenTelemetry with Inngest <VersionBadge version="TypeScript only" />
 

--- a/pages/docs/examples/realtime.mdx
+++ b/pages/docs/examples/realtime.mdx
@@ -2,7 +2,9 @@ import { ResourceGrid, Resource } from "src/shared/Docs/Resources";
 import { CardGroup, Card } from "src/shared/Docs/mdx";
 import { RiNodejsFill } from "@remixicon/react";
 
-export const description = "Stream updates and enable real-time workflows with Inngest functions.";
+
+export const metaTitle = "Stream Real-Time Updates from Inngest Functions"
+export const description = "Emit progress updates and stream results from long-running Inngest functions to your UI in real time using channels, topics, and the useRealtime hook."
 
 # Realtime: Stream updates from Inngest functions
 

--- a/pages/docs/examples/scheduling-one-off-function.mdx
+++ b/pages/docs/examples/scheduling-one-off-function.mdx
@@ -2,7 +2,9 @@ import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 import { Callout } from "src/shared/Docs/mdx";
 import { PencilSquareIcon } from "@heroicons/react/24/outline";
 
-export const description = "Schedule a function to run at a specific time in the future."
+
+export const metaTitle = "Schedule a One-Off Function Run | Inngest Docs"
+export const description = "Trigger an Inngest function to run at a specific future time using step.sleepUntil() or delayed event timestamps. No cron required for one-off jobs."
 
 # Scheduling a one-off function
 

--- a/pages/docs/examples/track-failures-in-datadog.mdx
+++ b/pages/docs/examples/track-failures-in-datadog.mdx
@@ -3,7 +3,9 @@ import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 import { RiBracesFill, RiErrorWarningFill } from "@remixicon/react";
 
 
-export const description = "Create a function that handles all function failures in an Inngest environment and forwards them to Datadog.";
+
+export const metaTitle = "Forward Inngest Function Failures to Datadog"
+export const description = "Create a catch-all failure handler that listens to inngest/function.failed events and forwards error details to Datadog for alerting and monitoring."
 
 # Track all function failures in Datadog
 

--- a/pages/docs/faq.mdx
+++ b/pages/docs/faq.mdx
@@ -1,4 +1,6 @@
-export const description = "Frequently asked questions about Inngest";
+
+export const metaTitle = "Inngest FAQ | Frequently Asked Questions"
+export const description = "Answers to common Inngest questions: cron configuration, stopping functions, branch environment keys, timeouts, authentication, data redaction, and more."
 
 # Frequently Asked Questions (FAQs)
 

--- a/pages/docs/features/events-triggers.mdx
+++ b/pages/docs/features/events-triggers.mdx
@@ -7,6 +7,9 @@ import {
   RiNewspaperLine,
 } from "@remixicon/react";
 
+export const metaTitle = "Events & Triggers | Inngest Docs"
+export const description = "Trigger Inngest functions from events, cron schedules, or direct invocation. Learn event format, wildcard matching, expression filters, and multi-trigger setup."
+
 # Events & Triggers
 
 Inngest functions are triggered asynchronously by **events** coming from various sources, including:

--- a/pages/docs/features/events-triggers/event-format.mdx
+++ b/pages/docs/features/events-triggers/event-format.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup, Callout, Info } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Inngest Event Payload Format | Inngest Docs"
+export const description = "Learn the required and optional fields in an Inngest event payload: name, data, user, ts, and v. Includes examples and validation rules for well-formed events."
+
 ## Event payload format
 
 The event payload is a JSON object that must contain a `name` and `data` property.

--- a/pages/docs/features/events-triggers/neon.mdx
+++ b/pages/docs/features/events-triggers/neon.mdx
@@ -1,6 +1,8 @@
 import { Callout, Info, ImageTheme } from "src/shared/Docs/mdx";
 
-export const description = `Trigger functions from your Neon Postgres database updates.`;
+
+export const metaTitle = "Trigger Inngest Functions from Neon Postgres | Inngest Docs"
+export const description = "Use Neon database change events to trigger Inngest functions. Set up the Neon integration to react to row inserts, updates, and deletes with durable workflows."
 
 # Neon
 

--- a/pages/docs/features/inngest-functions/cancellation.mdx
+++ b/pages/docs/features/inngest-functions/cancellation.mdx
@@ -6,6 +6,9 @@ import {
   RiCloseCircleLine,
 } from "@remixicon/react";
 
+export const metaTitle = "Function Cancellation | Stop In-Flight Runs"
+export const description = "Stop in-flight Inngest function runs using cancellation events, timeouts, or the bulk cancellation API. Optionally run cleanup logic on cancellation."
+
 # Cancellation
 
 Cancellation is a useful mechanism for preventing unnecessary actions based on previous actions (ex, skipping a report generation upon an account deletion) or stopping an unwanted function run composed of multiple steps (ex, deployment mistake, duplicates).

--- a/pages/docs/features/inngest-functions/cancellation/cancel-on-events.mdx
+++ b/pages/docs/features/inngest-functions/cancellation/cancel-on-events.mdx
@@ -1,5 +1,7 @@
 import { CodeGroup, Row, Col, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
-export const description = 'Learn how to cancel long running functions with events.'
+
+export const metaTitle = "Cancel Functions on Events | Inngest Docs"
+export const description = "Configure an Inngest function to automatically cancel when a specific event is received. Useful for aborting workflows when a user action supersedes them."
 
 # Cancel on Events
 

--- a/pages/docs/features/inngest-functions/cancellation/cancel-on-timeouts.mdx
+++ b/pages/docs/features/inngest-functions/cancellation/cancel-on-timeouts.mdx
@@ -1,5 +1,7 @@
 import { CodeGroup, Row, Col, LanguageSelector, LanguageSection, Callout, VersionBadge } from "src/shared/Docs/mdx";
-export const description = 'Learn how to cancel long running functions with events.'
+
+export const metaTitle = "Cancel Functions on Timeout | Inngest Docs"
+export const description = "Set a maximum duration on Inngest function runs and automatically cancel them if they exceed it. Prevents runaway jobs from consuming resources indefinitely."
 
 # Cancel on timeouts
 

--- a/pages/docs/features/inngest-functions/error-retries/failure-handlers.mdx
+++ b/pages/docs/features/inngest-functions/error-retries/failure-handlers.mdx
@@ -1,5 +1,8 @@
 import { CardGroup, Card, Callout, VersionBadge, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Failure Handlers | Run Code After All Retries Fail"
+export const description = "Define an onFailure handler that runs when an Inngest function exhausts all retries. Use it to alert, log, compensate, or trigger downstream recovery logic."
+
 # Failure handlers
 
 If your function exhausts all of its retries, it will be marked as "Failed." You can handle this circumstance by either providing an [`onFailure/on_failure`](/docs/reference/functions/handling-failures) handler when defining your function, or by listening for the [`inngest/function.failed`](/docs/reference/system-events/inngest-function-failed) system event.

--- a/pages/docs/features/inngest-functions/error-retries/inngest-errors.mdx
+++ b/pages/docs/features/inngest-functions/error-retries/inngest-errors.mdx
@@ -1,7 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Inngest Error Types | RetryAfterError & NonRetryableError"
+export const description = "Inngest SDK error classes: RetryAfterError to control retry timing, NonRetryableError to stop retries immediately, and step-level error handling."
 export const hidePageSidebar = true;
-
 
 # Inngest Errors
 

--- a/pages/docs/features/inngest-functions/error-retries/retries.mdx
+++ b/pages/docs/features/inngest-functions/error-retries/retries.mdx
@@ -1,5 +1,8 @@
 import { CardGroup, Card, Callout, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Automatic Retries in Inngest | Config & Behavior"
+export const description = "Inngest retries failed functions and steps up to 4 times with exponential backoff. Learn how to configure retry count, disable retries, and customize backoff."
+
 # Retries
 
 By default, in _addition_ to the **initial attempt**, Inngest will retry a function or a step up to 4 times until it succeeds. This means that for a function with a default configuration, it will be attempted 5 times in total.

--- a/pages/docs/features/inngest-functions/error-retries/rollbacks.mdx
+++ b/pages/docs/features/inngest-functions/error-retries/rollbacks.mdx
@@ -1,5 +1,8 @@
 import { CardGroup, Card, Callout, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Step Rollbacks on Failure | Inngest Docs"
+export const description = "Define rollback logic that runs if a step fails after all retries. Use step rollbacks to undo side effects and maintain consistency in multi-step workflows."
+
 # Rollbacks
 
 Unlike an error being thrown in the main function's body, a failing step (one that has exhausted all retries) will throw a `StepError`. This allows you to handle failures for each step individually, where you can recover from the error gracefully.

--- a/pages/docs/features/inngest-functions/steps-workflows/deferred-scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/deferred-scoring.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = "Build reusable scorers that run in the background and score based on events that arrive after a function completes."
+
+export const metaTitle = "Deferred Scoring | Run Evaluators After Completion"
+export const description = "Build reusable background scorers that evaluate AI outputs after a function completes, triggered by events that arrive asynchronously."
 
 # Build a deferred scorer
 

--- a/pages/docs/features/inngest-functions/steps-workflows/running-experiments.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/running-experiments.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = `Run experiments inside durable functions to compare AI models, prompt strategies, and pipeline approaches`
+
+export const metaTitle = "Run A/B Experiments Inside AI Pipelines | Inngest Docs"
+export const description = "Compare LLM models, prompts, and pipeline configurations within durable functions using group.experiment() for built-in, reproducible AI pipeline experiments."
 
 # Run experiments in AI pipelines
 

--- a/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = "Score Inngest function runs and steps to measure how well your AI workflows perform in production."
+
+export const metaTitle = "Score Inngest Function Runs | AI Evaluation Docs"
+export const description = "Attach quality scores to Inngest function runs and individual steps to measure AI workflow performance in production using the step metadata API."
 
 # Score a function run
 

--- a/pages/docs/features/inngest-functions/steps-workflows/sleeps.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/sleeps.mdx
@@ -1,6 +1,9 @@
 import { Callout, LanguageSelector, LanguageSection, CodeGroup } from "src/shared/Docs/mdx";
 
 
+export const metaTitle = "Sleeping in Inngest Functions | step.sleep() Guide"
+export const description = "Pause an Inngest function for a duration or until a specific datetime without blocking a thread or consuming compute. Supports durations up to 1 year."
+
 # Sleeps
 
 Two step methods, `step.sleep` and `step.sleepUntil`, are available to pause the execution of your function for a specific amount of time. Your function can sleep for seconds, minutes, or days, up to a maximum of one year.

--- a/pages/docs/features/inngest-functions/steps-workflows/sleeps.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/sleeps.mdx
@@ -1,7 +1,7 @@
 import { Callout, LanguageSelector, LanguageSection, CodeGroup } from "src/shared/Docs/mdx";
 
 
-export const metaTitle = "Sleeping in Inngest Functions | step.sleep() Guide"
+export const metaTitle = "Sleeping in Inngest Functions | step.sleep() & step.sleepUntil()"
 export const description = "Pause an Inngest function for a duration or until a specific datetime without blocking a thread or consuming compute. Supports durations up to 1 year."
 
 # Sleeps

--- a/pages/docs/features/inngest-functions/steps-workflows/step-ai-orchestration.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-ai-orchestration.mdx
@@ -1,6 +1,9 @@
 import { Callout, CodeGroup, VersionBadge, Card, CardGroup } from "src/shared/Docs/mdx";
 import Github from "src/shared/Icons/Github";
 
+export const metaTitle = "AI Inference Steps | Call LLMs Inside Inngest Functions"
+export const description = "Make retryable, observable LLM calls from within Inngest steps using the AI inference API. Works with OpenAI, Anthropic, and any OpenAI-compatible provider."
+
 # AI Inference <VersionBadge version="TypeScript and Python only" />
 
 You can build complex AI workflows and call model providers as steps using two-step methods, `step.ai.infer()` and `step.ai.wrap()`, or our AgentKit SDK.  They work with any model provider, and all offer full AI observability:

--- a/pages/docs/features/inngest-functions/steps-workflows/step-metadata-how-to.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-metadata-how-to.mdx
@@ -1,6 +1,8 @@
 import { CodeGroup, VersionBadge, Info, Warning } from "src/shared/Docs/mdx";
 
-export const description = "Practical guides for attaching metadata to function runs, using custom kinds, batching updates, and working with cross-run metadata.";
+
+export const metaTitle = "Step Metadata | Attach Data to Function Runs"
+export const description = "Use the step metadata API to attach custom key-value data to Inngest function runs and steps for scoring, labeling, and debugging in the Inngest dashboard."
 
 # Metadata how-to <VersionBadge version="TypeScript only" />
 

--- a/pages/docs/features/inngest-functions/steps-workflows/wait-for-event.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/wait-for-event.mdx
@@ -1,5 +1,8 @@
 import { Callout, LanguageSelector, LanguageSection, CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.waitForEvent() | Pause and Resume on an Event"
+export const description = "Pause an Inngest function until a matching event arrives, then resume with the event data. Configure a timeout and correlation expression for precise matching."
+
 {/* Sidebar doesn't work well when LanguageSection have different headings...  */}
 export const hidePageSidebar = true;
 

--- a/pages/docs/features/inngest-functions/steps-workflows/wait-for-signal.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/wait-for-signal.mdx
@@ -1,5 +1,8 @@
 import { Callout, LanguageSelector, LanguageSection, CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.waitForSignal() | Wait for External Signals"
+export const description = "Pause an Inngest function and resume it when a named signal is sent from your server or another function. Ideal for human-in-the-loop and approval workflows."
+
 {/* Sidebar doesn't work well when LanguageSection have different headings...  */}
 export const hidePageSidebar = true;
 

--- a/pages/docs/features/middleware.mdx
+++ b/pages/docs/features/middleware.mdx
@@ -6,6 +6,9 @@ import {
   RiFileSearchLine,
 } from "@remixicon/react";
 
+export const metaTitle = "Inngest Middleware | Docs Overview"
+export const description = "Extend Inngest's request lifecycle with middleware: inject dependencies, transform data, add logging, integrate Sentry, or encrypt sensitive payloads."
+
 # Middleware
 
 Middleware allows your code to run at various points in an Inngest client's lifecycle, such as during a function's execution or when sending an event. 

--- a/pages/docs/features/middleware/create.mdx
+++ b/pages/docs/features/middleware/create.mdx
@@ -8,6 +8,9 @@ import {
   RiKeyLine,
 } from "@remixicon/react";
 
+export const metaTitle = "Creating Inngest Middleware | Inngest Docs"
+export const description = "Build custom middleware for Inngest functions using the InngestMiddleware class. Hook into the function lifecycle to add logging, auth, or data transformation."
+
 # Creating middleware
 
 Creating middleware means defining the lifecycles and subsequent hooks in those lifecycles to run code in. Lifecycles are actions such as a function run or sending events, and individual hooks within those are where we run code, usually with a _before_ and _after_ step.

--- a/pages/docs/features/middleware/dependency-injection.mdx
+++ b/pages/docs/features/middleware/dependency-injection.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge, LanguageSelector, LanguageSection, Card, CardGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Dependency Injection with Inngest Middleware"
+export const description = "Use Inngest middleware to inject dependencies like database clients, loggers, or service instances into your functions without globals or manual threading."
+
 # Using Middleware for Dependency Injection
 
 Inngest Functions running in the same application often need to share common clients instances such as database clients or third-party

--- a/pages/docs/features/middleware/encryption-middleware.mdx
+++ b/pages/docs/features/middleware/encryption-middleware.mdx
@@ -13,6 +13,9 @@ import {
   VersionBadge,
 } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Encryption Middleware | Encrypt Step Data at Rest"
+export const description = "Automatically encrypt and decrypt sensitive step inputs and outputs with Inngest Encryption Middleware, so data is never stored in plaintext on Inngest servers."
+
 # Encryption Middleware
 
 

--- a/pages/docs/features/middleware/sentry-middleware.mdx
+++ b/pages/docs/features/middleware/sentry-middleware.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge, LanguageSelector, LanguageSection, Card, CardGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Sentry Middleware | Inngest Error Reporting"
+export const description = "Integrate Sentry with Inngest using the official Sentry middleware to automatically capture exceptions from function runs with full trace context."
+
 # Sentry Middleware
 
 

--- a/pages/docs/features/realtime.mdx
+++ b/pages/docs/features/realtime.mdx
@@ -11,7 +11,9 @@ import {
   VersionBadge,
 } from "src/shared/Docs/mdx";
 
-export const description = "Learn the v4 realtime concepts and workflow for streaming updates from Inngest functions.";
+
+export const metaTitle = "Inngest Realtime | Stream Updates from Functions"
+export const description = "Stream real-time updates from Inngest functions to your UI using typed channels and topics. Built into TypeScript SDK v4 with no extra infrastructure needed."
 
 # Realtime <VersionBadge version="TypeScript SDK v4" />
 

--- a/pages/docs/features/realtime.mdx
+++ b/pages/docs/features/realtime.mdx
@@ -11,9 +11,7 @@ import {
   VersionBadge,
 } from "src/shared/Docs/mdx";
 
-
-export const metaTitle = "Inngest Realtime | Stream Updates from Functions"
-export const description = "Stream real-time updates from Inngest functions to your UI using typed channels and topics. Built into TypeScript SDK v4 with no extra infrastructure needed."
+export const description = "Learn the v4 realtime concepts and workflow for streaming updates from Inngest functions.";
 
 # Realtime <VersionBadge version="TypeScript SDK v4" />
 

--- a/pages/docs/features/realtime/react-hooks.mdx
+++ b/pages/docs/features/realtime/react-hooks.mdx
@@ -4,7 +4,9 @@ import {
   RiNodejsFill,
 } from "@remixicon/react";
 
-export const description = "Learn how to use the v4 useRealtime hook in Next.js and React.";
+
+export const metaTitle = "useRealtime Hook | Stream Inngest Updates in React"
+export const description = "Use the useRealtime React hook in Next.js or React to subscribe to real-time updates from Inngest functions directly in your UI components."
 
 # React hooks / Next.js <VersionBadge version="TypeScript SDK v4" />
 

--- a/pages/docs/features/realtime/subscribe.mdx
+++ b/pages/docs/features/realtime/subscribe.mdx
@@ -1,6 +1,8 @@
 import { Steps, Step, CodeGroup, Warning } from "src/shared/Docs/mdx";
 
-export const description = 'Learn how to subscribe to data from Inngest functions.';
+
+export const metaTitle = "Subscribe to Inngest Realtime Channels | Server-Side"
+export const description = "Mint subscription tokens and consume Inngest real-time streams server-side using getClientSubscriptionToken() and the subscribe() API."
 
 <Warning>
   This page documents deprecated v3 subscribe patterns. For the current v4

--- a/pages/docs/functions/concurrency.mdx
+++ b/pages/docs/functions/concurrency.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup, Callout, Properties, Property } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Concurrency Configuration Reference | Inngest Docs"
+export const description = "Set limits, keys, and scopes to control step-level parallelism across function runs."
+
 # Managing concurrency
 
 Limit the number of concurrently running steps for your function with the [`concurrency`](/docs/reference/functions/create#configuration) configuration options. Setting an optional `key` parameter limits the concurrency for each unique value of the expression.

--- a/pages/docs/functions/references.mdx
+++ b/pages/docs/functions/references.mdx
@@ -1,5 +1,8 @@
 import { Callout, Properties, Property } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Referencing Inngest Functions | inngest.getFunction()"
+export const description = "Reference other Inngest functions by ID using inngest.getFunction() to invoke them directly or retrieve metadata without hard-coding function identifiers."
+
 # Referencing functions
 
 Using [`step.invoke()`](/docs/reference/functions/step-invoke), you can directly call one Inngest function from another and handle the result. You can use this with `referenceFunction` to call Inngest functions located in other apps, or to avoid importing dependencies of functions within the same app.

--- a/pages/docs/getting-started/astro-quick-start.mdx
+++ b/pages/docs/getting-started/astro-quick-start.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = `Get started with Inngest and Astro in this ten-minute tutorial`
+
+export const metaTitle = "Astro Quick Start | Add Background Jobs to Astro"
+export const description = "Add durable background functions and event-driven workflows to your Astro app in 10 minutes. No queue infrastructure needed."
 
 # Astro Quick Start
 

--- a/pages/docs/getting-started/express-quick-start.mdx
+++ b/pages/docs/getting-started/express-quick-start.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = `Get started with Inngest in this ten-minute JavaScript tutorial`
+
+export const metaTitle = "Express Quick Start | Add Background Jobs to Express"
+export const description = "Get started with Inngest in an Express.js app. Set up the serve handler, create your first durable function, and test it locally with the Inngest Dev Server."
 
 # Express Quick Start
 

--- a/pages/docs/getting-started/h3-quick-start.mdx
+++ b/pages/docs/getting-started/h3-quick-start.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = `Get started with Inngest and H3 in this ten-minute tutorial`
+
+export const metaTitle = "H3 Quick Start | Add Background Jobs to H3"
+export const description = "Add durable background functions and event-driven workflows to an H3 app in 10 minutes using the Inngest TypeScript SDK."
 
 # H3 Quick Start
 

--- a/pages/docs/getting-started/nestjs-quick-start.mdx
+++ b/pages/docs/getting-started/nestjs-quick-start.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = `Get started with Inngest and NestJS in this ten-minute tutorial`
+
+export const metaTitle = "NestJS Quick Start | Add Background Jobs to NestJS"
+export const description = "Integrate Inngest into a NestJS app. Register the serve module, write your first durable function, and test it locally in under 10 minutes."
 
 # NestJS Quick Start
 

--- a/pages/docs/getting-started/nodejs-quick-start.mdx
+++ b/pages/docs/getting-started/nodejs-quick-start.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup, Col, Row } from "src/shared/Docs/mdx";
 
-export const description = `Get started with Inngest in this ten-minute JavaScript tutorial`
+
+export const metaTitle = "Node.js Quick Start | Add Background Jobs to Node.js"
+export const description = "Get started with Inngest in any Node.js framework. Set up the serve handler, write a durable background function, and run it locally in under 10 minutes."
 
 # Node.js Quick Start
 

--- a/pages/docs/getting-started/python-quick-start.mdx
+++ b/pages/docs/getting-started/python-quick-start.mdx
@@ -1,6 +1,8 @@
 import { CodeGroup, Callout } from "src/shared/Docs/mdx";
 
-export const description = `Get started with Inngest in this ten-minute Python tutorial`
+
+export const metaTitle = "Python Quick Start | Add Background Jobs to Python"
+export const description = "Add durable background functions to a Python app using Flask, FastAPI, or Django in 10 minutes. No queue infrastructure required."
 
 {/* This is a duplicate of /docs/reference/python/overview/quick-start.mdx, which will soon be deleted*/}
 

--- a/pages/docs/getting-started/tanstack-start-quick-start.mdx
+++ b/pages/docs/getting-started/tanstack-start-quick-start.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = `Get started with Inngest in this ten-minute TanStack Start tutorial`
+
+export const metaTitle = "TanStack Start Quick Start | Background Jobs in TanStack"
+export const description = "Add Inngest to a TanStack Start app. Create durable background functions and test them locally with the Inngest Dev Server in under 10 minutes."
 
 # TanStack Start Quick Start
 

--- a/pages/docs/guides/background-jobs.mdx
+++ b/pages/docs/guides/background-jobs.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup, Row, Col, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
-export const description = `Define background jobs in just a few lines of code.`
+
+export const metaTitle = "Background Jobs with Inngest | Setup Guide"
+export const description = "Run background jobs with automatic retries in a few lines of code. No queues, no workers, no infrastructure. Works on serverless platforms out of the box."
 
 # Background jobs
 This guide will walk you through creating background jobs with retries in a few minutes.

--- a/pages/docs/guides/batching.mdx
+++ b/pages/docs/guides/batching.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = 'Handle high load by processing events in batches. Ideal for bulk operations.'
+
+export const metaTitle = "Batch Processing Events | Inngest Docs"
+export const description = "Process high volumes of events in batches to reduce function invocations and enable bulk operations. Configure batch size, timeout, and key-based grouping."
 
 # Batching events
 

--- a/pages/docs/guides/cancel-running-functions.mdx
+++ b/pages/docs/guides/cancel-running-functions.mdx
@@ -1,5 +1,7 @@
 import { CodeGroup, Row, Col } from "src/shared/Docs/mdx";
-export const description = 'Learn how to cancel long running functions with our API.'
+
+export const metaTitle = "Bulk Cancel Running Function Runs | Inngest Docs"
+export const description = "Cancel multiple in-flight Inngest function runs at once using the REST API. Filter by function ID, event name, or time range to scope the cancellation."
 
 # Bulk Cancellation
 

--- a/pages/docs/guides/clerk-webhook-events.mdx
+++ b/pages/docs/guides/clerk-webhook-events.mdx
@@ -1,4 +1,6 @@
-export const description = 'Set up Clerk webhooks with Inngest and use Clerk events within Inngest functions.'
+
+export const metaTitle = "Handle Clerk Webhooks with Inngest | Docs"
+export const description = "Receive Clerk webhook events in Inngest to sync user data to your database, provision account resources on signup, and trigger workflows on auth events."
 
 # Handling Clerk webhook events
 

--- a/pages/docs/guides/concurrency.mdx
+++ b/pages/docs/guides/concurrency.mdx
@@ -2,6 +2,9 @@ import { Callout, Info, Tip, CodeGroup, Properties, Property } from "src/shared/
 import Lottie from "lottie-react";
 import Concurrency from "components/RedesignedLanding/FlowAccoridion/Lottie/Concurrency.json";
 
+export const metaTitle = "Concurrency Control in Inngest | Step Limits"
+export const description = "Limit the number of steps executing concurrently across function runs. Set global or key-scoped concurrency limits to protect downstream services and databases."
+
 # Concurrency management
 
 Limiting concurrency in systems is an important tool for correctly managing computing resources and scaling workloads. Inngest's concurrency control enables you to manage the number of _steps_ that concurrently execute.

--- a/pages/docs/guides/concurrency.mdx
+++ b/pages/docs/guides/concurrency.mdx
@@ -2,7 +2,7 @@ import { Callout, Info, Tip, CodeGroup, Properties, Property } from "src/shared/
 import Lottie from "lottie-react";
 import Concurrency from "components/RedesignedLanding/FlowAccoridion/Lottie/Concurrency.json";
 
-export const metaTitle = "Concurrency Control in Inngest | Step Limits"
+export const metaTitle = "Concurrency Control in Inngest | Limit Parallel Step Execution"
 export const description = "Limit the number of steps executing concurrently across function runs. Set global or key-scoped concurrency limits to protect downstream services and databases."
 
 # Concurrency management

--- a/pages/docs/guides/debounce.mdx
+++ b/pages/docs/guides/debounce.mdx
@@ -1,6 +1,8 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = 'Avoid unnecessary function invocations by de-duplicating events over a sliding time window. Ideal for preventing wasted work when a function might be triggered in quick succession.'
+
+export const metaTitle = "Debounce | Deduplicate Events Over a Time Window"
+export const description = "Collapse rapid event sequences into one function run using a sliding time window. Avoids redundant work when a function might be triggered in quick succession."
 
 # Debounce
 

--- a/pages/docs/guides/debug-with-cli.mdx
+++ b/pages/docs/guides/debug-with-cli.mdx
@@ -1,4 +1,6 @@
-export const description = "Step-by-step guide to inspecting a failed function run and identifying the broken step using the Inngest CLI."
+
+export const metaTitle = "Debug Inngest Functions with the CLI | Inngest Docs"
+export const description = "Use the Inngest CLI to inspect function runs, send test events, and debug failures locally without needing the cloud dashboard."
 
 # Debug a function run from your terminal
 

--- a/pages/docs/guides/delayed-functions.mdx
+++ b/pages/docs/guides/delayed-functions.mdx
@@ -1,5 +1,8 @@
 import { LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Delayed & Scheduled One-Off Functions | Inngest Docs"
+export const description = "Schedule a function to run at a future time using event timestamps or step.sleepUntil(). Ideal for reminders, follow-ups, and time-delayed processing."
+
 # Delayed Functions
 
 You can easily run functions in the future with Inngest. There are three ways to delay function execution:

--- a/pages/docs/guides/error-handling.mdx
+++ b/pages/docs/guides/error-handling.mdx
@@ -3,7 +3,9 @@ import { RiArrowGoBackLine, RiErrorWarningLine } from "@remixicon/react";
 
 import ReplayIcon from 'src/shared/Icons/Replay';
 
-export const description = 'Learn how to handle errors and failures in your Inngest functions.'
+
+export const metaTitle = "Error Handling & Retries in Inngest | Docs"
+export const description = "Inngest functions automatically retry on failure. Customize retry counts, handle per-step errors, define onFailure handlers, and implement step-level rollbacks."
 
 # Errors & Retries
 

--- a/pages/docs/guides/error-handling.mdx
+++ b/pages/docs/guides/error-handling.mdx
@@ -3,9 +3,7 @@ import { RiArrowGoBackLine, RiErrorWarningLine } from "@remixicon/react";
 
 import ReplayIcon from 'src/shared/Icons/Replay';
 
-
-export const metaTitle = "Error Handling & Retries in Inngest | Docs"
-export const description = "Inngest functions automatically retry on failure. Customize retry counts, handle per-step errors, define onFailure handlers, and implement step-level rollbacks."
+export const description = 'Learn how to handle errors and failures in your Inngest functions.'
 
 # Errors & Retries
 

--- a/pages/docs/guides/fan-out-jobs.mdx
+++ b/pages/docs/guides/fan-out-jobs.mdx
@@ -1,6 +1,8 @@
 import { ImageTheme, LanguageSelector, LanguageSection, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = 'How to use the fan-out pattern with Inngest to trigger multiple functions from a single event.'
+
+export const metaTitle = "Fan-Out Pattern | One Event, Many Functions"
+export const description = "Trigger multiple Inngest functions from a single event to run work in parallel. Fan-out decouples producers from consumers for scalable event-driven systems."
 
 # Fan-out (one-to-many)
 

--- a/pages/docs/guides/flow-control.mdx
+++ b/pages/docs/guides/flow-control.mdx
@@ -8,7 +8,9 @@ import {
   RiSkipRightFill,
 } from "@remixicon/react";
 
-export const description = 'Learn how to manage how functions are executed with flow control.';
+
+export const metaTitle = "Flow Control in Inngest | Concurrency, Throttling & More"
+export const description = "Manage function execution with flow control: concurrency limits, throttling, rate limiting, event batching, priority, debounce, and singleton runs."
 
 # Flow Control
 

--- a/pages/docs/guides/handling-idempotency.mdx
+++ b/pages/docs/guides/handling-idempotency.mdx
@@ -1,5 +1,8 @@
 import { Callout, Row, Col, CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Idempotency in Inngest | Prevent Duplicate Runs"
+export const description = "Ensure Inngest functions run exactly once per event using idempotency keys. Prevent duplicate processing when events are retried or delivered more than once."
+
 # Handling idempotency
 
 Ensuring that your code is idempotent is foundational to building reliable systems. Within Inngest, there are multiple ways to ensure that your functions are idempotent.

--- a/pages/docs/guides/index.mdx
+++ b/pages/docs/guides/index.mdx
@@ -1,5 +1,7 @@
 import { ResourceGrid, Resource } from 'src/shared/Docs/Resources'
 
+export const metaTitle = "Inngest Guides | Patterns, Integrations & How-Tos"
+export const description = "In-depth guides for building with Inngest: flow control, error handling, scheduled jobs, webhook integrations, fan-out patterns, idempotency, and more."
 export const hidePageSidebar = true;
 
 # Guides

--- a/pages/docs/guides/instrumenting-graphql.mdx
+++ b/pages/docs/guides/instrumenting-graphql.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Instrument GraphQL with Inngest | Docs"
+export const description = "Add Inngest background jobs and durable workflows to a GraphQL API. Trigger functions from mutations and handle long-running work outside the request cycle."
+
 # Instrumenting GraphQL
 
 {/* Intro discussing what instrumenting GraphQL means */}

--- a/pages/docs/guides/invoking-functions-directly.mdx
+++ b/pages/docs/guides/invoking-functions-directly.mdx
@@ -1,5 +1,8 @@
 import { Callout, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Invoke Inngest Functions Directly | step.invoke() Guide"
+export const description = "Call Inngest functions directly from other functions using step.invoke() and wait for their return value. Compose workflows across multiple durable functions."
+
 # Invoking functions directly
 
 Inngest's `step.invoke()` function provides a powerful tool for calling functions directly within your event-driven system. It differs from traditional event-driven triggers, offering a more direct, RPC-like approach. This encourages a few key benefits:

--- a/pages/docs/guides/logging.mdx
+++ b/pages/docs/guides/logging.mdx
@@ -1,6 +1,9 @@
 import { CodeGroup, VersionBadge, Tip } from "src/shared/Docs/mdx";
 import { Tag } from "src/shared/Docs/Tag";
 
+export const metaTitle = "Logging Inside Inngest Functions | Inngest Docs"
+export const description = "Add structured logging to your Inngest functions using the built-in logger. Logs appear in the Inngest dashboard alongside step traces for each function run."
+
 # Logging in Inngest
 
 Log handling can have some caveats when working with serverless runtimes.

--- a/pages/docs/guides/mergent-migration.mdx
+++ b/pages/docs/guides/mergent-migration.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Migrating from Mergent to Inngest | Migration Guide"
+export const description = "Migrate from Mergent to Inngest for durable background job execution. Map Mergent task concepts to Inngest functions, triggers, and the Dev Server."
+
 # Mergent migration guide
 
 As Mergent transitions its focus, we recommend migrating your background jobs, workflows, and event-driven systems to Inngest, a modern developer platform purpose-built for reliable, scalable background functions and workflows.

--- a/pages/docs/guides/multiple-triggers.mdx
+++ b/pages/docs/guides/multiple-triggers.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup, Info } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Multiple Triggers & Event Wildcards | Inngest Docs"
+export const description = "Trigger a single Inngest function from multiple events or use wildcard patterns to match a family of events. Reduce code duplication across similar workflows."
+
 # Multiple triggers & wildcards
 
 Inngest functions can be configured to trigger on multiple events or schedules.

--- a/pages/docs/guides/pause-functions.mdx
+++ b/pages/docs/guides/pause-functions.mdx
@@ -1,4 +1,6 @@
-export const description = 'Learn how to pause an Inngest function.'
+
+export const metaTitle = "Pause & Resume Inngest Functions | Inngest Docs"
+export const description = "Temporarily pause an Inngest function to stop new runs from starting, then resume it when ready. Useful during incidents or planned maintenance windows."
 
 # Function Pausing
 

--- a/pages/docs/guides/priority.mdx
+++ b/pages/docs/guides/priority.mdx
@@ -1,6 +1,8 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = 'Dynamically adjust the execution order of functions based on any data. Ideal for pushing critical work to the front of the queue.'
+
+export const metaTitle = "Function Run Priority | Push Critical Work First"
+export const description = "Dynamically rank Inngest function runs using a CEL expression over event data. Ensure high-priority work executes first without managing separate queues."
 
 # Priority
 

--- a/pages/docs/guides/rate-limiting.mdx
+++ b/pages/docs/guides/rate-limiting.mdx
@@ -1,6 +1,8 @@
 import { CodeGroup, Callout } from "src/shared/Docs/mdx";
 
-export const description = 'Prevent excessive function runs over a given time period by skipping events beyond a specific limit. Ideal for protecting against abuse.'
+
+export const metaTitle = "Rate Limiting Inngest Functions | Skip Excess Events"
+export const description = "Prevent function runs from exceeding a rate over a time window by skipping events beyond the limit. Protect against abuse or third-party API quota exhaustion."
 
 # Rate limiting
 

--- a/pages/docs/guides/resend-webhook-events.mdx
+++ b/pages/docs/guides/resend-webhook-events.mdx
@@ -1,7 +1,9 @@
 import { ImageTheme, CodeGroup } from "src/shared/Docs/mdx";
 import ResendLogo from "src/public/assets/docs/guides/resend-webhook-events/featured-image.png";
 
-export const description = 'Set up Resend webhooks with Inngest and use Resend events within Inngest functions.'
+
+export const metaTitle = "Handle Resend Webhooks with Inngest | Email Event Workflows"
+export const description = "Receive Resend webhook events in Inngest to trigger workflows on email delivery, bounces, or complaints. Build reliable email-driven automation without polling."
 
 # Integrate email events with Resend webhooks
 

--- a/pages/docs/guides/scheduled-functions.mdx
+++ b/pages/docs/guides/scheduled-functions.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup, Callout, LanguageSection, LanguageSelector } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Scheduled Functions & Cron Jobs | Inngest Docs"
+export const description = "Create recurring background jobs using cron expressions in Inngest. Supports timezone-aware schedules and runs on any platform including serverless."
+
 # Crons (Scheduled Functions)
 
 You can create scheduled jobs using cron schedules within Inngest natively.  Inngest's cron schedules also support timezones, allowing you to schedule work in whatever timezone you need work to run in.

--- a/pages/docs/guides/sending-events-from-functions.mdx
+++ b/pages/docs/guides/sending-events-from-functions.mdx
@@ -1,6 +1,8 @@
 import { Callout, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
-export const description = 'How to send events from within functions to trigger other functions to run in parallel'
+
+export const metaTitle = "Send Events from Inside a Function | Inngest Docs"
+export const description = "Use step.sendEvent() inside an Inngest function to trigger other functions or fan-out work in parallel. Events are sent reliably as part of the step lifecycle."
 
 # Sending events from functions
 

--- a/pages/docs/guides/singleton.mdx
+++ b/pages/docs/guides/singleton.mdx
@@ -1,5 +1,8 @@
 import { VersionBadge, Callout, ImageTheme, Info, CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Singleton Functions | Ensure Only One Run at a Time"
+export const description = "Prevent concurrent runs of an Inngest function using the singleton configuration. Queue or skip additional invocations while one run is already in progress."
+
 # Singleton Functions <VersionBadge version="TypeScript v3.39.0+" /> <VersionBadge version="Go SDK v0.12.0+" /> <VersionBadge version="Python v0.5+" />
 
 

--- a/pages/docs/guides/step-parallelism.mdx
+++ b/pages/docs/guides/step-parallelism.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Parallel Steps | Run Multiple Steps Concurrently"
+export const description = "Execute multiple Inngest steps in parallel using Promise.all() to reduce total runtime. Steps run concurrently and results are collected when all complete."
+
 # Step parallelism
 
 - If you’re using a serverless platform to host, code will run in true parallelism similar to multi-threading (without shared state)

--- a/pages/docs/guides/throttling.mdx
+++ b/pages/docs/guides/throttling.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = 'Limit the throughput of function execution over a period of time. Ideal for working around third-party API rate limits.';
+
+export const metaTitle = "Throttling | Limit Function Throughput Over Time"
+export const description = "Cap Inngest function throughput to a maximum number of runs per time period. Ideal for respecting third-party API rate limits without dropping or losing events."
 
 # Throttling
 

--- a/pages/docs/guides/trigger-your-code-from-retool.mdx
+++ b/pages/docs/guides/trigger-your-code-from-retool.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Trigger Inngest Functions from Retool | Docs"
+export const description = "Send Inngest events from Retool internal tools to trigger background functions. Use Retool's HTTP connector to kick off durable workflows from admin dashboards."
+
 # Trigger your code from Retool
 
 Internal tools are a pain to build and maintain. Fortunately, [Retool](https://retool.com/) has helped tons of companies reduce the burden. Retool primarily focuses on building dashboards and forms and it integrates well with several databases and cloud APIs.

--- a/pages/docs/guides/user-defined-workflows.mdx
+++ b/pages/docs/guides/user-defined-workflows.mdx
@@ -1,6 +1,9 @@
 import { Callout, CodeGroup, Card, CardGroup, ImageTheme } from "src/shared/Docs/mdx";
 import GithubIcon from "shared/Icons/Github"
 
+export const metaTitle = "User-Defined Workflows | Build Workflow Engines"
+export const description = "Let your users configure and run their own workflows with Inngest's Workflow Kit. Build a visual workflow engine backed by durable, event-driven execution."
+
 # Build workflows configurable by your users
 
 Users today are demanding customization and integrations from every product. Your users may want your product to support custom workflows to automate key user actions.

--- a/pages/docs/guides/user-defined-workflows.mdx
+++ b/pages/docs/guides/user-defined-workflows.mdx
@@ -1,7 +1,7 @@
 import { Callout, CodeGroup, Card, CardGroup, ImageTheme } from "src/shared/Docs/mdx";
 import GithubIcon from "shared/Icons/Github"
 
-export const metaTitle = "User-Defined Workflows | Build Workflow Engines"
+export const metaTitle = "User-Defined Workflows | Build a Workflow Engine for Your Users"
 export const description = "Let your users configure and run their own workflows with Inngest's Workflow Kit. Build a visual workflow engine backed by durable, event-driven execution."
 
 # Build workflows configurable by your users

--- a/pages/docs/guides/working-with-loops.mdx
+++ b/pages/docs/guides/working-with-loops.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup, Callout, LanguageSection, LanguageSelector } from "shared/Docs/mdx";
 
-export const metaTitle = "Loops in Inngest Functions | Pitfalls & Patterns"
+export const metaTitle = "Working with Loops in Inngest Functions | Pitfalls & Patterns"
 export const description = "Safely implement loops inside Inngest functions. Avoid common step memoization pitfalls and learn the correct patterns for iterating over dynamic data."
 
 # Working with Loops in Inngest

--- a/pages/docs/guides/working-with-loops.mdx
+++ b/pages/docs/guides/working-with-loops.mdx
@@ -1,5 +1,7 @@
 import { CodeGroup, Callout, LanguageSection, LanguageSelector } from "shared/Docs/mdx";
-export const description = 'Implement loops in your Inngest functions and avoid common pitfalls.';
+
+export const metaTitle = "Loops in Inngest Functions | Pitfalls & Patterns"
+export const description = "Safely implement loops inside Inngest functions. Avoid common step memoization pitfalls and learn the correct patterns for iterating over dynamic data."
 
 # Working with Loops in Inngest
 

--- a/pages/docs/guides/writing-expressions.mdx
+++ b/pages/docs/guides/writing-expressions.mdx
@@ -1,5 +1,8 @@
 import { Info } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Writing Trigger Expressions (CEL) | Inngest Docs"
+export const description = "Write CEL expressions to filter which events trigger your Inngest functions. Match on event data fields, user properties, or custom attributes with precision."
+
 # Writing expressions
 
 Expressions are used in a number of ways for configuring your functions. They are used for:

--- a/pages/docs/improve-performance.mdx
+++ b/pages/docs/improve-performance.mdx
@@ -1,6 +1,8 @@
 import { Info, CodeGroup, LanguageSelector, LanguageSection } from "shared/Docs/mdx";
 
-export const description = "Solutions to reduce latency"
+
+export const metaTitle = "Improve Inngest Performance | Reduce Latency"
+export const description = "Reduce latency and increase throughput for Inngest function runs. Optimize step counts, SDK configuration, concurrency settings, and deployment topology."
 
 # Improve Performance
 

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -13,6 +13,8 @@ import SkillsMDIcon from 'src/shared/Icons/SkillsMD';
 import MCPIcon from 'src/shared/Icons/MCP';
 import LLMsTXTIcon from 'src/shared/Icons/LLMsTxt';
 
+export const metaTitle = "Inngest Docs | Inngest"
+export const description = "Build reliable background jobs, workflows, and AI agents in TypeScript, Python, and Go without managing queues or infrastructure."
 export const hidePageSidebar = true;
 
 # Inngest Documentation

--- a/pages/docs/learn/durable-endpoints.mdx
+++ b/pages/docs/learn/durable-endpoints.mdx
@@ -3,7 +3,7 @@ import { Info, Callout, CodeGroup, Steps, Step, CardGroup, Card, VersionBadge, L
 import { RiNextjsFill } from "@remixicon/react";
 
 
-export const metaTitle = "Durable Endpoints | Retriable HTTP Handlers"
+export const metaTitle = "Durable Endpoints | Turn Any HTTP Handler into a Durable Workflow"
 export const description = "Make any HTTP endpoint durable with automatic retries and step-based checkpointing using Inngest Durable Endpoints. No queue or worker infrastructure required."
 
 # Durable Endpoints <VersionBadge version="Beta" />

--- a/pages/docs/learn/durable-endpoints.mdx
+++ b/pages/docs/learn/durable-endpoints.mdx
@@ -2,7 +2,9 @@ import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 import { Info, Callout, CodeGroup, Steps, Step, CardGroup, Card, VersionBadge, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 import { RiNextjsFill } from "@remixicon/react";
 
-export const description = 'Learn how to create Durable Endpoints with Inngest. Turn any API endpoint into a durable, observable workflow with step-based checkpointing.';
+
+export const metaTitle = "Durable Endpoints | Retriable HTTP Handlers"
+export const description = "Make any HTTP endpoint durable with automatic retries and step-based checkpointing using Inngest Durable Endpoints. No queue or worker infrastructure required."
 
 # Durable Endpoints <VersionBadge version="Beta" />
 

--- a/pages/docs/learn/durable-endpoints/streaming.mdx
+++ b/pages/docs/learn/durable-endpoints/streaming.mdx
@@ -1,6 +1,8 @@
 import { Callout, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = 'Learn how to durably stream data back to clients from Durable Endpoints';
+
+export const metaTitle = "Streaming with Durable Endpoints | Inngest Docs"
+export const description = "Stream incremental responses back to clients from a Durable Endpoint while running durable step logic in the background. Combine streaming UX with reliability."
 
 # Durable Endpoints Streaming <VersionBadge version="Developer Preview" />
 

--- a/pages/docs/learn/glossary.mdx
+++ b/pages/docs/learn/glossary.mdx
@@ -1,4 +1,6 @@
-export const description = `Key terms for Inngest's documentation explained.`
+
+export const metaTitle = "Inngest Glossary | Key Terms Explained"
+export const description = "Definitions for core Inngest concepts: functions, steps, events, triggers, environments, apps, durable execution, flow control, and more."
 
 # Glossary
 

--- a/pages/docs/learn/how-functions-are-executed.mdx
+++ b/pages/docs/learn/how-functions-are-executed.mdx
@@ -1,6 +1,8 @@
 import { Callout } from "shared/Docs/mdx";
 
-export const description = "Learn how Inngest functions are executed using Durable Execution. Understand how steps are executed, how errors are handled, and how state is persisted."
+
+export const metaTitle = "How Inngest Functions Execute | Durable Execution"
+export const description = "How Inngest's Durable Execution Engine runs your functions: how steps are checkpointed, state is persisted, and retries work without re-running past steps."
 
 # How Inngest functions are executed: Durable Execution
 

--- a/pages/docs/learn/inngest-functions.mdx
+++ b/pages/docs/learn/inngest-functions.mdx
@@ -11,9 +11,6 @@ import TypeScriptIcon from 'src/shared/Icons/TypeScript';
 import PythonIcon from 'src/shared/Icons/Python';
 import GoIcon from 'src/shared/Icons/Go';
 
-export const metaTitle = "Inngest Functions | Durable Background Logic"
-export const description = "Inngest functions are durable, retriable units of background logic triggered by events or cron schedules. Write standard TypeScript, Python, or Go functions."
-
 # Inngest Functions
 
 Inngest functions enable developers to run reliable background logic, from background jobs to complex workflows.

--- a/pages/docs/learn/inngest-functions.mdx
+++ b/pages/docs/learn/inngest-functions.mdx
@@ -11,6 +11,9 @@ import TypeScriptIcon from 'src/shared/Icons/TypeScript';
 import PythonIcon from 'src/shared/Icons/Python';
 import GoIcon from 'src/shared/Icons/Go';
 
+export const metaTitle = "Inngest Functions | Durable Background Logic"
+export const description = "Inngest functions are durable, retriable units of background logic triggered by events or cron schedules. Write standard TypeScript, Python, or Go functions."
+
 # Inngest Functions
 
 Inngest functions enable developers to run reliable background logic, from background jobs to complex workflows.

--- a/pages/docs/learn/inngest-steps.mdx
+++ b/pages/docs/learn/inngest-steps.mdx
@@ -1,10 +1,8 @@
 import { Callout } from "shared/Docs/mdx";
 import IconConcurrency from 'src/shared/Icons/FlowControl/Concurrency';
 
+export const description = 'Learn about Inngest steps and their methods.';
 import { LanguageSelector, LanguageSection } from "shared/Docs/mdx";
-
-export const metaTitle = "Steps in Inngest | Checkpointed, Retriable Units of Work"
-export const description = "Steps are the building blocks of Inngest functions. Each step is memoized, retriable, and can sleep, wait for events, or invoke other functions independently."
 
 # Inngest Steps
 

--- a/pages/docs/learn/inngest-steps.mdx
+++ b/pages/docs/learn/inngest-steps.mdx
@@ -1,8 +1,10 @@
 import { Callout } from "shared/Docs/mdx";
 import IconConcurrency from 'src/shared/Icons/FlowControl/Concurrency';
 
-export const description = 'Learn about Inngest steps and their methods.';
 import { LanguageSelector, LanguageSection } from "shared/Docs/mdx";
+
+export const metaTitle = "Steps in Inngest | Checkpointed, Retriable Units of Work"
+export const description = "Steps are the building blocks of Inngest functions. Each step is memoized, retriable, and can sleep, wait for events, or invoke other functions independently."
 
 # Inngest Steps
 

--- a/pages/docs/learn/security.mdx
+++ b/pages/docs/learn/security.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Inngest Security | Signing Keys & Best Practices"
+export const description = "How Inngest secures communication with your servers: request signing, signing key rotation, environment isolation, and secure deployment best practices."
+
 # Security
 
 Security is a primary consideration when moving systems into production.  In this section we'll dive into how Inngest handles security, including endpoint security, encryption, standard practices, and how to add SAML authentication to your account. Learn more about

--- a/pages/docs/learn/versioning.mdx
+++ b/pages/docs/learn/versioning.mdx
@@ -1,6 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = "Learn how to evolve and version long-running Inngest functions over time with step-based memoization."
+
+export const metaTitle = "Function Versioning | Evolve Long-Running Inngest Functions"
+export const description = "Safely update Inngest functions while runs are in-flight using step memoization. Understand how new deploys interact with paused and sleeping function runs."
 
 # Versioning and Function Evolution
 

--- a/pages/docs/local-development.mdx
+++ b/pages/docs/local-development.mdx
@@ -9,9 +9,6 @@ import TypeScriptIcon from 'src/shared/Icons/TypeScript';
 import PythonIcon from 'src/shared/Icons/Python';
 import GoIcon from 'src/shared/Icons/Go';
 
-export const metaTitle = "Local Development with the Inngest Dev Server"
-export const description = "Run Inngest functions locally with one command. Full observability, event replay, and the same execution model as production. No Redis or workers required."
-
 # Local development
 
 Testing background jobs, durable workflows, and event-driven functions locally is notoriously painful. Most solutions require running a full Redis stack, managing separate worker processes, or writing mocks that don't reflect how your code behaves in production. The Inngest Dev Server eliminates all of that with a single command, giving you a complete local environment with the same execution model, flow control, and observability you get in production.

--- a/pages/docs/local-development.mdx
+++ b/pages/docs/local-development.mdx
@@ -9,6 +9,9 @@ import TypeScriptIcon from 'src/shared/Icons/TypeScript';
 import PythonIcon from 'src/shared/Icons/Python';
 import GoIcon from 'src/shared/Icons/Go';
 
+export const metaTitle = "Local Development with the Inngest Dev Server"
+export const description = "Run Inngest functions locally with one command. Full observability, event replay, and the same execution model as production. No Redis or workers required."
+
 # Local development
 
 Testing background jobs, durable workflows, and event-driven functions locally is notoriously painful. Most solutions require running a full Redis stack, managing separate worker processes, or writing mocks that don't reflect how your code behaves in production. The Inngest Dev Server eliminates all of that with a single command, giving you a complete local environment with the same execution model, flow control, and observability you get in production.

--- a/pages/docs/patterns/index.tsx
+++ b/pages/docs/patterns/index.tsx
@@ -13,17 +13,18 @@ import { indexMarkdown } from "../../../shared/Patterns/markdown";
 import "../../../shared/Patterns/patterns-docs.css";
 
 const META_DESCRIPTION =
-  "Patterns for building on Inngest: AI agents, durable workflows, scheduling, flow control, and background jobs. Each explains a recurring problem, the tradeoffs, and how to solve it with Inngest's primitives.";
+  "Architectural patterns for Inngest: AI agents, durable workflows, fan-out, scheduling, flow control, and background jobs, with tradeoffs and code examples.";
 
 export async function getStaticProps() {
   return {
     props: {
       title: "Patterns",
+      metaTitle: "Inngest Patterns | Workflow Architecture Guides",
       description: META_DESCRIPTION,
       hidePageSidebar: true,
       designVersion: "2",
       meta: {
-        title: "Patterns: How to build with Inngest",
+        title: "Inngest Patterns | Workflow Architecture Guides",
         description: META_DESCRIPTION,
       },
     },
@@ -33,7 +34,11 @@ export async function getStaticProps() {
 function Arrow({ s = 14 }: { s?: number }) {
   return (
     <svg width={s} height={s} viewBox="0 0 14 14" fill="none" aria-hidden>
-      <path d="M3 7 L11 7 M7 3 L11 7 L7 11" stroke="currentColor" strokeWidth="1.4" />
+      <path
+        d="M3 7 L11 7 M7 3 L11 7 L7 11"
+        stroke="currentColor"
+        strokeWidth="1.4"
+      />
     </svg>
   );
 }
@@ -59,7 +64,9 @@ export default function PatternsLanding() {
     );
   }
 
-  const featuredSection = sections.find((s) => s.id === FEATURED_PATTERN.category);
+  const featuredSection = sections.find(
+    (s) => s.id === FEATURED_PATTERN.category
+  );
   const featuredPattern = featuredSection?.patterns.find(
     (p) => p.slug === FEATURED_PATTERN.slug
   );
@@ -100,7 +107,10 @@ export default function PatternsLanding() {
               // eslint-disable-next-line @next/next/no-img-element
               <img src={FEATURED_PATTERN.image} alt="" className="feat-img" />
             ) : (
-              <Viz id={featuredSection.viz} accent={featuredSection.accent.hex} />
+              <Viz
+                id={featuredSection.viz}
+                accent={featuredSection.accent.hex}
+              />
             )}
           </div>
         </Link>
@@ -128,7 +138,8 @@ export default function PatternsLanding() {
             <span className="cat-card-name">{s.name}</span>
             <span className="cat-card-kicker">{s.kicker}</span>
             <span className="cat-card-meta mono">
-              {s.patterns.length} {s.patterns.length === 1 ? "pattern" : "patterns"}{" "}
+              {s.patterns.length}{" "}
+              {s.patterns.length === 1 ? "pattern" : "patterns"}{" "}
               <Arrow s={12} />
             </span>
           </Link>

--- a/pages/docs/platform/api-keys.mdx
+++ b/pages/docs/platform/api-keys.mdx
@@ -1,6 +1,8 @@
 import { Info, Warning, CodeGroup, Steps, Step } from "shared/Docs/mdx";
 
-export const description = 'Learn about API keys for use with the Inngest REST API.'
+
+export const metaTitle = "Inngest API Keys | REST API Authentication"
+export const description = "Create and manage API keys for authenticating requests to the Inngest REST API. Learn key scopes, how to rotate keys, and how to use them in CI/CD pipelines."
 
 # API Keys
 

--- a/pages/docs/platform/deployment.mdx
+++ b/pages/docs/platform/deployment.mdx
@@ -9,9 +9,6 @@ import {
   RiServerLine
 } from "@remixicon/react";
 
-export const metaTitle = "Deploying Inngest Functions | Platform Overview"
-export const description = "Overview of Inngest deployment options: the serve() HTTP handler for serverless platforms and the connect() persistent worker model for long-running compute."
-
 # Deployment
 
 Moving to production requires deploying your Inngest Functions on your favorite Cloud Provider and configuring it to allow the Inngest Platform to orchestrate runs: 

--- a/pages/docs/platform/deployment.mdx
+++ b/pages/docs/platform/deployment.mdx
@@ -9,6 +9,9 @@ import {
   RiServerLine
 } from "@remixicon/react";
 
+export const metaTitle = "Deploying Inngest Functions | Platform Overview"
+export const description = "Overview of Inngest deployment options: the serve() HTTP handler for serverless platforms and the connect() persistent worker model for long-running compute."
+
 # Deployment
 
 Moving to production requires deploying your Inngest Functions on your favorite Cloud Provider and configuring it to allow the Inngest Platform to orchestrate runs: 

--- a/pages/docs/platform/environments.mdx
+++ b/pages/docs/platform/environments.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Inngest Environments | Branch, Staging & Production"
+export const description = "Use separate Inngest environments for production, staging, and branch previews. Each has its own event keys, signing keys, and function registrations."
+
 # Environments
 
 Inngest accounts all have multiple environments that help support your entire software development lifecycle. Inngest has different types of environments:

--- a/pages/docs/platform/index.mdx
+++ b/pages/docs/platform/index.mdx
@@ -1,4 +1,6 @@
 import { GuideGrid, Guide } from 'src/shared/Docs/Guides'
+export const metaTitle = "Inngest Platform Guides | Manage, Monitor & Deploy"
+export const description = "Guides for the Inngest platform: managing environments, monitoring runs, configuring webhooks, rotating keys, bulk replay, and observability integrations."
 export const hidePageSidebar = true;
 
 # Platform Guides

--- a/pages/docs/platform/manage/apps.mdx
+++ b/pages/docs/platform/manage/apps.mdx
@@ -1,5 +1,8 @@
 import { Callout } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Managing Inngest Apps | Sync, View & Configure"
+export const description = "View and manage your synced Inngest apps in the dashboard. See registered functions, app status, SDK version, and sync history for each connected app."
+
 # Apps
 
 Inngest enables you to manage your Inngest Functions deployments via [Inngest Environments and Apps](/docs/apps). Inngest Environments (ex, production, testing) can contain multiple Apps that can be managed using:

--- a/pages/docs/platform/manage/bulk-cancellation.mdx
+++ b/pages/docs/platform/manage/bulk-cancellation.mdx
@@ -1,5 +1,8 @@
 import { Callout } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Bulk Cancel Function Runs | Inngest Platform Docs"
+export const description = "Cancel multiple in-flight function runs at once from the Inngest dashboard or REST API. Filter by function, event, or time range to target the right runs."
+
 # Function runs Bulk Cancellation
 
 In addition to providing [SDK Cancellation features](/docs/features/inngest-functions/cancellation/cancel-on-events) and a [dedicated REST API endpoint](/docs/guides/cancel-running-functions), the Inngest Platform also features a Bulk Cancellation UI.

--- a/pages/docs/platform/manage/rotating-keys.mdx
+++ b/pages/docs/platform/manage/rotating-keys.mdx
@@ -1,6 +1,8 @@
 import { Info, Warning, CodeGroup, Steps, Step } from "shared/Docs/mdx";
 
-export const description = 'Learn about how to rotate event and signing keys for Inngest apps.'
+
+export const metaTitle = "Rotate Inngest Signing & Event Keys | Security Guide"
+export const description = "Rotate Inngest signing and event keys without downtime. Learn the rotation sequence, how the SDK handles the key transition, and how to update your environment."
 
 # Rotating keys
 

--- a/pages/docs/platform/monitor/datadog-integration.mdx
+++ b/pages/docs/platform/monitor/datadog-integration.mdx
@@ -1,7 +1,9 @@
 import { Steps, Step, Button, Info } from "shared/Docs/mdx";
 import { RiExternalLinkLine } from "@remixicon/react";
 
-export const description = "Inngest supports exporting metrics to Datadog. This enables you to monitor your Ingest functions from your existing Datadog or Datadog-compatible monitoring tools like Grafana, New Relic, or similar."
+
+export const metaTitle = "Datadog Integration | Export Inngest Metrics"
+export const description = "Export Inngest function metrics to Datadog for monitoring. Compatible with Grafana, New Relic, and other Datadog-compatible monitoring tools."
 
 # Datadog integration
 

--- a/pages/docs/platform/monitor/insights.mdx
+++ b/pages/docs/platform/monitor/insights.mdx
@@ -1,6 +1,8 @@
 import { Info, Warning } from "src/shared/Docs/mdx";
 
-export const description = 'Query and analyze event and run data with SQL in the Inngest platform.';
+
+export const metaTitle = "Inngest Insights | Query Run & Event Data with SQL"
+export const description = "Run SQL queries over Inngest function run and event data in the platform. Analyze performance, error rates, event volumes, and trends without external tools."
 
 # Insights
 

--- a/pages/docs/platform/monitor/inspecting-events.mdx
+++ b/pages/docs/platform/monitor/inspecting-events.mdx
@@ -1,6 +1,9 @@
 import { Callout, Tip, Row, Col } from "src/shared/Docs/mdx";
 import { RiExternalLinkFill } from "@remixicon/react";
 
+export const metaTitle = "Inspect Events in the Inngest Dashboard | Docs"
+export const description = "Browse and inspect individual events received by Inngest: view payload data, which functions were triggered, and replay events to re-run affected functions."
+
 # Inspecting an Event
 
 The Event details will provide all the information to understand how this event was received, which data it contained and the tools to reproduce it locally.

--- a/pages/docs/platform/monitor/inspecting-function-runs.mdx
+++ b/pages/docs/platform/monitor/inspecting-function-runs.mdx
@@ -1,6 +1,9 @@
 import { Callout, Tip, Row, Col } from "src/shared/Docs/mdx";
 import { RiExternalLinkFill } from "@remixicon/react";
 
+export const metaTitle = "Inspect Function Runs | Step Traces & Debug Views"
+export const description = "View step traces, logs, and timing data for individual Inngest function runs in the dashboard. Debug failures, inspect step output, and replay failed runs."
+
 # Inspecting a Function run
 
 You identified a failed Function run and want to identify the root cause? Or simply want to dig into a run's timings?

--- a/pages/docs/platform/monitor/observability-metrics.mdx
+++ b/pages/docs/platform/monitor/observability-metrics.mdx
@@ -1,6 +1,8 @@
 import { Callout, Col, Row } from "src/shared/Docs/mdx";
 
-export const description = "Monitor function runs, event throughput, and step execution across your durable workflows and AI pipelines with built-in observability.";
+
+export const metaTitle = "Inngest Observability & Metrics | Monitor Function Health"
+export const description = "Monitor function run throughput, error rates, step execution, queue depth, and latency across your Inngest functions with built-in metrics and dashboards."
 
 # Observability & Metrics
 

--- a/pages/docs/platform/monitor/prometheus-metrics-export-integration.mdx
+++ b/pages/docs/platform/monitor/prometheus-metrics-export-integration.mdx
@@ -1,5 +1,8 @@
 import { Callout } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Prometheus Metrics Export | Inngest Integration"
+export const description = "Export Inngest function metrics in Prometheus format for scraping by Grafana, Prometheus, or compatible monitoring stacks."
+
 # Prometheus metrics export integration
 
 Inngest supports exporting [Prometheus](https://prometheus.io/) metrics via scrape endpoints. This enables you to monitor your Inngest functions from your existing Prometheus or Prometheus-compatible monitoring tools like [Grafana](https://prometheus.io/docs/visualization/grafana/), [New Relic](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/), or similar.

--- a/pages/docs/platform/monitor/traces.mdx
+++ b/pages/docs/platform/monitor/traces.mdx
@@ -1,6 +1,8 @@
 import { Callout, Note, Tip, Button, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = "Inngest traces give you a detailed, interactive timeline of every function run, from queue delays and step execution to HTTP connection phases and OpenTelemetry spans.";
+
+export const metaTitle = "Inngest Traces | Step Timelines & OTel Spans"
+export const description = "Inngest traces show an interactive timeline for every function run: queue delays, step execution, HTTP phases, and OpenTelemetry spans from your application."
 
 # Traces
 

--- a/pages/docs/platform/replay.mdx
+++ b/pages/docs/platform/replay.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Function Replay | Re-run Failed Runs in Bulk"
+export const description = "Replay failed Inngest function runs in bulk after a bug fix or outage. Filter by function, time range, or failure type and re-process without resending events."
+
 # Function Replay
 
 Functions will fail. It's unavoidable. When they do, you need to recover from the failure quickly.

--- a/pages/docs/platform/signing-keys.mdx
+++ b/pages/docs/platform/signing-keys.mdx
@@ -1,6 +1,8 @@
 import { Callout } from "src/shared/Docs/mdx";
 
-export const description = 'Learn about how signing keys are used to secure communication between Inngest and your servers, how to rotate them, and how to set them in your SDK.'
+
+export const metaTitle = "Inngest Signing Keys | Secure Function Communication"
+export const description = "Signing keys authenticate requests between Inngest and your server, preventing unauthorized invocations and replay attacks. Learn how to set and rotate them."
 
 # Signing keys
 

--- a/pages/docs/platform/webhooks.mdx
+++ b/pages/docs/platform/webhooks.mdx
@@ -4,6 +4,9 @@ import {
   RiGithubFill
 } from "@remixicon/react";
 
+export const metaTitle = "Consume Webhook Events via Inngest | Setup Guide"
+export const description = "Use Inngest as a webhook receiver to ingest events from third-party services. Transform payloads into Inngest events and trigger functions automatically."
+
 # Consuming webhook events
 
 At its core, Inngest is centered around functions that are triggered by events. Webhooks are one of the most ubiquitous sources for events for developers. Inngest was designed to support webhook events.

--- a/pages/docs/platform/webhooks/build-an-integration.mdx
+++ b/pages/docs/platform/webhooks/build-an-integration.mdx
@@ -1,6 +1,8 @@
 import { Properties, Property, Steps, Step } from "src/shared/Docs/mdx";
 
-export const description = "Build webhook integrations with any application using webhook intents."
+
+export const metaTitle = "Build a Webhook Integration with Inngest | Docs"
+export const description = "Use Inngest Webhook Intents to let external services trigger your functions. Includes payload transformation, signature verification, and integration setup."
 
 # Webhook intents: Building a webhook integration
 

--- a/pages/docs/reference/go/migrations/v0.7-to-v0.8.mdx
+++ b/pages/docs/reference/go/migrations/v0.7-to-v0.8.mdx
@@ -1,5 +1,8 @@
 import { Callout, Tip, Warning } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Go SDK Migration: v0.7 → v0.8 | Inngest Docs"
+export const description = "Step-by-step migration guide for upgrading the Inngest Go SDK from v0.7 to v0.8. Covers breaking changes, renamed types, and updated function configuration."
+
 # Go SDK migration guide: v0.7 to v0.8
 
 This guide will help you migrate your Inngest Go SDK from v0.7 to v0.8 by providing a summary of the breaking changes.

--- a/pages/docs/reference/go/migrations/v0.8-to-v0.11.mdx
+++ b/pages/docs/reference/go/migrations/v0.8-to-v0.11.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Go SDK Migration: v0.8 → v0.11 | Inngest Docs"
+export const description = "Step-by-step migration guide for upgrading the Inngest Go SDK from v0.8 to v0.11. Covers API changes, new features, and deprecated patterns."
+
 # Go SDK migration guide: v0.8 to v0.11
 
 This guide will help you migrate your Inngest Go SDK from v0.8 to v0.11 by providing a summary of the breaking changes.

--- a/pages/docs/reference/index.mdx
+++ b/pages/docs/reference/index.mdx
@@ -7,6 +7,8 @@ import {
 import GoIcon from "src/shared/Icons/Go";
 
 
+export const metaTitle = "Inngest SDK Reference | TypeScript, Python & Go"
+export const description = "Explore Inngest SDK APIs for TypeScript v4 and v3, Python, and Go, including function config, step methods, client setup, and middleware lifecycle."
 export const hidePageSidebar = true;
 
 # Reference

--- a/pages/docs/reference/index.mdx
+++ b/pages/docs/reference/index.mdx
@@ -8,7 +8,7 @@ import GoIcon from "src/shared/Icons/Go";
 
 
 export const metaTitle = "Inngest SDK Reference | TypeScript, Python & Go"
-export const description = "Explore Inngest SDK APIs for TypeScript v4 and v3, Python, and Go, including function config, step methods, client setup, and middleware lifecycle."
+export const description = "API reference for the Inngest SDKs: TypeScript (v4 and v3), Python, and Go. Covers function config, step methods, client setup, and the middleware lifecycle."
 export const hidePageSidebar = true;
 
 # Reference

--- a/pages/docs/reference/python/client/overview.mdx
+++ b/pages/docs/reference/python/client/overview.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Inngest Python Client | inngest.Inngest() Reference"
+export const description = "Initialize with your app ID, API key, and environment settings to send events and register functions."
+
 # Inngest client
 
 The Inngest client is used to configure your application and send events outside of Inngest functions.

--- a/pages/docs/reference/python/client/send.mdx
+++ b/pages/docs/reference/python/client/send.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Send Events | Python SDK Reference"
+export const description = "Use client.send() to send one or more events to Inngest from Python. Supports async usage with asyncio and integrates with FastAPI, Flask, and Django."
+
 # Send events
 
 <Callout variant="info" skipSearchCrawler>

--- a/pages/docs/reference/python/functions/create.mdx
+++ b/pages/docs/reference/python/functions/create.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Create a Function | Python SDK Reference"
+export const description = "inngest_client.create_function() configures function ID, triggers, retries, concurrency, and the handler signature in the Inngest Python SDK."
+
 # Create Function
 
 Define your functions using the `create_function` decorator.

--- a/pages/docs/reference/python/guides/modal.mdx
+++ b/pages/docs/reference/python/guides/modal.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Run Inngest Functions on Modal | Python Guide"
+export const description = "Deploy Inngest Python functions on Modal for scalable serverless GPU or CPU workloads. Configure the serve endpoint and sync your app with the Inngest platform."
+
 # Modal
 
 This guide will help you use setup an Inngest app in [Modal](https://modal.com), a platform for building and deploying serverless Python applications.

--- a/pages/docs/reference/python/guides/pydantic.mdx
+++ b/pages/docs/reference/python/guides/pydantic.mdx
@@ -1,5 +1,8 @@
 import { Info } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Pydantic Integration | Inngest Python SDK"
+export const description = "Use Pydantic models for type-safe event data and step outputs in Inngest Python functions. Automatic validation and serialization for structured payloads."
+
 # Pydantic
 
 This guide will help you use Pydantic to perform runtime type validation when sending and receiving events.

--- a/pages/docs/reference/python/guides/testing.mdx
+++ b/pages/docs/reference/python/guides/testing.mdx
@@ -1,5 +1,8 @@
 import { Callout, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Testing Inngest Python Functions | Unit Test Guide"
+export const description = "Write unit tests for Inngest Python functions using the test client. Test step logic, event handling, and retry behavior without a live Inngest environment."
+
 # Testing
 
 ## Unit testing

--- a/pages/docs/reference/python/index.mdx
+++ b/pages/docs/reference/python/index.mdx
@@ -1,5 +1,8 @@
 import GithubIcon from "shared/Icons/Github"
 
+export const metaTitle = "Inngest Python SDK Reference | Docs"
+export const description = "Explore Inngest Python SDK APIs for creating functions, sending events, step methods, middleware, environment variables, and framework integrations."
+
 # Python SDK
 
 ## Installing

--- a/pages/docs/reference/python/index.mdx
+++ b/pages/docs/reference/python/index.mdx
@@ -1,7 +1,7 @@
 import GithubIcon from "shared/Icons/Github"
 
 export const metaTitle = "Inngest Python SDK Reference | Docs"
-export const description = "Explore Inngest Python SDK APIs for creating functions, sending events, step methods, middleware, environment variables, and framework integrations."
+export const description = "Full reference for the Inngest Python SDK: creating functions, sending events, step methods, middleware, environment variables, and framework integrations."
 
 # Python SDK
 

--- a/pages/docs/reference/python/middleware/lifecycle.mdx
+++ b/pages/docs/reference/python/middleware/lifecycle.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Python Middleware Lifecycle | Inngest Docs"
+export const description = "Python middleware lifecycle hooks in the Inngest SDK: before_execution, after_execution, before_send_response, and transform_input."
+
 # Python middleware lifecycle
 
 The order of middleware lifecycle hooks is as follows:

--- a/pages/docs/reference/python/middleware/overview.mdx
+++ b/pages/docs/reference/python/middleware/overview.mdx
@@ -1,5 +1,8 @@
 import { VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Middleware Overview | Inngest Python SDK"
+export const description = "Add middleware to Inngest Python functions to inject dependencies, log requests, transform data, or integrate with observability tools across all function runs."
+
 # Middleware <VersionBadge version="v0.3.0+" />
 
 Middleware allows you to run code at various points in an Inngest function's lifecycle. This is useful for adding custom behavior to your functions, like error reporting and end-to-end encryption.

--- a/pages/docs/reference/python/migrations/v0.3-to-v0.4.mdx
+++ b/pages/docs/reference/python/migrations/v0.3-to-v0.4.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Python SDK Migration: v0.3 → v0.4 | Inngest Docs"
+export const description = "Upgrade guide for Inngest Python SDK v0.3 → v0.4. Covers breaking API changes and updated patterns for function creation, event sending, and client setup."
+
 # Python SDK migration guide: v0.3 to v0.4
 
 This guide will help you migrate your Inngest Python SDK from v0.3 to v0.4 by providing a summary of the breaking changes.

--- a/pages/docs/reference/python/migrations/v0.4-to-v0.5.mdx
+++ b/pages/docs/reference/python/migrations/v0.4-to-v0.5.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Python SDK Migration: v0.4 → v0.5 | Inngest Docs"
+export const description = "Migration guide for upgrading the Inngest Python SDK from v0.4 to v0.5. Covers breaking changes in step API, middleware, and client initialization."
+
 # Python SDK migration guide: v0.4 to v0.5
 
 This guide will help you migrate your Inngest Python SDK from v0.4 to v0.5.

--- a/pages/docs/reference/python/overview/env-vars.mdx
+++ b/pages/docs/reference/python/overview/env-vars.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Environment Variables | Inngest Python SDK"
+export const description = "Environment variables used by the Inngest Python SDK: INNGEST_API_KEY, INNGEST_SIGNING_KEY, INNGEST_BASE_URL, and dev mode settings."
+
 # Environment variables
 
 You can use environment variables to control some configuration.

--- a/pages/docs/reference/python/overview/prod-mode.mdx
+++ b/pages/docs/reference/python/overview/prod-mode.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Production Mode | Inngest Python SDK"
+export const description = "Configure the Inngest Python SDK for production. Enable signing key verification, set the API base URL, and disable Dev Server fallback for deployed apps."
+
 # Production mode
 
 When the SDK is in production mode it will try to connect to Inngest Cloud instead of the Inngest Dev Server. Production mode is opt-out for security reasons.

--- a/pages/docs/reference/python/steps/invoke.mdx
+++ b/pages/docs/reference/python/steps/invoke.mdx
@@ -1,7 +1,7 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
 export const metaTitle = "step.invoke() | Python SDK Reference"
-export const description = "Use step.invoke() inside a Python step to call another Inngest function, wait for its return value, and handle parameters and return types."
+export const description = "Invoke another Inngest function from within a Python step and wait for its return value. Reference for the invoke() method, parameters, and return type."
 
 # Invoke <VersionBadge version="v0.3.0+" />
 

--- a/pages/docs/reference/python/steps/invoke.mdx
+++ b/pages/docs/reference/python/steps/invoke.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.invoke() | Python SDK Reference"
+export const description = "Use step.invoke() inside a Python step to call another Inngest function, wait for its return value, and handle parameters and return types."
+
 # Invoke <VersionBadge version="v0.3.0+" />
 
 Calls another Inngest function, waits for its completion, and returns its output.

--- a/pages/docs/reference/python/steps/invoke_by_id.mdx
+++ b/pages/docs/reference/python/steps/invoke_by_id.mdx
@@ -1,5 +1,8 @@
 import { Properties, Property, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.invoke_by_id() | Python SDK Reference"
+export const description = "Invoke an Inngest function by its string ID from within a Python step. Useful when the target function is defined in a different codebase or SDK version."
+
 # Invoke by ID <VersionBadge version="v0.3.0+" />
 
 Calls another Inngest function, waits for its completion, and returns its output.

--- a/pages/docs/reference/python/steps/parallel.mdx
+++ b/pages/docs/reference/python/steps/parallel.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.parallel() | Run Steps Concurrently (Python SDK)"
+export const description = "Execute multiple Inngest steps concurrently in Python using step.parallel(). All steps run at the same time and results are returned as a tuple when complete."
+
 # Parallel <VersionBadge version="v0.3.0+" />
 
 Run steps in parallel. Returns the parallel steps' result as a tuple.

--- a/pages/docs/reference/python/steps/run.mdx
+++ b/pages/docs/reference/python/steps/run.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.run() | Execute a Step (Python SDK Reference)"
+export const description = "step.run() in the Inngest Python SDK wraps any logic in a retriable, memoized step visible in the Inngest dashboard trace."
+
 # Run
 
 Turn a normal function into a durable function. Any function passed to `step.run` will be executed in a durable way, including retries and memoization.

--- a/pages/docs/reference/python/steps/send-event.mdx
+++ b/pages/docs/reference/python/steps/send-event.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.send_event() | Send Events from a Step (Python)"
+export const description = "Reliably send one or more events from inside an Inngest Python function step. Events are sent as part of the step lifecycle and appear in the run trace."
+
 # Send event
 
 <Callout variant="info" skipSearchCrawler>

--- a/pages/docs/reference/python/steps/sleep-until.mdx
+++ b/pages/docs/reference/python/steps/sleep-until.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.sleep_until() | Sleep Until a Datetime (Python)"
+export const description = "Pause an Inngest Python function until a specific datetime using step.sleep_until(). The function resumes automatically at the target time."
+
 # Sleep until
 
 Sleep until a specific time. Accepts a `datetime.datetime` object.

--- a/pages/docs/reference/python/steps/sleep.mdx
+++ b/pages/docs/reference/python/steps/sleep.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.sleep() | Pause a Python Function (SDK Reference)"
+export const description = "Pause an Inngest Python function for a duration using step.sleep(). The function resumes automatically without blocking compute or consuming a thread."
+
 # Sleep
 
 Sleep for a period of time. Accepts either a `datetime.timedelta` object or a number of milliseconds.

--- a/pages/docs/reference/python/steps/wait-for-event.mdx
+++ b/pages/docs/reference/python/steps/wait-for-event.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.wait_for_event() | Wait for an Event (Python SDK)"
+export const description = "Pause an Inngest Python function and resume when a matching event is received. Set a timeout and correlation expression to match the right event."
+
 # Wait for event
 
 Wait until the Inngest server receives a specific event.

--- a/pages/docs/reference/rest-api/index.mdx
+++ b/pages/docs/reference/rest-api/index.mdx
@@ -1,5 +1,5 @@
 export const metaTitle = "Inngest REST API Reference | Docs"
-export const description = "Use the Inngest REST API to create events, fetch run status, cancel runs, manage functions, and integrate Inngest into backend workflows."
+export const description = "REST API reference for the Inngest platform: create events, fetch run status, cancel runs, manage functions, and integrate Inngest into your backend workflows."
 
 # REST API
 

--- a/pages/docs/reference/rest-api/index.mdx
+++ b/pages/docs/reference/rest-api/index.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Inngest REST API Reference | Docs"
+export const description = "Use the Inngest REST API to create events, fetch run status, cancel runs, manage functions, and integrate Inngest into backend workflows."
+
 # REST API
 
 You can view our REST API docs at our API reference portal: [https://api-docs.inngest.com](https://api-docs.inngest.com).

--- a/pages/docs/reference/system-events/inngest-function-cancelled.mdx
+++ b/pages/docs/reference/system-events/inngest-function-cancelled.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "inngest/function.cancelled | System Event Reference"
+export const description = "inngest/function.cancelled fires when a function run is cancelled. Use it to run cleanup logic or notify downstream systems."
+
 # `inngest/function.cancelled` {{ className: "not-prose" }}
 
 The `inngest/function.cancelled` event is sent whenever any single function is cancelled in your [Inngest environment](/docs/platform/environments). The event will be sent if the event is cancelled via [`cancelOn` event](/docs/features/inngest-functions/cancellation/cancel-on-events), [function timeouts](/docs/features/inngest-functions/cancellation/cancel-on-timeouts),  [REST API](/docs/guides/cancel-running-functions) or [bulk cancellation](/docs/platform/manage/bulk-cancellation).

--- a/pages/docs/reference/system-events/inngest-function-failed.mdx
+++ b/pages/docs/reference/system-events/inngest-function-failed.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "inngest/function.failed | System Event Reference"
+export const description = "inngest/function.failed fires when a function exhausts all retries. Use it to forward failures to Datadog, PagerDuty, or Slack."
+
 # `inngest/function.failed` {{ className: "not-prose" }}
 
 The `inngest/function.failed` event is sent whenever any single function fails in your [Inngest environment](/docs/platform/environments).

--- a/pages/docs/reference/typescript/v3/client/create.mdx
+++ b/pages/docs/reference/typescript/v3/client/create.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Create the Inngest Client | TypeScript SDK v3 Reference"
+export const description = "Configure your app ID, API key, event schemas, logger, and environment settings for the Inngest client."
+
 # Create the Inngest Client
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/durable-endpoints.mdx
+++ b/pages/docs/reference/typescript/v3/durable-endpoints.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, CodeGroup, Col, Properties, Property, Row, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = 'TypeScript SDK reference for Durable Endpoints. Create HTTP handlers with step-based checkpointing.';
+
+export const metaTitle = "Durable Endpoints | TypeScript SDK v3 Reference"
+export const description = "Turn HTTP handlers into durable, checkpointed workflows with automatic retries."
 
 # Durable Endpoints <VersionBadge version="Beta" />
 <Info skipSearchCrawler>

--- a/pages/docs/reference/typescript/v3/events/send.mdx
+++ b/pages/docs/reference/typescript/v3/events/send.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = `Send one or more events to Inngest via inngest.send() in the TypeScript SDK.`
+
+export const metaTitle = "inngest.send() | Send Events (TypeScript SDK v3)"
+export const description = "inngest.send() in TypeScript SDK v3 sends one or more typed events to Inngest from your application code or inside function steps."
 
 # Send events
 <Info skipSearchCrawler>

--- a/pages/docs/reference/typescript/v3/extended-traces.mdx
+++ b/pages/docs/reference/typescript/v3/extended-traces.mdx
@@ -2,7 +2,9 @@ import { Info, Callout, Note, CardGroup, Card } from "src/shared/Docs/mdx";
 import { RiBarChart2Fill } from "@remixicon/react";
 
 
-export const description = "Inngest supports OpenTelemetry for distributed tracing and observability. Use the extendedTracesMiddleware to automatically instrument your Inngest functions and send spans to your observability platform.";
+
+export const metaTitle = "Extended Traces (OpenTelemetry) | TypeScript SDK v3"
+export const description = "Use ExtendedTracesMiddleware in TypeScript SDK v3 to instrument Inngest functions and send spans to your OpenTelemetry-compatible observability platform."
 
 # Usage
 <Info skipSearchCrawler>

--- a/pages/docs/reference/typescript/v3/functions/cancel-on.mdx
+++ b/pages/docs/reference/typescript/v3/functions/cancel-on.mdx
@@ -1,6 +1,9 @@
 import { Info, Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 import { InformationCircleIcon } from '@heroicons/react/24/outline'
 
+export const metaTitle = "cancelOn | Auto-Cancel on Events (TypeScript SDK v3)"
+export const description = "Configure expressions to automatically cancel a function run when a matching event is received."
+
 # Cancel on
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/functions/create.mdx
+++ b/pages/docs/reference/typescript/v3/functions/create.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "inngest.createFunction() | TypeScript SDK v3 Reference"
+export const description = "inngest.createFunction() in TypeScript SDK v3 configures function ID, triggers, concurrency, retries, throttling, debounce, and the handler."
+
 # Create Function
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/functions/debounce.mdx
+++ b/pages/docs/reference/typescript/v3/functions/debounce.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Debounce | Deduplicate Events (TypeScript SDK v3)"
+export const description = "Delay function execution and cancel prior pending runs when new events arrive within the window."
+
 # Debounce functions <VersionBadge version="v3.1.0+" />
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/functions/handling-failures.mdx
+++ b/pages/docs/reference/typescript/v3/functions/handling-failures.mdx
@@ -2,6 +2,9 @@ import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge 
 import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 import { RiErrorWarningFill } from "@remixicon/react";
 
+export const metaTitle = "onFailure Handler | TypeScript SDK v3 Reference"
+export const description = "Define a handler that runs when a function exhausts all retries for logging, alerting, or compensation."
+
 # Handling Failures
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/functions/rate-limit.mdx
+++ b/pages/docs/reference/typescript/v3/functions/rate-limit.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Rate Limit | TypeScript SDK v3 Reference"
+export const description = "Skip function runs that exceed a configured rate over a time window."
+
 # Rate limit function execution
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/functions/run-priority.mdx
+++ b/pages/docs/reference/typescript/v3/functions/run-priority.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Function Run Priority | TypeScript SDK v3 Reference"
+export const description = "Dynamically adjust the execution order of function runs using a CEL expression."
+
 # Function run priority <VersionBadge version="v3.2.1+" />
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/functions/singleton.mdx
+++ b/pages/docs/reference/typescript/v3/functions/singleton.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Singleton (Exclusive Execution) | TypeScript SDK v3"
+export const description = "Ensure only one run of a function executes at a time; queue or skip additional invocations."
+
 # Ensure exclusive execution of a function
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/functions/step-invoke.mdx
+++ b/pages/docs/reference/typescript/v3/functions/step-invoke.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Calling Inngest functions directly from other functions with step.invoke()`
+
+export const metaTitle = "step.invoke() | TypeScript SDK v3 Reference"
+export const description = "Call another Inngest function from a step with step.invoke(), await its return value, and handle parameters, types, and results in SDK v3."
 
 # Invoke <VersionBadge version="v3.7.0+" />
 <Info skipSearchCrawler>

--- a/pages/docs/reference/typescript/v3/functions/step-invoke.mdx
+++ b/pages/docs/reference/typescript/v3/functions/step-invoke.mdx
@@ -2,7 +2,7 @@ import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge 
 
 
 export const metaTitle = "step.invoke() | TypeScript SDK v3 Reference"
-export const description = "Call another Inngest function from a step with step.invoke(), await its return value, and handle parameters, types, and results in SDK v3."
+export const description = "Call another Inngest function from within a step using step.invoke() and await its return value. Reference for parameters, types, and return handling in SDK v3."
 
 # Invoke <VersionBadge version="v3.7.0+" />
 <Info skipSearchCrawler>

--- a/pages/docs/reference/typescript/v3/functions/step-run.mdx
+++ b/pages/docs/reference/typescript/v3/functions/step-run.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Define steps to execute with step.run()`
+
+export const metaTitle = "step.run() | Execute a Step (TypeScript SDK v3)"
+export const description = "step.run() in TypeScript SDK v3 wraps any logic in a memoized, retriable step that appears in the Inngest run trace."
 
 # Run
 <Info skipSearchCrawler>

--- a/pages/docs/reference/typescript/v3/functions/step-send-event.mdx
+++ b/pages/docs/reference/typescript/v3/functions/step-send-event.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Send one or more events reliably from within your function with step.sendEvent().`;
+
+export const metaTitle = "step.sendEvent() | Send Events from a Step (SDK v3)"
+export const description = "Reliably send events from inside a function step using step.sendEvent() in TypeScript SDK v3. Events are sent as part of the step lifecycle."
 
 # Send Event
 <Info skipSearchCrawler>

--- a/pages/docs/reference/typescript/v3/functions/step-sleep-until.mdx
+++ b/pages/docs/reference/typescript/v3/functions/step-sleep-until.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, CodeGroup, Col, Properties, Property, Row, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Sleep until a specific date time with step.sleepUntil()`;
+
+export const metaTitle = "step.sleepUntil() | Sleep to a Date (TypeScript SDK v3)"
+export const description = "Pause an Inngest function until a specific Date or ISO timestamp using step.sleepUntil() in TypeScript SDK v3."
 
 # Sleep until `step.sleepUntil()`
 <Info skipSearchCrawler>

--- a/pages/docs/reference/typescript/v3/functions/step-sleep.mdx
+++ b/pages/docs/reference/typescript/v3/functions/step-sleep.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, CodeGroup, Col, Properties, Property, Row, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.sleep() | Pause a Function (TypeScript SDK v3)"
+export const description = "Pause an Inngest function for a specified duration using step.sleep() in TypeScript SDK v3. The function resumes automatically without consuming compute."
+
 # Sleep `step.sleep()`
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/functions/step-wait-for-event.mdx
+++ b/pages/docs/reference/typescript/v3/functions/step-wait-for-event.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Wait for a particular event to be received before continuing with step.waitForEvent()`;
+
+export const metaTitle = "step.waitForEvent() | TypeScript SDK v3 Reference"
+export const description = "Pause a function and resume when a matching event is received using step.waitForEvent() in TypeScript SDK v3. Configure timeout and correlation expressions."
 
 # Wait for event
 <Info skipSearchCrawler>

--- a/pages/docs/reference/typescript/v3/functions/step-wait-for-signal.mdx
+++ b/pages/docs/reference/typescript/v3/functions/step-wait-for-signal.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Wait for a particular signal to be received before continuing with step.waitForSignal()`;
+
+export const metaTitle = "step.waitForSignal() | TypeScript SDK v3 Reference"
+export const description = "Pause a function and resume it when a named signal is sent using step.waitForSignal() in SDK v3. Ideal for human-in-the-loop and external trigger workflows."
 
 # Wait for signal
 <Info skipSearchCrawler>

--- a/pages/docs/reference/typescript/v3/intro.mdx
+++ b/pages/docs/reference/typescript/v3/intro.mdx
@@ -2,6 +2,9 @@ import { Info, CodeGroup } from "src/shared/Docs/mdx";
 
 import GithubIcon from "shared/Icons/Github"
 
+export const metaTitle = "TypeScript SDK v3 | Inngest Reference (Legacy)"
+export const description = "See v4 for the latest."
+
 # TypeScript SDK v3
 
 <Info>

--- a/pages/docs/reference/typescript/v3/middleware/examples.mdx
+++ b/pages/docs/reference/typescript/v3/middleware/examples.mdx
@@ -1,6 +1,9 @@
 import { Info, Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge, Card, CardGroup } from "src/shared/Docs/mdx";
 import { RiKeyLine } from "@remixicon/react"
 
+export const metaTitle = "Middleware Examples | TypeScript SDK v3"
+export const description = "Example middleware implementations for Inngest TypeScript SDK v3: logging, dependency injection, error reporting, and custom data transformation."
+
 # Example middleware <VersionBadge version="v2.0.0+" />
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/middleware/lifecycle.mdx
+++ b/pages/docs/reference/typescript/v3/middleware/lifecycle.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Middleware Lifecycle | TypeScript SDK v3 Reference"
+export const description = "Inngest middleware lifecycle hooks in TypeScript SDK v3: onFunctionRun, transformInput, transformOutput, and beforeResponse."
+
 # Middleware lifecycle <VersionBadge version="v2.0.0+" />
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/migrations/v2-to-v3.mdx
+++ b/pages/docs/reference/typescript/v3/migrations/v2-to-v3.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = "How to migrate your code to the latest version of the Inngest TS SDK."
+
+export const metaTitle = "Migrate TypeScript SDK v2 → v3 | Inngest Docs"
+export const description = "Step-by-step guide for upgrading the Inngest TypeScript SDK from v2 to v3. Covers renamed APIs, updated function configuration, and new step method signatures."
 
 # Upgrading from Inngest SDK v2 to v3
 <Info skipSearchCrawler>

--- a/pages/docs/reference/typescript/v3/realtime/index.mdx
+++ b/pages/docs/reference/typescript/v3/realtime/index.mdx
@@ -11,7 +11,9 @@ import {
   VersionBadge,
 } from "src/shared/Docs/mdx";
 
-export const description = "Archived v3 realtime concepts documentation for the deprecated @inngest/realtime package.";
+
+export const metaTitle = "Realtime (Archived) | TypeScript SDK v3 Docs"
+export const description = "Review the deprecated @inngest/realtime package used in TypeScript SDK v3 and move current realtime work to the TypeScript SDK v4 APIs."
 
 # Realtime <VersionBadge version="TypeScript SDK v3" />
 

--- a/pages/docs/reference/typescript/v3/realtime/index.mdx
+++ b/pages/docs/reference/typescript/v3/realtime/index.mdx
@@ -13,7 +13,7 @@ import {
 
 
 export const metaTitle = "Realtime (Archived) | TypeScript SDK v3 Docs"
-export const description = "Review the deprecated @inngest/realtime package used in TypeScript SDK v3 and move current realtime work to the TypeScript SDK v4 APIs."
+export const description = "Archived reference for the deprecated @inngest/realtime package used in TypeScript SDK v3. For current realtime docs, see the TypeScript SDK v4 reference."
 
 # Realtime <VersionBadge version="TypeScript SDK v3" />
 

--- a/pages/docs/reference/typescript/v3/realtime/react-hooks.mdx
+++ b/pages/docs/reference/typescript/v3/realtime/react-hooks.mdx
@@ -10,7 +10,9 @@ import {
   VersionBadge,
 } from "src/shared/Docs/mdx";
 
-export const description = "Archived v3 React hook docs for useInngestSubscription().";
+
+export const metaTitle = "useInngestSubscription() (Archived) | SDK v3 Docs"
+export const description = "Review the deprecated useInngestSubscription() React hook from @inngest/realtime v3 and use v4 useRealtime docs for current API guidance."
 
 # React hooks / Next.js <VersionBadge version="TypeScript SDK v3" />
 

--- a/pages/docs/reference/typescript/v3/realtime/react-hooks.mdx
+++ b/pages/docs/reference/typescript/v3/realtime/react-hooks.mdx
@@ -12,7 +12,7 @@ import {
 
 
 export const metaTitle = "useInngestSubscription() (Archived) | SDK v3 Docs"
-export const description = "Review the deprecated useInngestSubscription() React hook from @inngest/realtime v3 and use v4 useRealtime docs for current API guidance."
+export const description = "Archived reference for the useInngestSubscription() React hook from the deprecated @inngest/realtime v3 package. See v4 useRealtime docs for the current API."
 
 # React hooks / Next.js <VersionBadge version="TypeScript SDK v3" />
 

--- a/pages/docs/reference/typescript/v3/serve/index.mdx
+++ b/pages/docs/reference/typescript/v3/serve/index.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "serve() Configuration | TypeScript SDK v3 Reference"
+export const description = "Set the signing key, base URL, streaming mode, and allowed origins for your app."
+
 # Serve
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v3/testing/index.mdx
+++ b/pages/docs/reference/typescript/v3/testing/index.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, CodeGroup, Tip } from "shared/Docs/mdx";
 
+export const metaTitle = "Testing Inngest Functions | TypeScript SDK v3"
+export const description = "Test Inngest functions in TypeScript SDK v3 using InngestTestEngine. Run functions in isolation, mock step results, and assert on step calls and return values."
+
 # Testing
 <Info skipSearchCrawler>
   **TypeScript SDK v4 is now in beta.** See the [v4 docs](/docs/reference/typescript/v4) and [migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4).

--- a/pages/docs/reference/typescript/v4/client/create.mdx
+++ b/pages/docs/reference/typescript/v4/client/create.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Create the Inngest Client | TypeScript SDK v4 Reference"
+export const description = "Configure your app ID, event schemas, signing key, logger, and middleware for the Inngest client instance."
+
 # Create the Inngest Client
 
 

--- a/pages/docs/reference/typescript/v4/durable-endpoints.mdx
+++ b/pages/docs/reference/typescript/v4/durable-endpoints.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, CodeGroup, Col, Properties, Property, Row, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = 'TypeScript SDK reference for Durable Endpoints. Create HTTP handlers with step-based checkpointing and streaming.'
+
+export const metaTitle = "Durable Endpoints | TypeScript SDK v4 Reference"
+export const description = "Turn HTTP handlers into durable, checkpointed workflows with automatic retries and streaming support."
 
 # Durable Endpoints <VersionBadge version="Beta" />
 

--- a/pages/docs/reference/typescript/v4/events/send.mdx
+++ b/pages/docs/reference/typescript/v4/events/send.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = `Send one or more events to Inngest via inngest.send() in the TypeScript SDK.`
+
+export const metaTitle = "inngest.send() | Send Events (TypeScript SDK v4)"
+export const description = "inngest.send() in TypeScript SDK v4 sends one or more typed events to Inngest with full TypeScript inference from your defined event schemas."
 
 # Send events
 

--- a/pages/docs/reference/typescript/v4/extended-traces.mdx
+++ b/pages/docs/reference/typescript/v4/extended-traces.mdx
@@ -2,7 +2,9 @@ import { Info, Callout, Note, CardGroup, Card } from "src/shared/Docs/mdx";
 import { RiBarChart2Fill } from "@remixicon/react";
 
 
-export const description = "Inngest supports OpenTelemetry for distributed tracing and observability. Use the extendedTracesMiddleware to automatically instrument your Inngest functions and send spans to your observability platform.";
+
+export const metaTitle = "Extended Traces (OpenTelemetry) | TypeScript SDK v4"
+export const description = "Use the ExtendedTracesMiddleware in TypeScript SDK v4 to automatically instrument Inngest functions and forward spans to Datadog, Grafana, or any OTel backend."
 
 # Extended Traces (OpenTelemetry)
 

--- a/pages/docs/reference/typescript/v4/functions/cancel-on.mdx
+++ b/pages/docs/reference/typescript/v4/functions/cancel-on.mdx
@@ -1,6 +1,9 @@
 import { Info, Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 import { InformationCircleIcon } from '@heroicons/react/24/outline'
 
+export const metaTitle = "cancelOn | Auto-Cancel on Events (TypeScript SDK v4)"
+export const description = "Auto-cancel in-flight runs when a matching event arrives, with optional CEL expression filtering."
+
 # Cancel on
 
 

--- a/pages/docs/reference/typescript/v4/functions/concurrency.mdx
+++ b/pages/docs/reference/typescript/v4/functions/concurrency.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup, Callout, Properties, Property } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Concurrency | TypeScript SDK v4 Reference"
+export const description = "Set step-level concurrency limits with key expressions for per-user or per-tenant scoping."
+
 # Managing concurrency
 
 Limit the number of concurrently running steps for your function with the [`concurrency`](/docs/reference/typescript/v4/functions/create#configuration) configuration options. Setting an optional `key` parameter limits the concurrency for each unique value of the expression.

--- a/pages/docs/reference/typescript/v4/functions/create.mdx
+++ b/pages/docs/reference/typescript/v4/functions/create.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "inngest.createFunction() | TypeScript SDK v4 Reference"
+export const description = "inngest.createFunction() in TypeScript SDK v4 configures triggers, concurrency, throttle, debounce, priority, retries, and the function handler."
+
 # Create Function
 
 

--- a/pages/docs/reference/typescript/v4/functions/debounce.mdx
+++ b/pages/docs/reference/typescript/v4/functions/debounce.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Debounce | Deduplicate Events (TypeScript SDK v4)"
+export const description = "Delay execution and collapse rapid event sequences into a single function run."
+
 # Debounce functions
 
 

--- a/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
+++ b/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
@@ -1,6 +1,8 @@
 import { Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = "Fire-and-forget independent work with typed data using deferred functions."
+
+export const metaTitle = "Deferred Functions | Fire-and-Forget Background Tasks"
+export const description = "Trigger independent background tasks with typed data without waiting for a return value."
 
 # Deferred Functions
 

--- a/pages/docs/reference/typescript/v4/functions/fetch.mdx
+++ b/pages/docs/reference/typescript/v4/functions/fetch.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup, CardGroup, Card, VersionBadge, Callout } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.fetch() | Durable HTTP Requests (TypeScript SDK v4)"
+export const description = "Make retryable, checkpointed HTTP requests using step.fetch() in TypeScript SDK v4. Automatic retries on failure without re-executing prior steps."
+
 # Fetch: performing API requests or fetching data <VersionBadge version="TypeScript only" />
 
 The Inngest TypeScript SDK provides a `step.fetch()` API and a `fetch()` utility, enabling you to make requests to third-party APIs or fetch data in a durable way by offloading them to the Inngest Platform:

--- a/pages/docs/reference/typescript/v4/functions/group-experiment.mdx
+++ b/pages/docs/reference/typescript/v4/functions/group-experiment.mdx
@@ -1,6 +1,8 @@
 import { Callout, Properties, Property, Row, Col, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = `API reference for group.experiment() — run experiments within durable functions`
+
+export const metaTitle = "group.experiment() | A/B Testing in Functions (SDK v4)"
+export const description = "group.experiment() in TypeScript SDK v4 runs reproducible A/B experiments within durable functions to compare models, prompts, or strategies."
 
 # `group.experiment()`
 

--- a/pages/docs/reference/typescript/v4/functions/handling-failures.mdx
+++ b/pages/docs/reference/typescript/v4/functions/handling-failures.mdx
@@ -2,6 +2,9 @@ import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge 
 import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 import { RiErrorWarningFill } from "@remixicon/react";
 
+export const metaTitle = "onFailure Handler | TypeScript SDK v4 Reference"
+export const description = "Define a handler that runs when a function exhausts all retries for cleanup, alerting, or compensation."
+
 # Handling Failures
 
 

--- a/pages/docs/reference/typescript/v4/functions/metadata.mdx
+++ b/pages/docs/reference/typescript/v4/functions/metadata.mdx
@@ -1,6 +1,8 @@
 import { CodeGroup, VersionBadge, Info, Warning } from "src/shared/Docs/mdx";
 
-export const description = "API reference for metadata: middleware setup, builder methods, scoping, size limits, and built-in metadata kinds.";
+
+export const metaTitle = "step.metadata() | Attach Metadata to Runs (SDK v4)"
+export const description = "Attach custom key-value data to function runs and steps for scoring, labeling, and observability."
 
 # Metadata reference <VersionBadge version="TypeScript only" />
 

--- a/pages/docs/reference/typescript/v4/functions/rate-limit.mdx
+++ b/pages/docs/reference/typescript/v4/functions/rate-limit.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Rate Limit | TypeScript SDK v4 Reference"
+export const description = "Skip function runs that exceed a configured rate over a time window to prevent abuse."
+
 # Rate limit function execution
 
 

--- a/pages/docs/reference/typescript/v4/functions/references.mdx
+++ b/pages/docs/reference/typescript/v4/functions/references.mdx
@@ -1,5 +1,8 @@
 import { Callout, Properties, Property } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Function References | inngest.getFunction() (SDK v4)"
+export const description = "Look up a registered Inngest function by ID using inngest.getFunction() for dynamic invocation."
+
 # Referencing functions
 
 Using [`step.invoke()`](/docs/reference/typescript/v4/functions/step-invoke), you can directly call one Inngest function from another and handle the result. You can use this with `referenceFunction` to call Inngest functions located in other apps, or to avoid importing dependencies of functions within the same app.

--- a/pages/docs/reference/typescript/v4/functions/run-priority.mdx
+++ b/pages/docs/reference/typescript/v4/functions/run-priority.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Function Run Priority | TypeScript SDK v4 Reference"
+export const description = "Dynamically rank function runs using a CEL expression over event or environment data."
+
 # Function run priority
 
 

--- a/pages/docs/reference/typescript/v4/functions/scoring.mdx
+++ b/pages/docs/reference/typescript/v4/functions/scoring.mdx
@@ -1,6 +1,8 @@
 import { Callout, Properties, Property, Row, Col } from "src/shared/Docs/mdx";
 
-export const description = "API reference for scoring function runs and steps in Inngest."
+
+export const metaTitle = "step.ai.score() | Score AI Outputs (TypeScript SDK v4)"
+export const description = "Attach numeric quality scores to AI function runs and steps to track performance across model versions."
 
 # Scoring
 

--- a/pages/docs/reference/typescript/v4/functions/singleton.mdx
+++ b/pages/docs/reference/typescript/v4/functions/singleton.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Singleton (Exclusive Execution) | TypeScript SDK v4"
+export const description = "Ensure only one run executes at a time; new invocations are queued or skipped until the current run completes."
+
 # Ensure exclusive execution of a function
 
 

--- a/pages/docs/reference/typescript/v4/functions/step-invoke.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-invoke.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Calling Inngest functions directly from other functions with step.invoke()`
+
+export const metaTitle = "step.invoke() | TypeScript SDK v4 Reference"
+export const description = "Call another Inngest function from within a step using step.invoke() in TypeScript SDK v4 and await its typed return value."
 
 # Invoke
 

--- a/pages/docs/reference/typescript/v4/functions/step-run.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-run.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Define steps to execute with step.run()`
+
+export const metaTitle = "step.run() | Execute a Step (TypeScript SDK v4)"
+export const description = "step.run() in TypeScript SDK v4 wraps any logic in a memoized, retriable, observable step visible in the Inngest dashboard run trace."
 
 # Run
 

--- a/pages/docs/reference/typescript/v4/functions/step-send-event.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-send-event.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Send one or more events reliably from within your function with step.sendEvent().`;
+
+export const metaTitle = "step.sendEvent() | Send Events from a Step (SDK v4)"
+export const description = "Send events from inside a function step using step.sendEvent() in TypeScript SDK v4. Events are sent atomically as part of the step lifecycle."
 
 # Send Event
 

--- a/pages/docs/reference/typescript/v4/functions/step-sleep-until.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-sleep-until.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, CodeGroup, Col, Properties, Property, Row, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Sleep until a specific date time with step.sleepUntil()`;
+
+export const metaTitle = "step.sleepUntil() | Sleep to a Date (TypeScript SDK v4)"
+export const description = "Pause an Inngest function until a specific Date or ISO timestamp using step.sleepUntil() in TypeScript SDK v4. Supports durations up to 1 year."
 
 # Sleep until `step.sleepUntil()`
 

--- a/pages/docs/reference/typescript/v4/functions/step-sleep.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-sleep.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, CodeGroup, Col, Properties, Property, Row, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "step.sleep() | Pause a Function (TypeScript SDK v4)"
+export const description = "Pause an Inngest function for a duration using step.sleep() in TypeScript SDK v4. The function resumes without re-running prior steps or consuming compute."
+
 # Sleep `step.sleep()`
 
 

--- a/pages/docs/reference/typescript/v4/functions/step-wait-for-event.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-wait-for-event.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Wait for a particular event to be received before continuing with step.waitForEvent()`;
+
+export const metaTitle = "step.waitForEvent() | TypeScript SDK v4 Reference"
+export const description = "Pause a function and resume when a matching event arrives using step.waitForEvent() in SDK v4. Configure timeout, correlation expression, and event data types."
 
 # Wait for event
 

--- a/pages/docs/reference/typescript/v4/functions/step-wait-for-signal.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-wait-for-signal.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Wait for a particular signal to be received before continuing with step.waitForSignal()`;
+
+export const metaTitle = "step.waitForSignal() | TypeScript SDK v4 Reference"
+export const description = "Pause a function and resume when a named signal is sent using step.waitForSignal() in SDK v4. Ideal for human approval and external trigger workflows."
 
 # Wait for signal
 

--- a/pages/docs/reference/typescript/v4/functions/triggers.mdx
+++ b/pages/docs/reference/typescript/v4/functions/triggers.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Reference for trigger helper functions: eventType(), cron(), invoke(), and staticSchema().`
+
+export const metaTitle = "Trigger Helpers | eventTrigger(), cron() (SDK v4)"
+export const description = "TypeScript SDK v4 trigger helpers: eventTrigger(), cron(), invoke(), and staticSchema() for typed, composable function trigger definitions."
 
 # Trigger helpers
 

--- a/pages/docs/reference/typescript/v4/intro.mdx
+++ b/pages/docs/reference/typescript/v4/intro.mdx
@@ -2,9 +2,6 @@ import { Info, CodeGroup } from "src/shared/Docs/mdx";
 
 import GithubIcon from "shared/Icons/Github"
 
-export const metaTitle = "TypeScript SDK v4 | Inngest Reference"
-export const description = "Inngest TypeScript SDK v4: the latest release with improved type safety, native realtime, new step APIs, and updated middleware."
-
 # TypeScript SDK v4
 
 <Info>

--- a/pages/docs/reference/typescript/v4/intro.mdx
+++ b/pages/docs/reference/typescript/v4/intro.mdx
@@ -2,6 +2,9 @@ import { Info, CodeGroup } from "src/shared/Docs/mdx";
 
 import GithubIcon from "shared/Icons/Github"
 
+export const metaTitle = "TypeScript SDK v4 | Inngest Reference"
+export const description = "Inngest TypeScript SDK v4: the latest release with improved type safety, native realtime, new step APIs, and updated middleware."
+
 # TypeScript SDK v4
 
 <Info>

--- a/pages/docs/reference/typescript/v4/logging.mdx
+++ b/pages/docs/reference/typescript/v4/logging.mdx
@@ -1,5 +1,8 @@
 import { CodeGroup, Properties, Property, Callout, Tip } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Logging | TypeScript SDK v4 Reference"
+export const description = "Pass a custom logger to the client to route function logs to your preferred logging provider."
+
 # Logging
 
 The Inngest SDK uses **Pino-style object-first** logging, where structured data is passed before the message string:

--- a/pages/docs/reference/typescript/v4/middleware/encryption.mdx
+++ b/pages/docs/reference/typescript/v4/middleware/encryption.mdx
@@ -1,5 +1,8 @@
 import { Properties, Property } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Encryption Middleware | TypeScript SDK v4 Reference"
+export const description = "Encrypt and decrypt step inputs and outputs automatically so sensitive data is never stored in plaintext."
+
 # Encryption middleware
 
 The encryption middleware provides end-to-end encryption for events, step output, and function output. **Only encrypted data is sent to Inngest servers**: encryption and decryption happen within your infrastructure.

--- a/pages/docs/reference/typescript/v4/middleware/examples.mdx
+++ b/pages/docs/reference/typescript/v4/middleware/examples.mdx
@@ -1,5 +1,8 @@
 import { Callout } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Middleware Examples | TypeScript SDK v4"
+export const description = "Example middleware for Inngest TypeScript SDK v4: logging, dependency injection, Sentry integration, custom serialization, and data transformation patterns."
+
 # Middleware examples
 
 Real-world examples using the v4 class-based middleware API. See [Lifecycle](/docs/reference/typescript/v4/middleware/lifecycle) for the full hook reference.

--- a/pages/docs/reference/typescript/v4/middleware/lifecycle.mdx
+++ b/pages/docs/reference/typescript/v4/middleware/lifecycle.mdx
@@ -1,5 +1,8 @@
 import { Callout, Properties, Property } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Middleware Lifecycle | TypeScript SDK v4 Reference"
+export const description = "Inngest middleware lifecycle in TypeScript SDK v4: onFunctionRun, transformInput, transformOutput, and beforeResponse hook signatures."
+
 # Middleware lifecycle
 
 Middleware lets you hook into function execution to add cross-cutting concerns like logging, error handling, and dependency injection. Middleware is class-based: you extend `Middleware.BaseMiddleware` and define hook methods.

--- a/pages/docs/reference/typescript/v4/middleware/sentry.mdx
+++ b/pages/docs/reference/typescript/v4/middleware/sentry.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Sentry Middleware | TypeScript SDK v4 Reference"
+export const description = "Automatically capture function exceptions in Sentry with trace context and step metadata."
+
 # Sentry middleware
 
 The Sentry middleware captures exceptions, adds tracing, and includes useful context (function ID, event names) for each function run.

--- a/pages/docs/reference/typescript/v4/middleware/serialization.mdx
+++ b/pages/docs/reference/typescript/v4/middleware/serialization.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Custom Serialization Middleware | TypeScript SDK v4"
+export const description = "Control how step inputs and outputs are serialized and deserialized for custom data types."
+
 # Custom serialization
 
 Inngest sends step output, function output, and event data as JSON. This means non-JSON types like `Date`, `Map`, `Set`, or custom classes are lost during serialization. Custom serializer middleware lets you preserve these types by converting them to a JSON-safe format on the way out and restoring them on the way in.

--- a/pages/docs/reference/typescript/v4/migrations/v3-to-v4.mdx
+++ b/pages/docs/reference/typescript/v4/migrations/v3-to-v4.mdx
@@ -1,5 +1,8 @@
 import { Info, Tip, Warning } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Migrate TypeScript SDK v3 → v4 | Inngest Docs"
+export const description = "Complete migration guide for upgrading the Inngest TypeScript SDK from v3 to v4. Covers all breaking changes, new APIs, and step-by-step upgrade instructions."
+
 # TypeScript SDK Migration Guide: v3 to v4
 
 This guide helps you migrate your Inngest TypeScript SDK from v3 to v4.

--- a/pages/docs/reference/typescript/v4/realtime/channels.mdx
+++ b/pages/docs/reference/typescript/v4/realtime/channels.mdx
@@ -1,6 +1,8 @@
 import { Info, Callout, Properties, Property, Row, Col, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = "Define typed realtime channels and topics with realtime.channel() for streaming updates from Inngest functions."
+
+export const metaTitle = "Channels & Topics | Realtime SDK v4 Reference"
+export const description = "realtime.channel() in TypeScript SDK v4 defines typed channels and topics for streaming structured updates from Inngest functions to subscribers."
 
 # Channels & topics
 

--- a/pages/docs/reference/typescript/v4/realtime/index.mdx
+++ b/pages/docs/reference/typescript/v4/realtime/index.mdx
@@ -1,6 +1,8 @@
 import { Info } from "src/shared/Docs/mdx";
 
-export const description = "Stream real-time updates from Inngest functions to your UI using channels, topics, and typed subscriptions, all built into the v4 SDK."
+
+export const metaTitle = "Realtime | TypeScript SDK v4 Reference"
+export const description = "Stream real-time updates from Inngest functions using typed channels, topics, and subscriptions built into TypeScript SDK v4. No separate package required."
 
 # Realtime
 

--- a/pages/docs/reference/typescript/v4/realtime/publishing.mdx
+++ b/pages/docs/reference/typescript/v4/realtime/publishing.mdx
@@ -1,6 +1,8 @@
 import { Info, Properties, Property, Row, Col } from "src/shared/Docs/mdx";
 
-export const description = "Publish typed messages to realtime channels from Inngest functions or server-side code."
+
+export const metaTitle = "Publishing Realtime Messages | TypeScript SDK v4"
+export const description = "Publish typed messages to realtime channels from Inngest functions or server-side code using the publish() API in TypeScript SDK v4."
 
 # Publishing
 

--- a/pages/docs/reference/typescript/v4/realtime/subscribing.mdx
+++ b/pages/docs/reference/typescript/v4/realtime/subscribing.mdx
@@ -1,6 +1,8 @@
 import { Info, Properties, Property, Row, Col, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = "Mint subscription tokens and consume realtime streams server-side with getClientSubscriptionToken and subscribe."
+
+export const metaTitle = "Server-Side Realtime Subscribing | TypeScript SDK v4"
+export const description = "Mint subscription tokens and consume streams using getClientSubscriptionToken() and subscribe()."
 
 # Subscribing
 

--- a/pages/docs/reference/typescript/v4/realtime/use-realtime.mdx
+++ b/pages/docs/reference/typescript/v4/realtime/use-realtime.mdx
@@ -1,6 +1,8 @@
 import { Properties, Property, CodeGroup } from "src/shared/Docs/mdx";
 
-export const description = "Subscribe to realtime updates from Inngest functions in React with the useRealtime hook."
+
+export const metaTitle = "useRealtime() Hook | TypeScript SDK v4 Reference"
+export const description = "Subscribe to Inngest realtime channels in React or Next.js with typed message payloads."
 
 # useRealtime
 

--- a/pages/docs/reference/typescript/v4/serve/index.mdx
+++ b/pages/docs/reference/typescript/v4/serve/index.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
+export const metaTitle = "serve() Configuration | TypeScript SDK v4 Reference"
+export const description = "Configure signing key, base URL, streaming mode, allowed origins, and framework-specific options."
+
 # Serve
 
 

--- a/pages/docs/reference/typescript/v4/serve/streaming.mdx
+++ b/pages/docs/reference/typescript/v4/serve/streaming.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Streaming with serve() | TypeScript SDK v4 Reference"
+export const description = "Enable HTTP streaming in the Inngest TypeScript SDK v4 serve handler to improve responsiveness on serverless platforms with execution time limits."
+
 # Streaming
 
 <Callout>

--- a/pages/docs/reference/typescript/v4/testing/index.mdx
+++ b/pages/docs/reference/typescript/v4/testing/index.mdx
@@ -1,5 +1,8 @@
 import { Info, Callout, CodeGroup, Tip } from "shared/Docs/mdx";
 
+export const metaTitle = "Testing Inngest Functions | TypeScript SDK v4"
+export const description = "Test Inngest functions in TypeScript SDK v4 using InngestTestEngine. Run in isolation, mock step outputs, and assert on behavior without a live server."
+
 # Testing
 
 

--- a/pages/docs/reference/workflow-kit/actions.mdx
+++ b/pages/docs/reference/workflow-kit/actions.mdx
@@ -1,6 +1,9 @@
 import { Callout, CodeGroup, Card, CardGroup, Properties, Property, ImageTheme } from "src/shared/Docs/mdx";
 
 
+export const metaTitle = "Creating Workflow Actions | Workflow Kit Reference"
+export const description = "Define typed schemas, inputs, and handlers users can combine into their own workflows."
+
 # Creating workflow actions
 
 The [`@inngest/workflow-kit`](https://npmjs.com/package/@inngest/workflow-kit) package provides a [workflow engine](/docs/reference/workflow-kit/engine), enabling you to create workflow actions on the back end. These actions are later provided to the front end so end-users can build their own workflow instance using the [`<Editor />`](/docs/reference/workflow-kit/components-api).

--- a/pages/docs/reference/workflow-kit/components-api.mdx
+++ b/pages/docs/reference/workflow-kit/components-api.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Card, CardGroup, Properties, Property } from "src/shared/Docs/mdx";
 
+export const metaTitle = "React Components API | Workflow Kit Reference"
+export const description = "Build a visual workflow editor UI backed by durable Inngest execution."
+
 # Components API (React)
 
 The [`@inngest/workflow-kit`](https://npmjs.com/package/@inngest/workflow-kit) package provides a set of React components, enabling you to build a workflow editor UI in no time!

--- a/pages/docs/reference/workflow-kit/engine.mdx
+++ b/pages/docs/reference/workflow-kit/engine.mdx
@@ -1,6 +1,9 @@
 import { Callout, CodeGroup, Card, CardGroup, Properties, Property } from "src/shared/Docs/mdx";
 
 
+export const metaTitle = "Workflow Engine | Workflow Kit Reference"
+export const description = "Execute user-defined workflow instances with durable step execution, conditional logic, and action composition."
+
 # Using the workflow engine
 
 The workflow `Engine` is used to run a given [workflow instance](/docs/reference/workflow-kit/workflow-instance) within an Inngest Function:

--- a/pages/docs/reference/workflow-kit/index.mdx
+++ b/pages/docs/reference/workflow-kit/index.mdx
@@ -3,6 +3,9 @@ import { Callout, CodeGroup, Card, CardGroup, ImageTheme } from "src/shared/Docs
 import GithubIcon from "shared/Icons/Github"
 import NewspaperIcon from "shared/Icons/Newspaper"
 
+export const metaTitle = "Workflow Kit | Build User-Defined Workflows"
+export const description = "Inngest Workflow Kit: build configurable, user-defined workflow engines with durable execution, a React UI, and a flexible action API."
+
 # Workflow Kit
 Workflow Kit enables you to build [user-defined workflows](/docs/guides/user-defined-workflows) with Inngest by providing a set of workflow actions to the **[Workflow Engine](/docs/reference/workflow-kit/engine)** while using the **[pre-built React components](/docs/reference/workflow-kit/components-api)** to build your Workflow Editor UI.
 

--- a/pages/docs/reference/workflow-kit/workflow-instance.mdx
+++ b/pages/docs/reference/workflow-kit/workflow-instance.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup, Card, CardGroup, Properties, Property } from "src/shared/Docs/mdx";
 
+export const metaTitle = "Workflow Instance Format | Workflow Kit Reference"
+export const description = "Inngest Workflow Kit workflow instance format: the JSON structure defining user-configured workflow graphs and action chains."
+
 # Workflow instance
 
 A workflow instance represents a user configuration of a sequence of [workflow actions](/docs/reference/workflow-kit/actions), later provided to the [workflow engine](/docs/reference/workflow-kit/engine) for execution.

--- a/pages/docs/release-phases.mdx
+++ b/pages/docs/release-phases.mdx
@@ -1,7 +1,9 @@
 import { Callout, ImageTheme } from "src/shared/Docs/mdx";
 
-export const description = "How Inngest features are released";
 
+
+export const metaTitle = "Inngest Feature Release Phases | Alpha, Beta & GA"
+export const description = "How Inngest releases new features: private alpha, public beta, and general availability. Learn what to expect at each phase and how to provide feedback."
 
 # Release Phases for Inngest
 

--- a/pages/docs/sdk/environment-variables.mdx
+++ b/pages/docs/sdk/environment-variables.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Inngest SDK Environment Variables | Reference"
+export const description = "Environment variables for Inngest SDKs: INNGEST_API_KEY, INNGEST_SIGNING_KEY, INNGEST_EVENT_KEY, INNGEST_BASE_URL, and dev mode settings."
+
 # Environment Variables
 
 You can set environment variables to change various parts of Inngest's configuration.

--- a/pages/docs/sdk/eslint.mdx
+++ b/pages/docs/sdk/eslint.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Inngest ESLint Plugin | Catch Common Mistakes"
+export const description = "Use the Inngest ESLint plugin to catch common mistakes: incorrect step usage, missing await, and patterns that break durable execution in TypeScript functions."
+
 # ESLint Plugin
 
 An ESLint plugin is available at [@inngest/eslint-plugin](https://www.npmjs.com/package/@inngest/eslint-plugin), providing rules to enforce best practices when writing Inngest functions.

--- a/pages/docs/self-hosting.mdx
+++ b/pages/docs/self-hosting.mdx
@@ -1,7 +1,9 @@
 import { Callout, Info, Warning, Tip, CodeGroup, DownloadLink, CardGroup, Card, VersionBadge } from "src/shared/Docs/mdx";
 import Github from "src/shared/Icons/Github.tsx";
 
-export const description = 'Learn how to self-host Inngest. Includes configuration options and instructions for using external services.'
+
+export const metaTitle = "Self-Hosting Inngest | Configuration & Setup"
+export const description = "Run Inngest on your own infrastructure. Covers Docker setup, external service requirements, and how to connect your app SDK to the self-hosted Inngest server."
 
 # Self-hosting
 

--- a/pages/docs/setup/checkpointing.mdx
+++ b/pages/docs/setup/checkpointing.mdx
@@ -1,5 +1,8 @@
 import { Info, Tip, Warning, CodeGroup, LanguageSelector, LanguageSection } from "shared/Docs/mdx";
 
+export const metaTitle = "Checkpointing | Inngest Docs"
+export const description = "Learn how Inngest checkpointing saves function execution state between steps so runs can recover from failures without re-executing completed work."
+
 # Checkpointing
 
 Checkpointing is a performance optimization for Inngest functions that executes steps eagerly rather than waiting on internal orchestration. The result is dramatically lower latency — ideal for real-time AI workflows.

--- a/pages/docs/setup/connect.mdx
+++ b/pages/docs/setup/connect.mdx
@@ -1,5 +1,8 @@
 import { Info, Warning, CodeGroup, Steps, Step } from "shared/Docs/mdx";
 
+export const metaTitle = "Connect | Persistent Worker Connections for Inngest"
+export const description = "Use connect() to create persistent outbound connections from workers to Inngest. Lowest-latency option with elastic scaling and no open inbound ports required."
+
 # Connect (workers)
 
 <Info>

--- a/pages/docs/streaming.mdx
+++ b/pages/docs/streaming.mdx
@@ -1,5 +1,8 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
+export const metaTitle = "HTTP Streaming with Inngest | Docs"
+export const description = "Enable HTTP streaming in Inngest to progressively send responses on serverless platforms. Overcome timeout limits by streaming output as work completes."
+
 # Streaming
 
 In select environments, the SDK allows streaming responses back to Inngest, hugely increasing maximum timeouts on many serverless platforms up to 15 minutes.

--- a/pages/docs/typescript.mdx
+++ b/pages/docs/typescript.mdx
@@ -1,6 +1,8 @@
 import { VersionBadge } from "src/shared/Docs/mdx";
 
-export const description = `Learn the Inngest SDK's type safe features with TypeScript`
+
+export const metaTitle = "TypeScript Support | Type-Safe Events & Functions"
+export const description = "Use TypeScript with Inngest for type-safe event schemas, function handlers, and step return types. Define event types once and share them across your codebase."
 
 # TypeScript
 

--- a/pages/docs/usage-limits/inngest.mdx
+++ b/pages/docs/usage-limits/inngest.mdx
@@ -1,9 +1,6 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 import { Tag } from "src/shared/Docs/Tag";
 
-export const metaTitle = "Inngest Usage Limits | Runs, Events & Retention"
-export const description = "Inngest platform limits by plan: max concurrency, event size, step count, function run timeout, log retention, and event history."
-
 # Usage Limits
 
 We have put some limits on the service to make sure we provide you a good default to start with, while also keeping it a good experience for all other users using Inngest.

--- a/pages/docs/usage-limits/inngest.mdx
+++ b/pages/docs/usage-limits/inngest.mdx
@@ -1,6 +1,9 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 import { Tag } from "src/shared/Docs/Tag";
 
+export const metaTitle = "Inngest Usage Limits | Runs, Events & Retention"
+export const description = "Inngest platform limits by plan: max concurrency, event size, step count, function run timeout, log retention, and event history."
+
 # Usage Limits
 
 We have put some limits on the service to make sure we provide you a good default to start with, while also keeping it a good experience for all other users using Inngest.

--- a/pages/docs/usage-limits/providers.mdx
+++ b/pages/docs/usage-limits/providers.mdx
@@ -1,3 +1,6 @@
+export const metaTitle = "Cloud Provider Usage Limits | Inngest Docs"
+export const description = "Understand how cloud provider compute limits for Vercel, Netlify, Cloudflare, and Render affect Inngest function execution time, memory, and request sizes."
+
 # Providers' Usage Limits
 
 As your functions' code runs on the hosting provider of your choice, you will be subject to provider or billing plan


### PR DESCRIPTION
## Summary

- Applies the reviewed June 2026 `/docs` metadata sweep to 223 MDX docs pages using top-level `metaTitle` and `description` exports.
- Updates the TSX-backed `/docs/patterns` page with the reviewed docs-layout `metaTitle` and description.
- Applies the DEV-430 review corrections from Pat's source sheet.
- Intentionally leaves focused page-refresh and cluster metadata rows to their owning PRs so the SEO batch can merge cleanly.

## Scope Notes

The downloaded workbook has 237 rows in the main docs metadata tab. All rows are implemented or assigned:

- 223 MDX rows implemented in this PR.
- 1 TSX row implemented in this PR: `/docs/patterns`.
- 13 rows intentionally covered by focused/cluster PRs:
  - `/docs/getting-started/nextjs-quick-start` -> [DEV-431](https://linear.app/inngest/issue/DEV-431/refresh-nextjs-quick-start-for-seo-ctr-recovery) / [PR #1687](https://github.com/inngest/website/pull/1687)
  - `/docs/learn/serving-inngest-functions` -> [DEV-432](https://linear.app/inngest/issue/DEV-432/refresh-serving-inngest-functions-page-for-rank-recovery) / [PR #1688](https://github.com/inngest/website/pull/1688)
  - `/docs/ai-dev-tools/agent-skills`, `/docs/ai-dev-tools/mcp`, `/docs/local-development`, `/docs/platform/deployment`, `/docs/reference/typescript/v4/intro` -> [DEV-441](https://linear.app/inngest/issue/DEV-441/build-first-wave-mcp-v4-self-host-connect-seo-docs-cluster) / [PR #1690](https://github.com/inngest/website/pull/1690)
  - `/docs/guides/error-handling` -> [DEV-435](https://linear.app/inngest/issue/DEV-435/refresh-error-handling-guide-for-seo-ctr-and-rank-recovery) / [PR #1691](https://github.com/inngest/website/pull/1691)
  - `/docs/events` -> [DEV-436](https://linear.app/inngest/issue/DEV-436/optimize-docsevents-snippet-title-and-structured-data) / [PR #1692](https://github.com/inngest/website/pull/1692)
  - `/docs/usage-limits/inngest` -> [DEV-437](https://linear.app/inngest/issue/DEV-437/optimize-usage-limits-docs-for-ctr-and-crawlable-answers) / [PR #1693](https://github.com/inngest/website/pull/1693)
  - `/docs/features/realtime` -> [DEV-438](https://linear.app/inngest/issue/DEV-438/optimize-realtime-docs-snippet-and-schema) / [PR #1694](https://github.com/inngest/website/pull/1694)
  - `/docs/learn/inngest-functions` -> [DEV-439](https://linear.app/inngest/issue/DEV-439/refresh-inngest-functions-intro-for-seo) / [PR #1696](https://github.com/inngest/website/pull/1696)
  - `/docs/learn/inngest-steps` -> [DEV-440](https://linear.app/inngest/issue/DEV-440/refresh-inngest-steps-intro-for-seo) / [PR #1697](https://github.com/inngest/website/pull/1697)

## Context

- Linear: [DEV-433](https://linear.app/inngest/issue/DEV-433/implement-full-docs-meta-title-and-description-sweep)
- Metadata review: [DEV-430](https://linear.app/inngest/issue/DEV-430/review-proposed-docs-meta-titles-and-descriptions)
- Notion source/tracker: [/docs SEO optimization recommendations (June 2026)](https://app.notion.com/p/37db64753bbd80dabf8ad5760ebce791)
- Metadata sheet: [Docs - Meta Titles & Descriptions / June 2026](https://docs.google.com/spreadsheets/d/1Z2n2x398ORBZFkoygO75FbiMPz37DsKSuILqjFQSiPc/edit?usp=sharing)
- Slack update: [#dev-rel-docs message](https://inngest.slack.com/archives/C068B3TL06L/p1781642438770439)
- Related SEO redirect foundation: [DEV-429](https://linear.app/inngest/issue/DEV-429/ship-301-redirects-for-v4-docs-migration-paths) / [PR #1683](https://github.com/inngest/website/pull/1683)

## Validation

- `pnpm exec prettier --check $(git diff --name-only -- pages/docs)`
- `git diff --check`
- Metadata verifier: 237 workbook rows accounted for; 223 MDX rows in this PR, 1 TSX row in this PR, 13 rows assigned to focused/cluster PRs, 0 unaccounted.
- Source-sheet alignment verifier after commit `4fb939a2`: 224 changed metadata files matched 224 tab-2 rows exactly against Proposed Title (column D) and Proposed Description (column E), 0 mismatches.
- Preview spot-check on `http://localhost:3002` confirmed rendered title and description tags for `/docs`, `/docs/reference`, `/docs/reference/typescript/v4/functions/cancel-on`, and `/docs/patterns`.
- Final merge-order simulation succeeded with `ALL MERGES CLEAN` for PRs #1687 -> #1688 -> #1689 -> #1690 -> #1691 -> #1692 -> #1693 -> #1694 -> #1695 -> #1696 -> #1697.
- GitHub checks are green.

Ready for review.
