### PR TITLE
docs: build SEO docs cluster

### DIFF
--- a/pages/docs/ai-dev-tools/agent-skills.mdx
+++ b/pages/docs/ai-dev-tools/agent-skills.mdx
@@ -3,7 +3,7 @@ import { Callout, CodeGroup } from "shared/Docs/mdx";
 
 import { CodeBracketIcon, ComputerDesktopIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 
-export const description = "Install Inngest plugins and skills for Claude Code, Codex, Cursor, and other AI coding agents so they can write, test, and debug durable functions."
+export const description = "Install Inngest plugins and skills for Claude Code, Codex, Cursor, and other AI coding agents so they can write, test, and debug durable functions correctly."
 
 # AI Coding Agent Plugins and Skills
 
@@ -12,6 +12,8 @@ Inngest provides official plugins and [agent skills](https://agentskills.io) for
 <Callout>
   Use the Claude Code or Codex plugin for the best experience. Each plugin packages Inngest skills with local dev server MCP wiring so your agent can write code and inspect running functions in one loop.
 </Callout>
+
+Start from the [AI development tools hub](/docs/ai-dev-tools) if you want to compare agent skills, Dev Server MCP, CLI workflows, and LLM-ready docs in one place.
 
 ## What to install
 

--- a/pages/docs/ai-dev-tools/agent-skills.mdx
+++ b/pages/docs/ai-dev-tools/agent-skills.mdx
@@ -3,6 +3,7 @@ import { Callout, CodeGroup } from "shared/Docs/mdx";
 
 import { CodeBracketIcon, ComputerDesktopIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 
+export const metaTitle = "AI Coding Agent Plugins & Skills | Inngest Docs";
 export const description = "Install Inngest plugins and skills for Claude Code, Codex, Cursor, and other AI coding agents so they can write, test, and debug durable functions correctly."
 
 # AI Coding Agent Plugins and Skills

--- a/pages/docs/ai-dev-tools/index.mdx
+++ b/pages/docs/ai-dev-tools/index.mdx
@@ -1,0 +1,87 @@
+import { CardGroup, Card } from "src/shared/Docs/mdx";
+import { RiTerminalBoxLine } from "@remixicon/react";
+import InngestIcon from "src/shared/Icons/InngestIcon";
+import SkillsMDIcon from "src/shared/Icons/SkillsMD";
+import MCPIcon from "src/shared/Icons/MCP";
+import LLMsTXTIcon from "src/shared/Icons/LLMsTxt";
+
+export const description =
+  "Use Inngest with AI coding agents, MCP, CLI workflows, and LLM-ready docs to build, test, and debug durable functions faster.";
+
+# AI development tools for Inngest
+
+Use Inngest with AI coding agents, local MCP tools, CLI workflows, and LLM-ready documentation. These resources help agents write current Inngest code, connect to your running Dev Server, trigger test events, inspect runs, and debug durable functions in one loop.
+
+<CardGroup cols={2}>
+  <Card
+    href={"/docs/ai-dev-tools/mcp?ref=docs-ai-dev-tools"}
+    title={"Dev Server MCP"}
+    icon={<MCPIcon className="text-basis h-12 w-12" />}
+    iconPlacement="top"
+  >
+    Connect Claude Code, Cursor, and other MCP-compatible tools to your local Inngest Dev Server to list functions, send events, and inspect runs.
+  </Card>
+
+  <Card
+    href={"/docs/ai-dev-tools/agent-skills?ref=docs-ai-dev-tools"}
+    title={"Agent Plugins and Skills"}
+    icon={<SkillsMDIcon square={false} className="text-basis h-16 w-32" />}
+    iconPlacement="top"
+  >
+    Install Inngest plugins and portable skills so coding agents have current guidance for setup, durable functions, steps, flow control, realtime, and migrations.
+  </Card>
+
+  <Card
+    href={"/docs/ai-patterns/cli-for-coding-agents?ref=docs-ai-dev-tools"}
+    title={"CLI for Coding Agents"}
+    icon={<RiTerminalBoxLine className="text-basis h-10 w-10" />}
+    iconPlacement="top"
+  >
+    Use the Inngest CLI from an agent session to start the Dev Server, trigger events, inspect runs, and keep local debugging grounded in real execution.
+  </Card>
+
+  <Card
+    href={"#llm-docs"}
+    title={"LLM Docs"}
+    icon={<LLMsTXTIcon square={false} className="text-basis h-16 w-32" />}
+    iconPlacement="top"
+  >
+    Give AI tools compact or full-text documentation context with `llms.txt` and `llms-full.txt`.
+  </Card>
+</CardGroup>
+
+## How the tools fit together
+
+- **Agent skills and plugins** teach your coding agent how to build with Inngest APIs and current patterns.
+- **Dev Server MCP** lets your agent interact with your running local app by sending events, invoking functions, and inspecting run status.
+- **The CLI** gives both you and your agent a terminal-first way to start local services and debug function runs.
+- **LLM docs** provide crawlable markdown context for AI tools that need a compact table of contents or the full docs corpus.
+
+For the best feedback loop, install the agent plugin or skills for your coding tool, start the Inngest Dev Server, and connect the tool to the [Dev Server MCP endpoint](/docs/ai-dev-tools/mcp?ref=docs-ai-dev-tools).
+
+## LLM Docs
+
+An LLM-friendly version of the Inngest docs is available in two formats:
+
+- [inngest.com/llms.txt](https://www.inngest.com/llms.txt) - a table of contents for smaller context windows or tools that can crawl selected docs.
+- [inngest.com/llms-full.txt](https://www.inngest.com/llms-full.txt) - the full docs in markdown format.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    href={"/docs/local-development?ref=docs-ai-dev-tools"}
+    title={"Local development"}
+    icon={<InngestIcon className="text-basis h-8 w-8" />}
+  >
+    Start the Dev Server and run Inngest functions locally with production-like execution semantics.
+  </Card>
+
+  <Card
+    href={"/docs/reference/typescript/v4/intro?ref=docs-ai-dev-tools"}
+    title={"TypeScript SDK v4"}
+    icon={<InngestIcon className="text-basis h-8 w-8" />}
+  >
+    Build with the latest TypeScript SDK, including checkpointing, realtime, middleware, and updated step APIs.
+  </Card>
+</CardGroup>

--- a/pages/docs/ai-dev-tools/mcp.mdx
+++ b/pages/docs/ai-dev-tools/mcp.mdx
@@ -3,7 +3,7 @@ import { Callout, CodeGroup } from "shared/Docs/mdx";
 
 import { BookOpenIcon, CodeBracketIcon, ComputerDesktopIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 
-export const description = "Integrate AI development tools with Inngest using Model Context Protocol (MCP). Test functions, monitor execution, and debug workflows with Claude Code, Cursor, and other AI assistants."
+export const description = "Connect AI coding agents to your Inngest Dev Server via MCP. List functions, send events, and inspect runs from Claude Code, Cursor, or any MCP-compatible tool."
 
 # Model Context Protocol (MCP) Integration
 
@@ -21,6 +21,10 @@ The Inngest dev server includes a comprehensive Model Context Protocol (MCP) ser
 
 <Callout>
 The Inngest MCP server runs locally with your dev server and requires no external dependencies, API keys, or internet connection to function.
+</Callout>
+
+<Callout variant="info">
+Pair Dev Server MCP with [Inngest agent plugins and skills](/docs/ai-dev-tools/agent-skills) for the complete AI development loop. Start from the [AI development tools hub](/docs/ai-dev-tools) to choose the right resources for your coding agent.
 </Callout>
 
 ## Quick Start
@@ -306,7 +310,23 @@ Search docs for 'step\\.run.*retry' to find step retry examples
 
 ## Resources
 
-<ResourceGrid cols={2}>
+<ResourceGrid cols={3}>
+
+<Resource resource={{
+href: "/docs/ai-dev-tools",
+name: "AI Development Tools",
+icon: ComputerDesktopIcon,
+description: "Start here for Inngest MCP, agent plugins and skills, CLI workflows, and LLM-ready docs.",
+pattern: 1,
+}}/>
+
+<Resource resource={{
+href: "/docs/ai-dev-tools/agent-skills",
+name: "Agent Plugins and Skills",
+icon: CodeBracketIcon,
+description: "Install Inngest plugins and skills for Claude Code, Codex, Cursor, Windsurf, and other agents.",
+pattern: 1,
+}}/>
 
 <Resource resource={{
 href: "https://modelcontextprotocol.io/introduction",
@@ -317,7 +337,7 @@ pattern: 1,
 }}/>
 
 <Resource resource={{
-href: "/docs/dev-server",
+href: "/docs/local-development",
 name: "Inngest Dev Server Documentation",
 icon: ComputerDesktopIcon,
 description: "Comprehensive guide to the Inngest dev server and local development.",
@@ -344,9 +364,10 @@ pattern: 1,
 
 ## Related Concepts
 
+- [AI Development Tools](/docs/ai-dev-tools): Hub for MCP, agent skills, CLI workflows, and LLM-ready docs
+- [Agent Plugins and Skills](/docs/ai-dev-tools/agent-skills): Install current Inngest guidance for AI coding agents
 - [Inngest Functions](/docs/features/inngest-functions): Learn how to create and configure functions
 - [Event Triggers](/docs/features/events-triggers): Understanding event-driven architectures
 - [Local Development](/docs/local-development): Setting up your development environment
-- [Testing Functions](/docs/reference/testing): Comprehensive testing strategies
-- [Dev Server](/docs/dev-server): Complete dev server documentation
+- [Testing Functions](/docs/reference/typescript/v4/testing): Comprehensive testing strategies
 - [Error Handling](/docs/guides/error-handling): Debugging and error recovery patterns

--- a/pages/docs/ai-dev-tools/mcp.mdx
+++ b/pages/docs/ai-dev-tools/mcp.mdx
@@ -3,6 +3,7 @@ import { Callout, CodeGroup } from "shared/Docs/mdx";
 
 import { BookOpenIcon, CodeBracketIcon, ComputerDesktopIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 
+export const metaTitle = "Model Context Protocol (MCP) Integration | Inngest Docs";
 export const description = "Connect AI coding agents to your Inngest Dev Server via MCP. List functions, send events, and inspect runs from Claude Code, Cursor, or any MCP-compatible tool."
 
 # Model Context Protocol (MCP) Integration

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -14,6 +14,7 @@ import MCPIcon from 'src/shared/Icons/MCP';
 import LLMsTXTIcon from 'src/shared/Icons/LLMsTxt';
 
 export const hidePageSidebar = true;
+export const description = "Build reliable background jobs, workflows, and AI agents in TypeScript, Python, and Go without managing queues or infrastructure.";
 
 # Inngest Documentation
 
@@ -68,7 +69,16 @@ Write functions in TypeScript, Python or Go to power background and scheduled jo
 
 ## Coding agent resources
 
-<CardGroup cols={3}>
+<CardGroup cols={4}>
+  <Card
+    href={"/docs/ai-dev-tools?ref=docs-home"}
+    title={"AI development tools"}
+    icon={<InngestIcon className="text-basis h-12 w-12"/>}
+    iconPlacement="top"
+  >
+    Resources for using Inngest with AI coding agents, MCP, CLI workflows, and LLM-ready documentation.
+  </Card>
+
   <Card
     href={"/docs/ai-dev-tools/agent-skills"}
     title={"Agent Plugins and Skills"}

--- a/pages/docs/learn/how-functions-are-executed.mdx
+++ b/pages/docs/learn/how-functions-are-executed.mdx
@@ -116,14 +116,14 @@ Temporal is a pull-based durable execution platform, and teams often evaluate bo
 
 **Flow control.** Inngest includes [concurrency controls](/docs/functions/concurrency), [prioritization](/docs/guides/priority), [throttling](/docs/guides/throttling), [debouncing](/docs/guides/debounce), [rate limiting](/docs/guides/rate-limiting), and [idempotency](/docs/guides/handling-idempotency) as built-in features of the SDK, available in every environment: local development, self-hosted, and cloud. Temporal has recently introduced priority and fairness features for task queues, but fairness is a paid feature available only in Temporal Cloud.
 
-**Self-hosting.** Inngest can be self-hosted as a single binary with SQLite or Postgres as a backing store. Temporal self-hosting requires running multiple server components with a Cassandra or Postgres dependency, along with separate worker infrastructure.
+**Self-hosting.** Inngest can be [self-hosted](/docs/self-hosting) as a single binary with SQLite or Postgres as a backing store. Temporal self-hosting requires running multiple server components with a Cassandra or Postgres dependency, along with separate worker infrastructure.
 
 | | Inngest | Temporal |
 | --- | --- | --- |
 | **Infrastructure** | No separate infrastructure. Serve (serverless) or Connect (workers) on your compute. | Requires Temporal Server cluster + separate worker processes. |
 | **Programming model** | Step-based memoization with standard language primitives. | Deterministic replay with strict runtime rules. |
 | **Flow control** | Built-in: [concurrency](/docs/functions/concurrency), [priority](/docs/guides/priority), [throttling](/docs/guides/throttling), [debounce](/docs/guides/debounce), [rate limiting](/docs/guides/rate-limiting). Available everywhere. | Priority and fairness features are paid, cloud-only. |
-| **Self-hosting** | Single binary with SQLite or Postgres. | Multi-component cluster with Cassandra/Postgres. |
+| **Self-hosting** | [Single binary with SQLite or Postgres](/docs/self-hosting). | Multi-component cluster with Cassandra/Postgres. |
 | **Serverless support** | Native. Designed for serverless-first environments. | Requires persistent worker processes; not serverless-native. |
 
 ## Conclusion

--- a/pages/docs/local-development.mdx
+++ b/pages/docs/local-development.mdx
@@ -9,6 +9,8 @@ import TypeScriptIcon from 'src/shared/Icons/TypeScript';
 import PythonIcon from 'src/shared/Icons/Python';
 import GoIcon from 'src/shared/Icons/Go';
 
+export const description = "Run Inngest functions locally with one command. Full observability, event replay, and the same execution model as production. No Redis or workers required.";
+
 # Local development
 
 Testing background jobs, durable workflows, and event-driven functions locally is notoriously painful. Most solutions require running a full Redis stack, managing separate worker processes, or writing mocks that don't reflect how your code behaves in production. The Inngest Dev Server eliminates all of that with a single command, giving you a complete local environment with the same execution model, flow control, and observability you get in production.
@@ -44,6 +46,10 @@ You can now open the dev server's browser interface on [`http://localhost:8288`]
 <Callout variant="info">
   Set the `INNGEST_DEV=1` environment variable when starting your app so it connects to the local Dev Server instead of Inngest Cloud. You can add this to your `.env` file or pass it inline: `INNGEST_DEV=1 npm run dev`. [Learn more about local development environment variables](/docs/sdk/environment-variables#inngest-dev).
 </Callout>
+
+## AI-assisted local development
+
+The Dev Server also exposes a local [Model Context Protocol (MCP) integration](/docs/ai-dev-tools/mcp) at `http://127.0.0.1:8288/mcp`. Connect Claude Code, Cursor, or another MCP-compatible coding agent to list registered functions, send test events, invoke functions, and inspect run status while your app is running locally.
 
 ## Connecting apps to the Dev Server
 

--- a/pages/docs/local-development.mdx
+++ b/pages/docs/local-development.mdx
@@ -9,6 +9,7 @@ import TypeScriptIcon from 'src/shared/Icons/TypeScript';
 import PythonIcon from 'src/shared/Icons/Python';
 import GoIcon from 'src/shared/Icons/Go';
 
+export const metaTitle = "Local Development with the Inngest Dev Server";
 export const description = "Run Inngest functions locally with one command. Full observability, event replay, and the same execution model as production. No Redis or workers required.";
 
 # Local development

--- a/pages/docs/platform/deployment.mdx
+++ b/pages/docs/platform/deployment.mdx
@@ -9,6 +9,7 @@ import {
   RiServerLine
 } from "@remixicon/react";
 
+export const metaTitle = "Deploying Inngest Functions | Platform Overview";
 export const description = "Overview of Inngest deployment options: the serve() HTTP handler for serverless platforms and the connect() persistent worker model for long-running compute.";
 
 # Deployment

--- a/pages/docs/platform/deployment.mdx
+++ b/pages/docs/platform/deployment.mdx
@@ -9,6 +9,8 @@ import {
   RiServerLine
 } from "@remixicon/react";
 
+export const description = "Overview of Inngest deployment options: the serve() HTTP handler for serverless platforms and the connect() persistent worker model for long-running compute.";
+
 # Deployment
 
 Moving to production requires deploying your Inngest Functions on your favorite Cloud Provider and configuring it to allow the Inngest Platform to orchestrate runs: 
@@ -30,10 +32,18 @@ Moving to production requires deploying your Inngest Functions on your favorite 
   <Card title="Deploy with Render" icon={<RenderIcon className="text-basis"/>} href={'/docs/deploy/render'}>
     Deploy your Inngest Functions on Render.
   </Card>
+  <Card title="Connect workers to Inngest" icon={<RiServerLine className="text-basis h-5 w-5" />} href={'/docs/setup/connect'}>
+    Use Connect for persistent worker-style deployments on long-running compute.
+  </Card>
+  <Card title="Use checkpointing in production" icon={<RiCloudLine className="text-basis h-5 w-5" />} href={'/docs/setup/checkpointing'}>
+    Resume durable functions quickly across steps, retries, and deploys.
+  </Card>
   <Card title="Self-host Inngest" icon={<RiServerLine className="text-basis h-5 w-5" />} href={'/docs/self-hosting'}>
     Self-host Inngest on your own infrastructure.
   </Card>
 </CardGroup>
+
+Most serverless and API-route deployments use the `serve()` HTTP handler. Long-running worker or container deployments can use [Connect](/docs/setup/connect), which keeps a persistent connection open to Inngest. If you need to run the execution engine on your own infrastructure, see [Self-hosting](/docs/self-hosting).
 
 ## How Inngest handles Function Runs
 

--- a/pages/docs/reference/typescript/v4/intro.mdx
+++ b/pages/docs/reference/typescript/v4/intro.mdx
@@ -2,6 +2,7 @@ import { Info, CodeGroup } from "src/shared/Docs/mdx";
 
 import GithubIcon from "shared/Icons/Github"
 
+export const metaTitle = "TypeScript SDK v4 | Inngest Reference";
 export const description = "Inngest TypeScript SDK v4: the latest release with improved type safety, native realtime, new step APIs, and updated middleware.";
 
 # TypeScript SDK v4

--- a/pages/docs/reference/typescript/v4/intro.mdx
+++ b/pages/docs/reference/typescript/v4/intro.mdx
@@ -2,6 +2,8 @@ import { Info, CodeGroup } from "src/shared/Docs/mdx";
 
 import GithubIcon from "shared/Icons/Github"
 
+export const description = "Inngest TypeScript SDK v4: the latest release with improved type safety, native realtime, new step APIs, and updated middleware.";
+
 # TypeScript SDK v4
 
 <Info>
@@ -17,21 +19,31 @@ The TypeScript SDK v4 delivers a major upgrade to speed and developer experience
 - **Better schemas** — Runtime event data validation with Standard Schema support (not just Zod!).
 - **Faster by default** — Parallel step optimization and checkpointing are both enabled by default, leading to fewer requests and lower latency.
 - **Improved logging** — Structured logging (Pino-style) and cleaner separation of internal vs. app logs.
-- **Cleaner API** — Triggers in the options object, lazy init for edge runtimes, and more compile-time safety
+- **Cleaner API** — Triggers in the options object, lazy init for edge runtimes, and more compile-time safety.
 
 ## Installing
 
 <CodeGroup>
 ```shell {{ title: "npm" }}
-npm install inngest@beta
+npm install inngest
 ```
 ```shell {{ title: "pnpm" }}
-pnpm add inngest@beta
+pnpm add inngest
 ```
 ```shell {{ title: "yarn" }}
-yarn add inngest@beta
+yarn add inngest
 ```
 </CodeGroup>
+
+## Build with v4
+
+Start with the [client setup](/docs/reference/typescript/v4/client/create) and [function creation](/docs/reference/typescript/v4/functions/create) references, then use the v4 feature docs that match your application:
+
+- [Checkpointing](/docs/setup/checkpointing) for low-latency resumptions across durable steps.
+- [Realtime](/docs/features/realtime) for publishing workflow progress to users.
+- [Durable Endpoints](/docs/learn/durable-endpoints) for durable HTTP responses and streaming APIs.
+- [Middleware](/docs/reference/typescript/v4/middleware/lifecycle) for cross-cutting concerns like observability, serialization, encryption, and Sentry.
+- [v3 to v4 migration guide](/docs/reference/typescript/v4/migrations/v3-to-v4) for upgrading existing TypeScript projects.
 
 ## Source code
 

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -355,6 +355,7 @@ const sectionLearn: (NavGroup | NavLink)[] = [
         { title: "Sync your app", href: `/docs/apps/cloud` },
         { title: "Connect (workers)", href: `/docs/setup/connect`, tag: "beta" },
         { title: "Checkpointing", href: `/docs/setup/checkpointing`, tag: "new" },
+        { title: "Self-hosting", href: `/docs/self-hosting` },
         { title: "Cloud providers", links: [
           { title: "Vercel", href: "/docs/deploy/vercel" },
           { title: "DigitalOcean", href: "/docs/deploy/digital-ocean", tag: "new" },
@@ -403,6 +404,7 @@ const sectionLearn: (NavGroup | NavLink)[] = [
   {
     title: "AI",
     links: [
+      { title: "AI development tools", href: "/docs/ai-dev-tools" },
       { title: "Agent Plugins and Skills", href: "/docs/ai-dev-tools/agent-skills" },
       { title: "Dev Server MCP", href: "/docs/ai-dev-tools/mcp" },
       { title: "AgentKit", href: "https://agentkit.inngest.com", target: "_blank" },


### PR DESCRIPTION
## Context

Based on Pat's June 2026 docs SEO recommendations and the completed DEV-434 audit for the MCP / v4 / self-host / Connect growth cluster.

Links:
- Notion source/tracker: https://app.notion.com/p/37db64753bbd80dabf8ad5760ebce791
- Linear implementation ticket: https://linear.app/inngest/issue/DEV-441/build-first-wave-mcp-v4-self-host-connect-seo-docs-cluster
- Linear audit ticket: https://linear.app/inngest/issue/DEV-434/audit-mcp-v4-self-host-connect-docs-cluster-for-seo-growth
- Metadata sheet: https://docs.google.com/spreadsheets/d/1Z2n2x398ORBZFkoygO75FbiMPz37DsKSuILqjFQSiPc/edit?usp=sharing
- Slack update: https://inngest.slack.com/archives/C068B3TL06L/p1781643647471869

DEV-434 decision: do not create one broad MCP / v4 / self-host / Connect mega-page. The first wave should add a lightweight AI/dev-tooling hub and strengthen links into the existing dedicated pages.

## What changed

- Added `/docs/ai-dev-tools` as an AI development tools hub for Dev Server MCP, Agent Plugins and Skills, CLI for coding agents, and LLM docs.
- Linked the hub from the docs home and docs navigation.
- Strengthened the MCP <> agent skills connection and fixed the MCP page's stale `/docs/dev-server` and testing links.
- Added Dev Server MCP context to `/docs/local-development`.
- Refreshed `/docs/reference/typescript/v4/intro` so v4 installs use `inngest`, not `inngest@beta`, and added links to checkpointing, realtime, durable endpoints, middleware, and migration docs.
- Added Connect/checkpointing/self-hosting routing to `/docs/platform/deployment` and the self-hosting nav entry under Learn > Deploying.
- Added self-hosting links in the Durable Execution comparison page.
- Owns the reviewed metadata rows for the five touched docs pages that are intentionally deferred from DEV-433: `/docs/ai-dev-tools/agent-skills`, `/docs/ai-dev-tools/mcp`, `/docs/local-development`, `/docs/platform/deployment`, and `/docs/reference/typescript/v4/intro`.

## Coordination notes

- DEV-431 and DEV-432 own the P1 page refreshes for Next.js quick start and serving functions, so this PR avoids changing those pages until those PRs merge.
- DEV-433 owns the broad metadata sweep and now intentionally defers the five cluster rows listed above to this PR.
- DEV-442 remains the post-launch validation ticket.
- Final merge-order simulation succeeded with `ALL MERGES CLEAN` for PRs #1687 -> #1688 -> #1689 -> #1690 -> #1691 -> #1692 -> #1693 -> #1694 -> #1695 -> #1696 -> #1697.

## Verification

- `pnpm test:docs-markdown`
- `git diff --check`
- Targeted internal route verifier for links touched by this PR
- `pnpm exec prettier --check pages/docs/ai-dev-tools/agent-skills.mdx pages/docs/ai-dev-tools/mcp.mdx pages/docs/local-development.mdx pages/docs/platform/deployment.mdx pages/docs/reference/typescript/v4/intro.mdx`
- Local dev server spot-checks on `http://localhost:3002` for `/docs/ai-dev-tools`, `/docs/ai-dev-tools/mcp`, `/docs/local-development`, `/docs/platform/deployment`, `/docs/reference/typescript/v4/intro`, `/docs/learn/how-functions-are-executed`, and `/docs`
- `pnpm build`

Notes: `pnpm link-check:offline` could not run locally because `lychee` is not installed. The dev server also emitted the existing Turbopack HMR `Invalid file type Directory` warning, but all spot-checked routes returned 200 and `pnpm build` completed successfully.