### PR TITLE
docs: optimize events SEO snippet

### DIFF
--- a/pages/docs/events/index.mdx
+++ b/pages/docs/events/index.mdx
@@ -3,6 +3,30 @@ import { CodeGroup, Callout, LanguageSelector, LanguageSection, Note } from "src
 export const metaTitle = "Sending Events to Inngest | SDK & HTTP Reference"
 export const description = "Send events to Inngest using the TypeScript, Python, or Go SDK, or via HTTP from any language. Learn payload format, batching, and environment routing."
 
+export const structuredData = {
+  "@type": "HowTo",
+  name: "Send events to Inngest",
+  description:
+    "Create an Inngest client, send one or more events, and configure an Event Key for production environments.",
+  step: [
+    {
+      "@type": "HowToStep",
+      name: "Create an Inngest client",
+      text: "Instantiate the Inngest client in a shared file so it can be imported anywhere in your application.",
+    },
+    {
+      "@type": "HowToStep",
+      name: "Send an event",
+      text: "Call send() with an event name and data payload, then await the returned promise so the event is delivered before the process exits.",
+    },
+    {
+      "@type": "HowToStep",
+      name: "Set an Event Key in production",
+      text: "Set the INNGEST_EVENT_KEY environment variable with your Event Key so your application can send events to the correct Inngest environment.",
+    },
+  ],
+};
+
 # Sending events to Inngest
 
 Send events to Inngest from the TypeScript, Python, or Go SDK, or use the Event API to send events over HTTP from any language or service.

--- a/pages/docs/events/index.mdx
+++ b/pages/docs/events/index.mdx
@@ -1,8 +1,11 @@
 import { CodeGroup, Callout, LanguageSelector, LanguageSection, Note } from "src/shared/Docs/mdx";
 
-export const description = 'Learn how to send events with the Inngest SDK, set the Event Key, and send events from other languages via HTTP.';
+export const metaTitle = "Sending Events to Inngest | SDK & HTTP Reference"
+export const description = "Send events to Inngest using the TypeScript, Python, or Go SDK, or via HTTP from any language. Learn payload format, batching, and environment routing."
 
-# Sending events
+# Sending events to Inngest
+
+Send events to Inngest from the TypeScript, Python, or Go SDK, or use the Event API to send events over HTTP from any language or service.
 
 To start, make sure you have [installed the Inngest SDK](/docs/sdk/overview).
 
@@ -430,4 +433,3 @@ For example, for two events like `storefront/item.imported` and `storefront/item
 * [TypeScript SDK Reference: Send events](/docs/reference/events/send)
 * [Python SDK Reference: Send events](/docs/reference/python/client/send)
 * [Go SDK Reference: Send events](https://pkg.go.dev/github.com/inngest/inngestgo#Client)
-


### PR DESCRIPTION
## Context

This is the DEV-436 implementation from Pat's June 2026 docs SEO optimization work.

Links:
- Linear: https://linear.app/inngest/issue/DEV-436/optimize-docsevents-snippet-title-and-structured-data
- Notion tracker: https://app.notion.com/p/37db64753bbd80dabf8ad5760ebce791
- Metadata sheet: https://docs.google.com/spreadsheets/d/1Z2n2x398ORBZFkoygO75FbiMPz37DsKSuILqjFQSiPc/edit?usp=sharing
- Slack update: https://inngest.slack.com/archives/C068B3TL06L/p1781644842050259
- Shared structured-data layout: https://github.com/inngest/website/pull/1695
- Branch: `codex/dev-436-events-seo`

## What changed

- Updated `/docs/events` with Pat's proposed click-oriented title and meta description.
- Changed the H1 from `Sending events` to `Sending events to Inngest`.
- Added a single direct-answer lead sentence covering SDK and HTTP event sending.
- Added a page-owned `HowTo` `structuredData` export for the core event-sending steps.
- Avoided a broader content rewrite; the existing page already covers SDKs, Event Keys, payload format, batching, branch environment routing, HTTP sends, Event IDs, and deduplication.

## Structured data note

This PR owns the page-specific `HowTo` schema export for `/docs/events`. The schema is emitted as JSON-LD by the shared docs layout support in [DEV-443 / PR #1695](https://github.com/inngest/website/pull/1695). Keeping the schema export in this page PR keeps the schema next to the content and avoids merge conflicts with the shared layout PR.

## Validation

- `git diff --check`
- Verified Pat's downloaded metadata workbook row for `/docs/events`
- `pnpm exec prettier --check pages/docs/events/index.mdx`
- `pnpm test:docs-markdown`
- `pnpm build`
- Local rendered check at `http://localhost:3003/docs/events`: title/meta, H1, lead sentence, and `TechArticle` JSON-LD verified
- Final merge-order simulation succeeded with `ALL MERGES CLEAN` for PRs #1687 -> #1688 -> #1689 -> #1690 -> #1691 -> #1692 -> #1693 -> #1694 -> #1695 -> #1696 -> #1697.

Notes:
- `pnpm prettier` was attempted, but the existing repo script exits 2 because `pages/**/*.js` and `shared/*.js` match no files; it also formats unrelated TSX files before that failure. I restored those unrelated formatter side effects and used the targeted MDX Prettier check above.
- Local dev served the page with `200`; Turbopack also logged an existing-style HMR panic (`Invalid file type Directory`) during local verification. Production build passed.
- Local `lychee` is not installed, so link-check was not run locally; CI will still generate the report-only lychee artifact.