### PR TITLE
docs: optimize usage limits SEO

### DIFF
--- a/pages/docs/usage-limits/inngest.mdx
+++ b/pages/docs/usage-limits/inngest.mdx
@@ -4,6 +4,44 @@ import { Tag } from "src/shared/Docs/Tag";
 export const metaTitle = "Inngest Usage Limits | Runs, Events & Retention"
 export const description = "Inngest platform limits by plan: max concurrency, event size, step count, function run timeout, log retention, and event history."
 
+export const structuredData = {
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "How long can an Inngest function sleep?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Inngest supports sleeps up to one year. Free plan sleeps are limited to up to seven days.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How many steps can an Inngest function have?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The maximum number of steps allowed per function is 1000.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What is the default event payload size limit?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The default event payload size on the Free Tier is 256KB and can be upgraded to 3MB.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How many events can I send in one request?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "You can send a maximum of 5000 events in one request.",
+      },
+    },
+  ],
+};
+
 # Inngest usage limits
 
 Inngest usage limits keep function runs, steps, events, and history predictable for every account. Use these tables to check plan limits, rate-limit related controls, event payload limits, retention windows, and hard platform limits.

--- a/pages/docs/usage-limits/inngest.mdx
+++ b/pages/docs/usage-limits/inngest.mdx
@@ -1,11 +1,41 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 import { Tag } from "src/shared/Docs/Tag";
 
-# Usage Limits
+export const metaTitle = "Inngest Usage Limits | Runs, Events & Retention"
+export const description = "Inngest platform limits by plan: max concurrency, event size, step count, function run timeout, log retention, and event history."
 
-We have put some limits on the service to make sure we provide you a good default to start with, while also keeping it a good experience for all other users using Inngest.
+# Inngest usage limits
+
+Inngest usage limits keep function runs, steps, events, and history predictable for every account. Use these tables to check plan limits, rate-limit related controls, event payload limits, retention windows, and hard platform limits.
+
+If you're looking for function-level rate limiting, use the [rate limiting guide](/docs/guides/rate-limiting?ref=docs-usage-limits) or [throttling guide](/docs/guides/throttling?ref=docs-usage-limits).
 
 Some of these limits are customizable, so if you need more than what the current limits provide, please [contact us][contact] and we can update the limits for you.
+
+## Plan limits
+
+| Limit | Free | Basic | Pro | Enterprise |
+| --- | --- | --- | --- | --- |
+| Max concurrent steps | 5 | 25 | 200+ | Custom |
+| Single event size | 256KiB | 512KiB | 3MiB | Custom |
+| Trace and log history | 24 hours | 7 days | 14 days | 90 days |
+| Event lookback period | 1 hour | 1 hour | 3 days | Custom |
+| Maximum function run length | 30 days | 90 days | 366 days | Custom |
+
+See the [pricing page](/pricing?ref=docs-usage-limits) for plan packaging, included usage, and paid upgrade details.
+
+## Platform limits
+
+| Limit | Current value | Notes |
+| --- | --- | --- |
+| Step sleep duration | Up to 1 year | Free plan supports sleeps up to 7 days. |
+| Step timeout | Up to 2 hours | Also depends on your hosting provider's timeout. |
+| Step-returned payload size | 4MiB | Applies to data returned by a step. |
+| Function run state size | 32MiB | Includes event data, step data, function return data, and internal metadata. |
+| Steps per function | 1000 | Loops that create one step per item can hit this quickly. |
+| Event name length | 256 characters | Applies to the event `name`. |
+| Events per request | 5000 | Applies to `step.sendEvent(events)` and `inngest.send(events)`. |
+| Batch size | 10MiB | Hard cap regardless of `timeout` or `maxSize`. |
 
 ## Functions
 
@@ -13,7 +43,7 @@ The following applies to `step` usage.
 
 ### Sleep duration
 
-Sleep (with `step.sleep()` and `step.sleepUntil()`) up to a year, and for free plan up to seven days. Check the [pricing page](/pricing) for more information.
+Sleep (with `step.sleep()` and `step.sleepUntil()`) up to a year, and for free plan up to seven days. Check the [pricing page](/pricing?ref=docs-usage-limits) for more information.
 
 ### Timeout
 
@@ -21,7 +51,7 @@ Each step has a timeout depending on the hosting provider of your choice ([see m
 
 ### Concurrency <Tag>Upgradable</Tag>
 
-Check your concurrency limits on the [billing page](https://app.inngest.com/billing). See the [pricing page](https://www.inngest.com/pricing) for more info about the concurrency limits in all plans.
+Check your concurrency limits on the [billing page](https://app.inngest.com/billing). See the [pricing page](/pricing?ref=docs-usage-limits) for more info about the concurrency limits in all plans.
 
 ### Payload Size
 
@@ -55,7 +85,7 @@ The maximum length allowed for an event name is `256` characters.
 
 ### Request Body Size <Tag>Upgradable</Tag>
 
-The maximum event payload size is dependent on your billing plan. The default on the Free Tier is `256KB` and is upgradable to `3MB`. See [the pricing page](/pricing?ref=docs-usage-limits) for additional detail.
+The maximum event payload size is dependent on your billing plan. The Free plan supports `256KiB`, Basic supports `512KiB`, Pro supports `3MiB`, and Enterprise plans can use custom limits. See [the pricing page](/pricing?ref=docs-usage-limits) for additional detail.
 
 ### Number of events per request <Tag>Customizable</Tag>
 


### PR DESCRIPTION
## Summary

- Applies Pat's June 2026 metadata recommendation for `/docs/usage-limits/inngest` from the docs SEO sheet.
- Adds crawlable answer-shaped usage-limit tables for plan limits and platform limits.
- Adds direct rate limiting/throttling links for the losing `inngest rate limit` query cluster.
- Adds a page-owned `FAQPage` `structuredData` export for usage-limit answers.
- Updates touched internal pricing links to relative URLs with `?ref=docs-usage-limits`.

## Context

- Linear: [DEV-437](https://linear.app/inngest/issue/DEV-437/optimize-usage-limits-docs-for-ctr-and-crawlable-answers)
- Notion tracker: [docs SEO optimization recommendations June 2026](https://app.notion.com/p/37db64753bbd80dabf8ad5760ebce791)
- Metadata sheet: [Docs - Meta Titles & Descriptions _ June 2026](https://docs.google.com/spreadsheets/d/1Z2n2x398ORBZFkoygO75FbiMPz37DsKSuILqjFQSiPc/edit?usp=sharing)
- Slack update: [#dev-rel-docs message](https://inngest.slack.com/archives/C068B3TL06L/p1781645503620409)
- Shared structured-data layout: [DEV-443 / PR #1695](https://github.com/inngest/website/pull/1695)
- Baseline SEO cleanup: [PR #1683](https://github.com/inngest/website/pull/1683)

## Structured Data

This PR owns the page-specific `FAQPage` schema export for `/docs/usage-limits/inngest`. The schema is emitted as JSON-LD by the shared docs layout support in [DEV-443 / PR #1695](https://github.com/inngest/website/pull/1695). Keeping the schema export in this page PR keeps the schema next to the content and avoids merge conflicts with the shared layout PR.

## Validation

- `pnpm exec prettier --check pages/docs/usage-limits/inngest.mdx`
- `pnpm test:docs-markdown`
- `pnpm build`
- `git diff --check`
- Browser verification at `http://localhost:3004/docs/usage-limits/inngest` confirmed title, meta description, H1, crawlable tables, rate-limit links, and shared `TechArticle` JSON-LD.
- Final merge-order simulation succeeded with `ALL MERGES CLEAN` for PRs #1687 -> #1688 -> #1689 -> #1690 -> #1691 -> #1692 -> #1693 -> #1694 -> #1695 -> #1696 -> #1697.

## Notes

- `pnpm prettier` still exits 2 because `pages/**/*.js` and `shared/*.js` match no files after it writes unrelated TSX formatting changes. I restored those generated side effects and used the targeted MDX prettier check above.
- Local `pnpm dev` still emits the known Turbopack HMR `Invalid file type Directory` panic, but the page served 200 and `pnpm build` passed.