### PR TITLE
docs: optimize realtime SEO

### DIFF
--- a/pages/docs/features/realtime.mdx
+++ b/pages/docs/features/realtime.mdx
@@ -14,6 +14,30 @@ import {
 export const metaTitle = "Inngest Realtime | Stream Updates from Functions";
 export const description = "Stream real-time updates from Inngest functions to your UI using typed channels and topics. Built into TypeScript SDK v4 with no extra infrastructure needed.";
 
+export const structuredData = {
+  "@type": "HowTo",
+  name: "Stream realtime updates from an Inngest function",
+  description:
+    "Define a typed realtime channel, publish updates from a function, then mint a token and subscribe from the client.",
+  step: [
+    {
+      "@type": "HowToStep",
+      name: "Define a shared channel",
+      text: "Use realtime.channel() to define a channel and its typed topics for the updates your UI should receive.",
+    },
+    {
+      "@type": "HowToStep",
+      name: "Publish from a function",
+      text: "Publish messages with publish() for transient updates or step.realtime.publish() for durable, memoized updates inside a function.",
+    },
+    {
+      "@type": "HowToStep",
+      name: "Mint a token and subscribe from the client",
+      text: "Mint a subscription token on the server, then pass it to useRealtime() or subscribe() so the client can receive channel updates.",
+    },
+  ],
+};
+
 # Realtime <VersionBadge version="TypeScript SDK v4" />
 
 <Info>

--- a/pages/docs/features/realtime.mdx
+++ b/pages/docs/features/realtime.mdx
@@ -11,7 +11,8 @@ import {
   VersionBadge,
 } from "src/shared/Docs/mdx";
 
-export const description = "Learn the v4 realtime concepts and workflow for streaming updates from Inngest functions.";
+export const metaTitle = "Inngest Realtime | Stream Updates from Functions";
+export const description = "Stream real-time updates from Inngest functions to your UI using typed channels and topics. Built into TypeScript SDK v4 with no extra infrastructure needed.";
 
 # Realtime <VersionBadge version="TypeScript SDK v4" />
 
@@ -27,9 +28,10 @@ export const description = "Learn the v4 realtime concepts and workflow for stre
   v3 docs [here](/docs/reference/typescript/v3/realtime).
 </Warning>
 
-Realtime lets you stream function progress, push live updates into the browser,
-and build interactive workflows like human-in-the-loop approvals without
-managing your own websocket infrastructure.
+Inngest Realtime streams updates from your functions to your UI with typed
+channels and topics in TypeScript SDK v4. Use it to show function progress, push
+live browser updates, and build interactive workflows like human-in-the-loop
+approvals without managing your own websocket infrastructure.
 
 ## Concepts
 


### PR DESCRIPTION
## Summary

- Applies Pat's June 2026 metadata recommendation for `/docs/features/realtime` from the docs SEO sheet.
- Adds a dedicated `metaTitle` for realtime search intent.
- Replaces the generic description with the reviewed typed channels/topics description.
- Lightly tunes the opening paragraph to reinforce streaming updates from functions without changing the page structure or conversion cards.
- Adds a page-owned `HowTo` `structuredData` export for the realtime implementation steps.

## Context

- Linear: [DEV-438](https://linear.app/inngest/issue/DEV-438/optimize-realtime-docs-snippet-and-schema)
- Notion tracker: [docs SEO optimization recommendations June 2026](https://app.notion.com/p/37db64753bbd80dabf8ad5760ebce791)
- Metadata sheet: [Docs - Meta Titles & Descriptions _ June 2026](https://docs.google.com/spreadsheets/d/1Z2n2x398ORBZFkoygO75FbiMPz37DsKSuILqjFQSiPc/edit?usp=sharing)
- Slack update: [#dev-rel-docs message](https://inngest.slack.com/archives/C068B3TL06L/p1781645971004069)
- Shared structured-data layout: [DEV-443 / PR #1695](https://github.com/inngest/website/pull/1695)
- Baseline SEO cleanup: [PR #1683](https://github.com/inngest/website/pull/1683)

## Structured Data

This PR owns the page-specific `HowTo` schema export for `/docs/features/realtime`. The schema is emitted as JSON-LD by the shared docs layout support in [DEV-443 / PR #1695](https://github.com/inngest/website/pull/1695). Keeping the schema export in this page PR keeps the schema next to the content and avoids merge conflicts with the shared layout PR.

## Validation

- `pnpm exec prettier --check pages/docs/features/realtime.mdx`
- `pnpm test:docs-markdown`
- `pnpm build`
- `git diff --check`
- Browser verification at `http://localhost:3005/docs/features/realtime` confirmed title, meta description, H1, updated intro, existing conversion links/cards, and shared `TechArticle` JSON-LD.
- Final merge-order simulation succeeded with `ALL MERGES CLEAN` for PRs #1687 -> #1688 -> #1689 -> #1690 -> #1691 -> #1692 -> #1693 -> #1694 -> #1695 -> #1696 -> #1697.

## Notes

- `pnpm prettier` still exits 2 because `pages/**/*.js` and `shared/*.js` match no files after it writes unrelated TSX formatting changes. I restored those generated side effects and used the targeted MDX prettier check above.
- Local `pnpm dev` still emits the known Turbopack HMR `Invalid file type Directory` panic, but the page served 200 and `pnpm build` passed.