### PR TITLE
docs: refresh inngest functions SEO intro

### DIFF
--- a/pages/docs/learn/inngest-functions.mdx
+++ b/pages/docs/learn/inngest-functions.mdx
@@ -11,10 +11,20 @@ import TypeScriptIcon from 'src/shared/Icons/TypeScript';
 import PythonIcon from 'src/shared/Icons/Python';
 import GoIcon from 'src/shared/Icons/Go';
 
+export const metaTitle = "Inngest Functions | Durable Background Logic";
+export const description = "Inngest functions are durable, retriable units of background logic triggered by events or cron schedules. Write standard TypeScript, Python, or Go functions.";
+
 # Inngest Functions
 
-Inngest functions enable developers to run reliable background logic, from background jobs to complex workflows.
-An Inngest Function is composed of 3 main parts that provide robust tools for retrying, scheduling, and coordinating complex sequences of operations:
+Inngest functions are durable, retriable units of background logic that run on your own compute and are triggered by events, cron schedules, or webhooks. Use them for background jobs, scheduled work, and multi-step workflows that need automatic retries, step-level state, and observability without adding a queue or workflow engine.
+
+You write standard TypeScript, Python, or Go code, then expose functions with [`serve()`](/docs/learn/serving-inngest-functions) or [Connect](/docs/setup/connect) so Inngest can invoke and coordinate runs from the platform.
+
+## What are Inngest functions?
+
+An Inngest function is a regular function wrapped with Inngest trigger and execution metadata. Inngest starts a run when a matching event, schedule, or webhook arrives, then records each step so failed work can retry from the last successful checkpoint instead of restarting from scratch.
+
+At a high level, an Inngest function has three core parts:
 
 <CardGroup cols={3}>
   <Card title="Triggers" icon={<EventIcon className="text-basis h-4 w-4"/>} href={'/docs/features/events-triggers'}>


### PR DESCRIPTION
## Summary

- Adds the reviewed SEO title and meta description for `/docs/learn/inngest-functions`.
- Reworks the opening into an answer-shaped definition of Inngest functions for high-impression, low-CTR search intent.
- Links the intro to `serve()` and Connect so the page reflects the existing DEV-248 rework direction without taking over the full rewrite.

## Context

- Linear: [DEV-439](https://linear.app/inngest/issue/DEV-439/fold-june-seo-findings-into-docslearninngest-functions-rework)
- Related rework ticket: [DEV-248](https://linear.app/inngest/issue/DEV-248/docslearninngest-functions-rework)
- Notion source: [/docs SEO optimization recommendations (June 2026)](https://app.notion.com/p/37db64753bbd80dabf8ad5760ebce791)
- Slack update: [#dev-rel-docs message](https://inngest.slack.com/archives/C068B3TL06L/p1781647110964319)
- Metadata sheet: [Docs - Meta Titles & Descriptions (June 2026)](https://docs.google.com/spreadsheets/d/1Z2n2x398ORBZFkoygO75FbiMPz37DsKSuILqjFQSiPc/edit?usp=sharing)
- Pat's baseline redirect fix: [PR #1683](https://github.com/inngest/website/pull/1683)

## Validation

- `pnpm exec prettier --check pages/docs/learn/inngest-functions.mdx`
- `pnpm test:docs-markdown`
- `pnpm build`
- `git diff --check`
- Rendered HTML check for `/docs/learn/inngest-functions` confirmed the updated title, meta description, answer-shaped intro, and serve/Connect links.

Note: `pnpm prettier` still exits 2 on the existing stale repo globs `pages/**/*.js` and `shared/*.js` after formatting unrelated TSX files. I restored that unrelated formatter churn and used the targeted Prettier check above for the touched file.