### PR TITLE
Instruct users not to use connection pooling for the Neon integration

### DIFF
--- a/pages/docs/features/events-triggers/neon.mdx
+++ b/pages/docs/features/events-triggers/neon.mdx
@@ -52,6 +52,11 @@ Inngest doesn’t store your credentials. Make sure you don’t refresh the page
 </Callout>
 
 Insert your postgres credentials and hit the “Verify” button to start the validation process:
+
+<Callout variant="warning">
+Your connection string must not use connection pooling and thus should not contain `-pooler` in the host. When getting the connection string from the Neon dashboard, ensure that the Connection pooling is disabled. 
+</Callout>
+
 <ImageTheme
   light={'/assets/docs/features/events-triggers/neon/neon-authorize-step.png'}
   className="my-0"


### PR DESCRIPTION
- We require connections without connection pooling. Surface this to the user in the instructions for the smoothest installation
- I inserted the warning block below. See the before at https://www.inngest.com/docs/features/events-triggers/neon
<img width="872" height="692" alt="Screenshot 2026-06-17 at 11 15 17 AM" src="https://github.com/user-attachments/assets/0689f09f-71f0-4d67-bb6e-fa257c0cb9bc" />
