### PR TITLE
fix: point background jobs TypeScript card to reference docs

### DIFF
--- a/components/v1/sections/BackgroundJobs/Reliability.tsx
+++ b/components/v1/sections/BackgroundJobs/Reliability.tsx
@@ -94,7 +94,7 @@ const FEATURES: Feature[] = [
     id: "typescript",
     title: "TypeScript-native",
     body: "Define event payload types once. End-to-end type safety from the event sender all the way into your function body.",
-    href: "https://www.inngest.com/docs/guides/singleton",
+    href: "/docs/reference/typescript/v4/intro",
   },
 ];
 


### PR DESCRIPTION
## Summary

- Update the Background Jobs page's "TypeScript-native" docs card to point to the TypeScript v4 reference intro instead of the singleton guide.

## Context

This is the one remaining useful change from Pat's closed PR #1680. The redirect work from #1680 was already shipped in #1683, so #1680 was closed as superseded and this small link fix was split into its own focused PR.

Links:
- Pat's original PR: #1680
- Superseding redirect PR: #1683

## Validation

- `git diff --check`

Note: I also ran `pnpm exec prettier --check components/v1/sections/BackgroundJobs/Reliability.tsx`; it reports pre-existing formatting/style churn in this file. I kept this PR to the single href change instead of adding unrelated formatting noise.