### PR TITLE
[codex] Remove hard-coded docs title suffixes

### DIFF
--- a/pages/docs/ai-dev-tools/agent-skills.mdx
+++ b/pages/docs/ai-dev-tools/agent-skills.mdx
@@ -3,7 +3,7 @@ import { Callout, CodeGroup } from "shared/Docs/mdx";
 
 import { CodeBracketIcon, ComputerDesktopIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 
-export const metaTitle = "AI Coding Agent Plugins & Skills | Inngest Docs";
+export const metaTitle = "AI Coding Agent Plugins & Skills";
 export const description = "Install Inngest plugins and skills for Claude Code, Codex, Cursor, and other AI coding agents so they can write, test, and debug durable functions correctly."
 
 # AI Coding Agent Plugins and Skills

--- a/pages/docs/ai-dev-tools/mcp.mdx
+++ b/pages/docs/ai-dev-tools/mcp.mdx
@@ -3,7 +3,7 @@ import { Callout, CodeGroup } from "shared/Docs/mdx";
 
 import { BookOpenIcon, CodeBracketIcon, ComputerDesktopIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 
-export const metaTitle = "Model Context Protocol (MCP) Integration | Inngest Docs";
+export const metaTitle = "Model Context Protocol (MCP) Integration";
 export const description = "Connect AI coding agents to your Inngest Dev Server via MCP. List functions, send events, and inspect runs from Claude Code, Cursor, or any MCP-compatible tool."
 
 # Model Context Protocol (MCP) Integration

--- a/pages/docs/ai-patterns/agent-tool-loops.mdx
+++ b/pages/docs/ai-patterns/agent-tool-loops.mdx
@@ -1,5 +1,5 @@
 
-export const metaTitle = "Build a Durable AI Agent Tool Loop | Inngest Docs"
+export const metaTitle = "Build a Durable AI Agent Tool Loop"
 export const description = "Build a fault-tolerant AI agent loop where every LLM call and tool execution is a checkpointed, retriable step. Survive failures without losing progress."
 
 # Build an Agent Tool Loop

--- a/pages/docs/ai-patterns/cli-for-coding-agents.mdx
+++ b/pages/docs/ai-patterns/cli-for-coding-agents.mdx
@@ -1,5 +1,5 @@
 
-export const metaTitle = "Inngest CLI for Coding Agents | Inngest Docs"
+export const metaTitle = "Inngest CLI for Coding Agents"
 export const description = "Use the Inngest CLI with AI coding agents to test, trigger, and debug durable functions from the terminal during local development."
 
 # Use the CLI with coding agents

--- a/pages/docs/ai-patterns/human-in-the-loop.mdx
+++ b/pages/docs/ai-patterns/human-in-the-loop.mdx
@@ -1,5 +1,5 @@
 
-export const metaTitle = "Human-in-the-Loop AI Workflows | Inngest Docs"
+export const metaTitle = "Human-in-the-Loop AI Workflows"
 export const description = "Pause AI workflows for human review using step.waitForEvent(). Build auditable pipelines that resume automatically when a decision or approval is received."
 
 # Human-in-the-loop (HITL)

--- a/pages/docs/ai-patterns/sub-agent-delegation.mdx
+++ b/pages/docs/ai-patterns/sub-agent-delegation.mdx
@@ -1,5 +1,5 @@
 
-export const metaTitle = "Sub-Agent Delegation | Inngest Docs"
+export const metaTitle = "Sub-Agent Delegation"
 export const description = "Delegate tasks to specialized sub-agents in your AI system, each with its own context window, tools, and token budget. Scale multi-agent pipelines with Inngest."
 
 # Delegate Tasks to Sub-Agents

--- a/pages/docs/apps/cloud.mdx
+++ b/pages/docs/apps/cloud.mdx
@@ -1,7 +1,7 @@
 import { Callout, ButtonCol, ButtonDeploy } from "src/shared/Docs/mdx";
 
 
-export const metaTitle = "Sync Your Inngest App After Deploy | Inngest Docs"
+export const metaTitle = "Sync Your Inngest App After Deploy"
 export const description = "Learn how to sync your Inngest app with the platform after each deploy, so your functions are always up to date in production and branch environments."
 
 # Syncing an Inngest App

--- a/pages/docs/cli.mdx
+++ b/pages/docs/cli.mdx
@@ -1,7 +1,7 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
 
-export const metaTitle = "Inngest CLI | Inngest Docs"
+export const metaTitle = "Inngest CLI"
 export const description = "Start the Dev Server, manage local development, and run commands to test and debug your Inngest functions from the terminal."
 
 # Inngest CLI

--- a/pages/docs/deploy/cloudflare.mdx
+++ b/pages/docs/deploy/cloudflare.mdx
@@ -1,4 +1,4 @@
-export const metaTitle = "Deploy Inngest to Cloudflare Pages | Inngest Docs"
+export const metaTitle = "Deploy Inngest to Cloudflare Pages"
 export const description = "Host Inngest functions on Cloudflare Pages. Set up the serve handler, configure environment variables, and deploy your durable workflows to the edge."
 
 # Cloudflare Pages

--- a/pages/docs/deploy/digital-ocean.mdx
+++ b/pages/docs/deploy/digital-ocean.mdx
@@ -1,6 +1,6 @@
 import { Callout, ButtonDeploy, CodeGroup } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Deploy Inngest to DigitalOcean | Inngest Docs"
+export const metaTitle = "Deploy Inngest to DigitalOcean"
 export const description = "Run Inngest functions on DigitalOcean. Configure your serve endpoint, set environment variables, and connect your DigitalOcean app to the Inngest platform."
 
 # DigitalOcean

--- a/pages/docs/deploy/netlify.mdx
+++ b/pages/docs/deploy/netlify.mdx
@@ -1,4 +1,4 @@
-export const metaTitle = "Deploy Inngest to Netlify | Inngest Docs"
+export const metaTitle = "Deploy Inngest to Netlify"
 export const description = "Host Inngest functions on Netlify. Set up the serve handler, configure your Netlify function endpoint, and connect to Inngest for durable background jobs."
 
 # Netlify

--- a/pages/docs/deploy/render.mdx
+++ b/pages/docs/deploy/render.mdx
@@ -1,6 +1,6 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Deploy Inngest to Render | Inngest Docs"
+export const metaTitle = "Deploy Inngest to Render"
 export const description = "Run Inngest background functions on Render. Configure the serve endpoint, set required environment variables, and sync your app with the Inngest platform."
 
 # Render

--- a/pages/docs/deploy/vercel.mdx
+++ b/pages/docs/deploy/vercel.mdx
@@ -1,6 +1,6 @@
 import { Callout, GuideSelector, GuideSection, ButtonDeploy, Tip } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Deploy Inngest to Vercel | Inngest Docs"
+export const metaTitle = "Deploy Inngest to Vercel"
 export const description = "Host Inngest functions on Vercel serverless functions alongside your existing API routes. Supports Next.js App Router, Pages Router, and Express-style handlers."
 
 # Vercel

--- a/pages/docs/events/creating-an-event-key.mdx
+++ b/pages/docs/events/creating-an-event-key.mdx
@@ -1,6 +1,6 @@
 import { Callout } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Create an Inngest Event Key | Inngest Docs"
+export const metaTitle = "Create an Inngest Event Key"
 export const description = "Generate and manage Event Keys to authenticate event ingestion from your app or third-party services. Scope keys to specific environments for security."
 
 # Creating an Event Key

--- a/pages/docs/examples/cleanup-after-function-cancellation.mdx
+++ b/pages/docs/examples/cleanup-after-function-cancellation.mdx
@@ -3,7 +3,7 @@ import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 import { RiBracesFill, RiErrorWarningFill } from "@remixicon/react";
 
 
-export const metaTitle = "Run Cleanup Logic After Function Cancellation | Inngest Docs"
+export const metaTitle = "Run Cleanup Logic After Function Cancellation"
 export const description = "Execute cleanup code when an Inngest function run is cancelled, whether via event, REST API, or bulk cancellation, using the onCancel lifecycle handler."
 
 # Cleanup after function cancellation

--- a/pages/docs/examples/durable-endpoints.mdx
+++ b/pages/docs/examples/durable-endpoints.mdx
@@ -4,7 +4,7 @@ import { RiNextjsFill } from "@remixicon/react";
 import { CodeBracketIcon } from "@heroicons/react/24/outline";
 
 
-export const metaTitle = "Durable Endpoints Example | Inngest Docs"
+export const metaTitle = "Durable Endpoints Example"
 export const description = "Turn any HTTP handler into a durable, observable workflow with automatic retries and step checkpointing. Full working example with TypeScript."
 
 # Durable Endpoints

--- a/pages/docs/examples/fetch-run-status-and-output.mdx
+++ b/pages/docs/examples/fetch-run-status-and-output.mdx
@@ -2,7 +2,7 @@ import { ResourceGrid, Resource } from 'src/shared/Docs/Resources';
 import { RiBracesFill } from "@remixicon/react";
 
 
-export const metaTitle = "Fetch Run Status and Output via API | Inngest Docs"
+export const metaTitle = "Fetch Run Status and Output via API"
 export const description = "Poll or fetch the status and output of an Inngest function run using the REST API. Useful for external systems that need to wait on a background job result."
 
 # Fetch run status and output

--- a/pages/docs/examples/fetch.mdx
+++ b/pages/docs/examples/fetch.mdx
@@ -2,7 +2,7 @@ import { CodeGroup, CardGroup, Card, VersionBadge, Callout } from "src/shared/Do
 
 
 
-export const metaTitle = "Durable HTTP Requests with step.fetch() | Inngest Docs"
+export const metaTitle = "Durable HTTP Requests with step.fetch()"
 export const description = "Make retryable, checkpointed HTTP requests inside Inngest functions using step.fetch(). Survive transient failures without re-running prior steps."
 
 # Fetch: performing API requests or fetching data <VersionBadge version="TypeScript only" />

--- a/pages/docs/examples/middleware/cloudflare-workers-environment-variables.mdx
+++ b/pages/docs/examples/middleware/cloudflare-workers-environment-variables.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Cloudflare Workers: Env Variables via Middleware | Inngest Docs"
+export const metaTitle = "Cloudflare Workers: Env Variables via Middleware"
 export const description = "Access Cloudflare Workers environment bindings and context inside Inngest functions using middleware for dependency injection."
 
 # Cloudflare Workers environment variables and context

--- a/pages/docs/examples/open-telemetry.mdx
+++ b/pages/docs/examples/open-telemetry.mdx
@@ -2,7 +2,7 @@ import { VersionBadge, Callout } from "src/shared/Docs/mdx";
 
 
 
-export const metaTitle = "OpenTelemetry Integration with Inngest | Inngest Docs"
+export const metaTitle = "OpenTelemetry Integration with Inngest"
 export const description = "Enrich Inngest function traces with your application's OpenTelemetry spans. Set up the ExtendedTraces middleware for end-to-end distributed tracing."
 
 # Set up OpenTelemetry with Inngest <VersionBadge version="TypeScript only" />

--- a/pages/docs/examples/scheduling-one-off-function.mdx
+++ b/pages/docs/examples/scheduling-one-off-function.mdx
@@ -3,7 +3,7 @@ import { Callout } from "src/shared/Docs/mdx";
 import { PencilSquareIcon } from "@heroicons/react/24/outline";
 
 
-export const metaTitle = "Schedule a One-Off Function Run | Inngest Docs"
+export const metaTitle = "Schedule a One-Off Function Run"
 export const description = "Trigger an Inngest function to run at a specific future time using step.sleepUntil() or delayed event timestamps. No cron required for one-off jobs."
 
 # Scheduling a one-off function

--- a/pages/docs/features/events-triggers.mdx
+++ b/pages/docs/features/events-triggers.mdx
@@ -7,7 +7,7 @@ import {
   RiNewspaperLine,
 } from "@remixicon/react";
 
-export const metaTitle = "Events & Triggers | Inngest Docs"
+export const metaTitle = "Events & Triggers"
 export const description = "Trigger Inngest functions from events, cron schedules, or direct invocation. Learn event format, wildcard matching, expression filters, and multi-trigger setup."
 
 # Events & Triggers

--- a/pages/docs/features/events-triggers/event-format.mdx
+++ b/pages/docs/features/events-triggers/event-format.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup, Callout, Info } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Inngest Event Payload Format | Inngest Docs"
+export const metaTitle = "Inngest Event Payload Format"
 export const description = "Learn the required and optional fields in an Inngest event payload: name, data, user, ts, and v. Includes examples and validation rules for well-formed events."
 
 ## Event payload format

--- a/pages/docs/features/events-triggers/neon.mdx
+++ b/pages/docs/features/events-triggers/neon.mdx
@@ -1,7 +1,7 @@
 import { Callout, Info, ImageTheme } from "src/shared/Docs/mdx";
 
 
-export const metaTitle = "Trigger Inngest Functions from Neon Postgres | Inngest Docs"
+export const metaTitle = "Trigger Inngest Functions from Neon Postgres"
 export const description = "Use Neon database change events to trigger Inngest functions. Set up the Neon integration to react to row inserts, updates, and deletes with durable workflows."
 
 # Neon

--- a/pages/docs/features/inngest-functions/cancellation/cancel-on-events.mdx
+++ b/pages/docs/features/inngest-functions/cancellation/cancel-on-events.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup, Row, Col, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Cancel Functions on Events | Inngest Docs"
+export const metaTitle = "Cancel Functions on Events"
 export const description = "Configure an Inngest function to automatically cancel when a specific event is received. Useful for aborting workflows when a user action supersedes them."
 
 # Cancel on Events

--- a/pages/docs/features/inngest-functions/cancellation/cancel-on-timeouts.mdx
+++ b/pages/docs/features/inngest-functions/cancellation/cancel-on-timeouts.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup, Row, Col, LanguageSelector, LanguageSection, Callout, VersionBadge } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Cancel Functions on Timeout | Inngest Docs"
+export const metaTitle = "Cancel Functions on Timeout"
 export const description = "Set a maximum duration on Inngest function runs and automatically cancel them if they exceed it. Prevents runaway jobs from consuming resources indefinitely."
 
 # Cancel on timeouts

--- a/pages/docs/features/inngest-functions/error-retries/rollbacks.mdx
+++ b/pages/docs/features/inngest-functions/error-retries/rollbacks.mdx
@@ -1,6 +1,6 @@
 import { CardGroup, Card, Callout, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Step Rollbacks on Failure | Inngest Docs"
+export const metaTitle = "Step Rollbacks on Failure"
 export const description = "Define rollback logic that runs if a step fails after all retries. Use step rollbacks to undo side effects and maintain consistency in multi-step workflows."
 
 # Rollbacks

--- a/pages/docs/features/inngest-functions/steps-workflows/running-experiments.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/running-experiments.mdx
@@ -1,7 +1,7 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
 
-export const metaTitle = "Run A/B Experiments Inside AI Pipelines | Inngest Docs"
+export const metaTitle = "Run A/B Experiments Inside AI Pipelines"
 export const description = "Compare LLM models, prompts, and pipeline configurations within durable functions using group.experiment() for built-in, reproducible AI pipeline experiments."
 
 # Run experiments in AI pipelines

--- a/pages/docs/features/middleware/create.mdx
+++ b/pages/docs/features/middleware/create.mdx
@@ -8,7 +8,7 @@ import {
   RiKeyLine,
 } from "@remixicon/react";
 
-export const metaTitle = "Creating Inngest Middleware | Inngest Docs"
+export const metaTitle = "Creating Inngest Middleware"
 export const description = "Build custom middleware for Inngest functions using the InngestMiddleware class. Hook into the function lifecycle to add logging, auth, or data transformation."
 
 # Creating middleware

--- a/pages/docs/functions/concurrency.mdx
+++ b/pages/docs/functions/concurrency.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup, Callout, Properties, Property } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Concurrency Configuration Reference | Inngest Docs"
+export const metaTitle = "Concurrency Configuration Reference"
 export const description = "Set limits, keys, and scopes to control step-level parallelism across function runs."
 
 # Managing concurrency

--- a/pages/docs/guides/batching.mdx
+++ b/pages/docs/guides/batching.mdx
@@ -1,7 +1,7 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
 
-export const metaTitle = "Batch Processing Events | Inngest Docs"
+export const metaTitle = "Batch Processing Events"
 export const description = "Process high volumes of events in batches to reduce function invocations and enable bulk operations. Configure batch size, timeout, and key-based grouping."
 
 # Batching events

--- a/pages/docs/guides/cancel-running-functions.mdx
+++ b/pages/docs/guides/cancel-running-functions.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup, Row, Col } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Bulk Cancel Running Function Runs | Inngest Docs"
+export const metaTitle = "Bulk Cancel Running Function Runs"
 export const description = "Cancel multiple in-flight Inngest function runs at once using the REST API. Filter by function ID, event name, or time range to scope the cancellation."
 
 # Bulk Cancellation

--- a/pages/docs/guides/clerk-webhook-events.mdx
+++ b/pages/docs/guides/clerk-webhook-events.mdx
@@ -1,5 +1,5 @@
 
-export const metaTitle = "Handle Clerk Webhooks with Inngest | Docs"
+export const metaTitle = "Handle Clerk Webhooks with Inngest"
 export const description = "Receive Clerk webhook events in Inngest to sync user data to your database, provision account resources on signup, and trigger workflows on auth events."
 
 # Handling Clerk webhook events

--- a/pages/docs/guides/debug-with-cli.mdx
+++ b/pages/docs/guides/debug-with-cli.mdx
@@ -1,5 +1,5 @@
 
-export const metaTitle = "Debug Inngest Functions with the CLI | Inngest Docs"
+export const metaTitle = "Debug Inngest Functions with the CLI"
 export const description = "Use the Inngest CLI to inspect function runs, send test events, and debug failures locally without needing the cloud dashboard."
 
 # Debug a function run from your terminal

--- a/pages/docs/guides/delayed-functions.mdx
+++ b/pages/docs/guides/delayed-functions.mdx
@@ -1,6 +1,6 @@
 import { LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Delayed & Scheduled One-Off Functions | Inngest Docs"
+export const metaTitle = "Delayed & Scheduled One-Off Functions"
 export const description = "Schedule a function to run at a future time using event timestamps or step.sleepUntil(). Ideal for reminders, follow-ups, and time-delayed processing."
 
 # Delayed Functions

--- a/pages/docs/guides/error-handling.mdx
+++ b/pages/docs/guides/error-handling.mdx
@@ -3,7 +3,7 @@ import { RiArrowGoBackLine, RiErrorWarningLine } from "@remixicon/react";
 
 import ReplayIcon from 'src/shared/Icons/Replay';
 
-export const metaTitle = "Error Handling & Retries in Inngest | Docs"
+export const metaTitle = "Error Handling & Retries in Inngest"
 export const description = "Inngest functions automatically retry on failure. Customize retry counts, handle per-step errors, define onFailure handlers, and implement step-level rollbacks."
 
 export const structuredData = {

--- a/pages/docs/guides/instrumenting-graphql.mdx
+++ b/pages/docs/guides/instrumenting-graphql.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Instrument GraphQL with Inngest | Docs"
+export const metaTitle = "Instrument GraphQL with Inngest"
 export const description = "Add Inngest background jobs and durable workflows to a GraphQL API. Trigger functions from mutations and handle long-running work outside the request cycle."
 
 # Instrumenting GraphQL

--- a/pages/docs/guides/logging.mdx
+++ b/pages/docs/guides/logging.mdx
@@ -1,7 +1,7 @@
 import { CodeGroup, VersionBadge, Tip } from "src/shared/Docs/mdx";
 import { Tag } from "src/shared/Docs/Tag";
 
-export const metaTitle = "Logging Inside Inngest Functions | Inngest Docs"
+export const metaTitle = "Logging Inside Inngest Functions"
 export const description = "Add structured logging to your Inngest functions using the built-in logger. Logs appear in the Inngest dashboard alongside step traces for each function run."
 
 # Logging in Inngest

--- a/pages/docs/guides/multiple-triggers.mdx
+++ b/pages/docs/guides/multiple-triggers.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup, Info } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Multiple Triggers & Event Wildcards | Inngest Docs"
+export const metaTitle = "Multiple Triggers & Event Wildcards"
 export const description = "Trigger a single Inngest function from multiple events or use wildcard patterns to match a family of events. Reduce code duplication across similar workflows."
 
 # Multiple triggers & wildcards

--- a/pages/docs/guides/pause-functions.mdx
+++ b/pages/docs/guides/pause-functions.mdx
@@ -1,5 +1,5 @@
 
-export const metaTitle = "Pause & Resume Inngest Functions | Inngest Docs"
+export const metaTitle = "Pause & Resume Inngest Functions"
 export const description = "Temporarily pause an Inngest function to stop new runs from starting, then resume it when ready. Useful during incidents or planned maintenance windows."
 
 # Function Pausing

--- a/pages/docs/guides/scheduled-functions.mdx
+++ b/pages/docs/guides/scheduled-functions.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup, Callout, LanguageSection, LanguageSelector } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Scheduled Functions & Cron Jobs | Inngest Docs"
+export const metaTitle = "Scheduled Functions & Cron Jobs"
 export const description = "Create recurring background jobs using cron expressions in Inngest. Supports timezone-aware schedules and runs on any platform including serverless."
 
 # Crons (Scheduled Functions)

--- a/pages/docs/guides/sending-events-from-functions.mdx
+++ b/pages/docs/guides/sending-events-from-functions.mdx
@@ -1,7 +1,7 @@
 import { Callout, LanguageSelector, LanguageSection } from "src/shared/Docs/mdx";
 
 
-export const metaTitle = "Send Events from Inside a Function | Inngest Docs"
+export const metaTitle = "Send Events from Inside a Function"
 export const description = "Use step.sendEvent() inside an Inngest function to trigger other functions or fan-out work in parallel. Events are sent reliably as part of the step lifecycle."
 
 # Sending events from functions

--- a/pages/docs/guides/trigger-your-code-from-retool.mdx
+++ b/pages/docs/guides/trigger-your-code-from-retool.mdx
@@ -1,6 +1,6 @@
 import { CodeGroup } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Trigger Inngest Functions from Retool | Docs"
+export const metaTitle = "Trigger Inngest Functions from Retool"
 export const description = "Send Inngest events from Retool internal tools to trigger background functions. Use Retool's HTTP connector to kick off durable workflows from admin dashboards."
 
 # Trigger your code from Retool

--- a/pages/docs/guides/writing-expressions.mdx
+++ b/pages/docs/guides/writing-expressions.mdx
@@ -1,6 +1,6 @@
 import { Info } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Writing Trigger Expressions (CEL) | Inngest Docs"
+export const metaTitle = "Writing Trigger Expressions (CEL)"
 export const description = "Write CEL expressions to filter which events trigger your Inngest functions. Match on event data fields, user properties, or custom attributes with precision."
 
 # Writing expressions

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -13,7 +13,7 @@ import SkillsMDIcon from 'src/shared/Icons/SkillsMD';
 import MCPIcon from 'src/shared/Icons/MCP';
 import LLMsTXTIcon from 'src/shared/Icons/LLMsTxt';
 
-export const metaTitle = "Inngest Docs | Inngest"
+export const metaTitle = "Inngest Docs"
 export const description = "Build reliable background jobs, workflows, and AI agents in TypeScript, Python, and Go without managing queues or infrastructure."
 export const hidePageSidebar = true;
 

--- a/pages/docs/learn/durable-endpoints/streaming.mdx
+++ b/pages/docs/learn/durable-endpoints/streaming.mdx
@@ -1,7 +1,7 @@
 import { Callout, VersionBadge } from "src/shared/Docs/mdx";
 
 
-export const metaTitle = "Streaming with Durable Endpoints | Inngest Docs"
+export const metaTitle = "Streaming with Durable Endpoints"
 export const description = "Stream incremental responses back to clients from a Durable Endpoint while running durable step logic in the background. Combine streaming UX with reliability."
 
 # Durable Endpoints Streaming <VersionBadge version="Developer Preview" />

--- a/pages/docs/platform/monitor/inspecting-events.mdx
+++ b/pages/docs/platform/monitor/inspecting-events.mdx
@@ -1,7 +1,7 @@
 import { Callout, Tip, Row, Col } from "src/shared/Docs/mdx";
 import { RiExternalLinkFill } from "@remixicon/react";
 
-export const metaTitle = "Inspect Events in the Inngest Dashboard | Docs"
+export const metaTitle = "Inspect Events in the Inngest Dashboard"
 export const description = "Browse and inspect individual events received by Inngest: view payload data, which functions were triggered, and replay events to re-run affected functions."
 
 # Inspecting an Event

--- a/pages/docs/platform/webhooks/build-an-integration.mdx
+++ b/pages/docs/platform/webhooks/build-an-integration.mdx
@@ -1,7 +1,7 @@
 import { Properties, Property, Steps, Step } from "src/shared/Docs/mdx";
 
 
-export const metaTitle = "Build a Webhook Integration with Inngest | Docs"
+export const metaTitle = "Build a Webhook Integration with Inngest"
 export const description = "Use Inngest Webhook Intents to let external services trigger your functions. Includes payload transformation, signature verification, and integration setup."
 
 # Webhook intents: Building a webhook integration

--- a/pages/docs/reference/go/migrations/v0.7-to-v0.8.mdx
+++ b/pages/docs/reference/go/migrations/v0.7-to-v0.8.mdx
@@ -1,6 +1,6 @@
 import { Callout, Tip, Warning } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Go SDK Migration: v0.7 → v0.8 | Inngest Docs"
+export const metaTitle = "Go SDK Migration: v0.7 → v0.8"
 export const description = "Step-by-step migration guide for upgrading the Inngest Go SDK from v0.7 to v0.8. Covers breaking changes, renamed types, and updated function configuration."
 
 # Go SDK migration guide: v0.7 to v0.8

--- a/pages/docs/reference/go/migrations/v0.8-to-v0.11.mdx
+++ b/pages/docs/reference/go/migrations/v0.8-to-v0.11.mdx
@@ -1,4 +1,4 @@
-export const metaTitle = "Go SDK Migration: v0.8 → v0.11 | Inngest Docs"
+export const metaTitle = "Go SDK Migration: v0.8 → v0.11"
 export const description = "Step-by-step migration guide for upgrading the Inngest Go SDK from v0.8 to v0.11. Covers API changes, new features, and deprecated patterns."
 
 # Go SDK migration guide: v0.8 to v0.11

--- a/pages/docs/reference/python/index.mdx
+++ b/pages/docs/reference/python/index.mdx
@@ -1,6 +1,6 @@
 import GithubIcon from "shared/Icons/Github"
 
-export const metaTitle = "Inngest Python SDK Reference | Docs"
+export const metaTitle = "Inngest Python SDK Reference"
 export const description = "Full reference for the Inngest Python SDK: creating functions, sending events, step methods, middleware, environment variables, and framework integrations."
 
 # Python SDK

--- a/pages/docs/reference/python/middleware/lifecycle.mdx
+++ b/pages/docs/reference/python/middleware/lifecycle.mdx
@@ -1,6 +1,6 @@
 import { Callout, CodeGroup, Properties, Property, Row, Col, VersionBadge } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Python Middleware Lifecycle | Inngest Docs"
+export const metaTitle = "Python Middleware Lifecycle"
 export const description = "Python middleware lifecycle hooks in the Inngest SDK: before_execution, after_execution, before_send_response, and transform_input."
 
 # Python middleware lifecycle

--- a/pages/docs/reference/python/migrations/v0.3-to-v0.4.mdx
+++ b/pages/docs/reference/python/migrations/v0.3-to-v0.4.mdx
@@ -1,4 +1,4 @@
-export const metaTitle = "Python SDK Migration: v0.3 → v0.4 | Inngest Docs"
+export const metaTitle = "Python SDK Migration: v0.3 → v0.4"
 export const description = "Upgrade guide for Inngest Python SDK v0.3 → v0.4. Covers breaking API changes and updated patterns for function creation, event sending, and client setup."
 
 # Python SDK migration guide: v0.3 to v0.4

--- a/pages/docs/reference/python/migrations/v0.4-to-v0.5.mdx
+++ b/pages/docs/reference/python/migrations/v0.4-to-v0.5.mdx
@@ -1,4 +1,4 @@
-export const metaTitle = "Python SDK Migration: v0.4 → v0.5 | Inngest Docs"
+export const metaTitle = "Python SDK Migration: v0.4 → v0.5"
 export const description = "Migration guide for upgrading the Inngest Python SDK from v0.4 to v0.5. Covers breaking changes in step API, middleware, and client initialization."
 
 # Python SDK migration guide: v0.4 to v0.5

--- a/pages/docs/reference/rest-api/index.mdx
+++ b/pages/docs/reference/rest-api/index.mdx
@@ -1,4 +1,4 @@
-export const metaTitle = "Inngest REST API Reference | Docs"
+export const metaTitle = "Inngest REST API Reference"
 export const description = "REST API reference for the Inngest platform: create events, fetch run status, cancel runs, manage functions, and integrate Inngest into your backend workflows."
 
 # REST API

--- a/pages/docs/reference/typescript/v3/migrations/v2-to-v3.mdx
+++ b/pages/docs/reference/typescript/v3/migrations/v2-to-v3.mdx
@@ -1,7 +1,7 @@
 import { Info, Callout, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
 
 
-export const metaTitle = "Migrate TypeScript SDK v2 → v3 | Inngest Docs"
+export const metaTitle = "Migrate TypeScript SDK v2 → v3"
 export const description = "Step-by-step guide for upgrading the Inngest TypeScript SDK from v2 to v3. Covers renamed APIs, updated function configuration, and new step method signatures."
 
 # Upgrading from Inngest SDK v2 to v3

--- a/pages/docs/reference/typescript/v4/migrations/v3-to-v4.mdx
+++ b/pages/docs/reference/typescript/v4/migrations/v3-to-v4.mdx
@@ -1,6 +1,6 @@
 import { Info, Tip, Warning } from "src/shared/Docs/mdx";
 
-export const metaTitle = "Migrate TypeScript SDK v3 → v4 | Inngest Docs"
+export const metaTitle = "Migrate TypeScript SDK v3 → v4"
 export const description = "Complete migration guide for upgrading the Inngest TypeScript SDK from v3 to v4. Covers all breaking changes, new APIs, and step-by-step upgrade instructions."
 
 # TypeScript SDK Migration Guide: v3 to v4

--- a/pages/docs/setup/checkpointing.mdx
+++ b/pages/docs/setup/checkpointing.mdx
@@ -1,6 +1,6 @@
 import { Info, Tip, Warning, CodeGroup, LanguageSelector, LanguageSection } from "shared/Docs/mdx";
 
-export const metaTitle = "Checkpointing | Inngest Docs"
+export const metaTitle = "Checkpointing"
 export const description = "Learn how Inngest checkpointing saves function execution state between steps so runs can recover from failures without re-executing completed work."
 
 # Checkpointing

--- a/pages/docs/streaming.mdx
+++ b/pages/docs/streaming.mdx
@@ -1,6 +1,6 @@
 import { Callout, CodeGroup } from "src/shared/Docs/mdx";
 
-export const metaTitle = "HTTP Streaming with Inngest | Docs"
+export const metaTitle = "HTTP Streaming with Inngest"
 export const description = "Enable HTTP streaming in Inngest to progressively send responses on serverless platforms. Overcome timeout limits by streaming output as work completes."
 
 # Streaming

--- a/pages/docs/usage-limits/providers.mdx
+++ b/pages/docs/usage-limits/providers.mdx
@@ -1,4 +1,4 @@
-export const metaTitle = "Cloud Provider Usage Limits | Inngest Docs"
+export const metaTitle = "Cloud Provider Usage Limits"
 export const description = "Understand how cloud provider compute limits for Vercel, Netlify, Cloudflare, and Render affect Inngest function execution time, memory, and request sizes."
 
 # Providers' Usage Limits


### PR DESCRIPTION
## Summary

- Remove literal trailing `| Inngest Docs` / `| Docs` suffixes from docs `metaTitle` exports.
- Leave `shared/Docs/Layout.tsx` unchanged for now, so the existing centralized `- Inngest Documentation` suffix remains in place until Dan/Pat decide whether to switch it to `| Inngest Docs`.

## Why

This is a targeted follow-up to the June docs SEO metadata work, not a revert. Some spreadsheet titles were applied literally with `| Inngest Docs` / `| Docs`, while `shared/Docs/Layout.tsx` already appends the docs suffix centrally. That produced doubled live titles such as:

```text
Cloud Provider Usage Limits | Inngest Docs - Inngest Documentation
```

This PR removes the hard-coded suffixes from individual docs metadata and lets the current centralized layout behavior continue owning the final external title suffix.

## Context Links

- Pat's Notion SEO recommendations: https://app.notion.com/p/inngest/docs-SEO-optimization-recommendations-June-2026-37db64753bbd80dabf8ad5760ebce791
- Metadata sheet: https://docs.google.com/spreadsheets/d/1Z2n2x398ORBZFkoygO75FbiMPz37DsKSuILqjFQSiPc/edit?usp=sharing
- Slack thread with Pat/Dan context: https://inngest.slack.com/archives/C068B3TL06L/p1781718085471649
- Prior metadata PR where the duplicated suffix showed up: https://github.com/inngest/website/pull/1689

## Validation

- `git diff --check origin/main`
- `pnpm exec tsc --noEmit --pretty false`
- Regex sweep confirmed no docs `metaTitle` still ends with `| Inngest Docs`, bare `| Docs`, `| Inngest Documentation`, `- Inngest Docs`, or `- Inngest Documentation`.
