### PR TITLE
[codex] Add Inngest docs writer skill

### DIFF
--- a/.agents/skills/inngest-docs-writer/SKILL.md
+++ b/.agents/skills/inngest-docs-writer/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: inngest-docs-writer
+description: Use when planning, writing, reviewing, or updating Inngest documentation, docs metadata, docs PRs, launch docs, tutorials, how-to guides, reference pages, migration guides, LLM/AX docs, or docs-related Linear/Notion/Slack/GitHub workflows. This skill helps agents build source-grounded docs from Notion, Slack, Linear, GitHub, and the local website repo; apply SEO and metadata rules from the June 2026 docs SEO work; choose pragmatic Diataxis-style content shapes; check agent-readable docs surfaces; and close the loop with circular links across PRs, tickets, Notion, and Slack.
+---
+
+# Inngest Docs Writer
+
+## Prime Directive
+
+Do not write docs from memory. Build a source packet first, then write.
+
+Every docs change should be traceable to source material: product code, implementation PRs, Linear scope, Notion specs, Slack decisions, and existing docs patterns. If a source is unavailable, say what is missing and either ask for it or mark the claim as an assumption.
+
+## Core Workflow
+
+1. **Classify the work.** Identify whether the request is a new doc, doc refresh, SEO metadata pass, launch doc, migration guide, API/reference update, tutorial/how-to, troubleshooting page, or agent/LLM-facing docs work.
+2. **Build the source packet.** Gather and cite context before drafting. Read [references/source-discovery.md](references/source-discovery.md) for the minimum source packet and connector workflow.
+3. **Choose the content shape.** Use Diataxis as a lens, not a cage. Read [references/content-shapes.md](references/content-shapes.md) when choosing between tutorial, how-to, reference, explanation, or hybrid docs.
+4. **Apply SEO metadata rules.** Read [references/seo-metadata.md](references/seo-metadata.md) before changing `metaTitle`, `description`, redirects, title suffix behavior, or search-result-facing copy.
+5. **Check AX/readability.** Read [references/ax-docs.md](references/ax-docs.md) when the content affects `llms.txt`, `/docs-markdown`, code snippets, MCP/agent docs, or agent consumption.
+6. **Implement in the repo.** Follow local `AGENTS.md`, existing MDX patterns, snippet conventions, and focused validation. Read [references/implementation.md](references/implementation.md) before editing files.
+7. **Close the loop.** For tracked work, link GitHub, Linear, Notion, and Slack in both directions. Read [references/closeout.md](references/closeout.md) before opening or closing PRs/tickets.
+
+For Claude Code or agents that cannot load Codex skills directly, adapt the workflow from [references/portable-agent-brief.md](references/portable-agent-brief.md).
+
+## Source Packet
+
+Create a short working note before drafting:
+
+- **Objective:** user request and desired outcome.
+- **Audience:** beginner, active implementer, maintainer, agent, search visitor, or mixed.
+- **Primary sources:** Notion pages, Slack threads, Linear tickets, GitHub issues/PRs, source code, existing docs.
+- **Decisions:** what is already decided, by whom, and where it was stated.
+- **Unknowns:** questions that need owner confirmation.
+- **Required links:** links that must appear in PR body, Linear ticket, Notion tracker, or Slack update.
+
+Proceed only when the source packet is sufficient for the risk level. For low-risk copy edits, local context may be enough. For launch docs, API behavior, SEO recommendations, or customer-impacting docs, gather external source context first.
+
+## Writing Standards
+
+- Prefer exact implementation truth over polished guesses.
+- Keep internal links relative, with `?ref=` tags when appropriate per repo guidance.
+- Preserve existing docs style unless the request is explicitly a restructure.
+- Make code snippets runnable or clearly scoped; use the repo snippet system when examples should be reused or validated.
+- Use concise headings that match the task a reader or agent is trying to complete.
+- Avoid marketing-style filler in docs. Docs should answer, orient, and unblock.
+- Avoid unrelated formatting churn. Keep diffs reviewable.
+
+## Review Checklist
+
+Before calling the work done, verify:
+
+- The source packet supports the claims.
+- Metadata is page-specific and does not hard-code global suffixes.
+- The doc shape matches the reader's task.
+- Internal links are relative and useful.
+- Agent-readable surfaces are not broken by MDX-only assumptions.
+- The PR body explains what changed, why, sources, validation, and known follow-ups.
+- Linear, Notion, GitHub, and Slack are linked when this is tracked project work.

--- a/.agents/skills/inngest-docs-writer/agents/openai.yaml
+++ b/.agents/skills/inngest-docs-writer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Inngest Docs Writer"
+  short_description: "Write source-grounded Inngest docs"
+  default_prompt: "Use $inngest-docs-writer to plan and draft an Inngest docs update from source context."

--- a/.agents/skills/inngest-docs-writer/references/ax-docs.md
+++ b/.agents/skills/inngest-docs-writer/references/ax-docs.md
@@ -1,0 +1,43 @@
+# AX And Agent-Readable Docs
+
+AX means Agent Experience: how well agents can discover, understand, and use the docs.
+
+## Agent-Facing Surfaces
+
+- `/llms.txt`: table of contents and entrypoints for LLM tools.
+- `/llms-full.txt`: larger bundled context.
+- `/docs-markdown/...`: markdown version of individual docs pages.
+- `pages/api/docs/chat.ts`: helper for sending page content to chat providers.
+- Snippets in `snippets/`: source-backed code examples used in MDX.
+
+## Writing For Agents
+
+- Use stable, descriptive headings.
+- Put prerequisites before steps.
+- Keep code blocks complete enough to copy or adapt.
+- Avoid relying on visual-only explanation.
+- Prefer explicit names over "this" or "that" when referring to APIs.
+- Link to canonical reference pages.
+- Keep MDX components from hiding critical text from markdown conversion.
+
+## Verification
+
+When docs affect agent consumption:
+
+```bash
+pnpm test:docs-markdown
+```
+
+Inspect the markdown route or generated markdown for the changed page when possible:
+
+```text
+/docs-markdown/<docs-path>
+```
+
+Check that important context survives conversion from MDX to markdown.
+
+## Algolia vs AX
+
+Algolia powers human docs search. It is not the primary AX path.
+
+The crawler indexes rendered docs pages and feeds the search modal. Agent-readable docs should primarily rely on markdown surfaces and source-backed snippets, not Algolia search records.

--- a/.agents/skills/inngest-docs-writer/references/closeout.md
+++ b/.agents/skills/inngest-docs-writer/references/closeout.md
@@ -1,0 +1,58 @@
+# Closeout And Circular Linking
+
+For tracked docs/SEO work, make the links circular so nobody has to search later.
+
+## Required Links
+
+Where applicable, link:
+
+- GitHub PR to Linear ticket, Notion tracker/spec, source sheet, and Slack thread.
+- Linear ticket to GitHub PR, Notion page, source sheet, and Slack thread.
+- Notion page/tracker to GitHub PR, Linear ticket, source sheet, and Slack thread.
+- Slack update to GitHub PR, Linear ticket, Notion page, and owner mentions.
+
+## PR Body Template
+
+```md
+## Summary
+
+- What changed.
+- Why it changed.
+
+## Context
+
+- Linear: <ticket>
+- Notion: <page>
+- Slack: <thread>
+- Source sheet/spec: <link>
+- Related PRs: <links>
+
+## Validation
+
+- `<command>`
+```
+
+## Slack Update Template
+
+```text
+<owner mention> quick update:
+
+Opened/updated <PR link> for <short purpose>.
+
+Context:
+- Linear: <ticket>
+- Notion: <page>
+- Slack/source thread: <thread>
+
+Validation:
+- `<command>`
+```
+
+## Merge Closeout
+
+After merge:
+
+- Update Linear status and add PR/merge link.
+- Update Notion tracker/spec with PR and final status.
+- Reply in Slack with the merged PR and any follow-up.
+- Create a new ticket/PR for intentionally deferred work.

--- a/.agents/skills/inngest-docs-writer/references/content-shapes.md
+++ b/.agents/skills/inngest-docs-writer/references/content-shapes.md
@@ -1,0 +1,33 @@
+# Content Shapes
+
+Use Diataxis as a practical lens, not a rigid taxonomy.
+
+## Choose A Shape
+
+- **Tutorial:** teach by walking through a concrete first success. Use for onboarding and learning paths.
+- **How-to:** help an active user complete a task. Use direct steps and prerequisites.
+- **Reference:** document exact API, SDK, config, event, CLI, or behavior details. Prioritize accuracy and scanability.
+- **Explanation:** build mental models and tradeoffs. Use when users need the why, not just the steps.
+
+Hybrid pages are allowed when they serve the reader. Make the dominant intent obvious.
+
+## When AX Changes The Shape
+
+Agent-facing docs reward predictable structure:
+
+- Stable headings.
+- Direct task language.
+- Complete examples.
+- Explicit prerequisites.
+- Canonical links.
+- Clear "what to do next" sections.
+
+Diataxis still helps agents because it separates action, facts, and explanation. The skill should not preserve Diataxis at the cost of retrieval or task completion.
+
+## Common Inngest Patterns
+
+- Quick starts: tutorial plus minimal reference links.
+- Guides: how-to first, explanation second.
+- SDK pages: reference first, examples inline.
+- Migration guides: task sequence plus compatibility notes.
+- AI/agent docs: task-oriented docs with exact code, durable execution caveats, and links to markdown/LLM resources.

--- a/.agents/skills/inngest-docs-writer/references/implementation.md
+++ b/.agents/skills/inngest-docs-writer/references/implementation.md
@@ -1,0 +1,52 @@
+# Implementation
+
+Follow the repo's `AGENTS.md` first.
+
+## Local Repo Rules
+
+- Use `pnpm`, never `npm`.
+- Prefer `rg` and `rg --files` for search.
+- Use relative URLs for internal links.
+- Use existing docs components and MDX patterns.
+- Use `apply_patch` for manual edits.
+- Do not revert unrelated user changes.
+- Avoid broad Prettier churn; format only touched files when useful.
+
+## Docs Files
+
+- Documentation lives under `pages/docs/**/*.mdx`.
+- Blog posts live under `content/blog`.
+- Snippets live under `snippets`.
+- Docs search notes live in `shared/Docs/SEARCH.md`.
+- Docs layout metadata is in `shared/Docs/Layout.tsx`.
+
+## Snippets
+
+Use snippets when code examples should be centralized or reused.
+
+Markers:
+
+```ts
+// !snippet:start
+// !snippet:end
+```
+
+MDX reference:
+
+````mdx
+```ts
+!snippet:path=snippets/path/to/file.ts
+```
+````
+
+Run snippet/markdown checks when changing snippets or generated markdown.
+
+## PR Practice
+
+Keep docs PRs narrow:
+
+- One behavioral/documentation goal per PR.
+- Clear source links in the PR body.
+- Validation commands included.
+- Known follow-ups called out explicitly.
+- Draft PRs when waiting on owner confirmation.

--- a/.agents/skills/inngest-docs-writer/references/portable-agent-brief.md
+++ b/.agents/skills/inngest-docs-writer/references/portable-agent-brief.md
@@ -1,0 +1,38 @@
+# Portable Agent Brief
+
+Use this brief when adapting the skill for Claude Code or another agent system.
+
+## Core Instruction
+
+When writing or updating Inngest docs, do not draft from memory. First build a source packet from available project context, then write the smallest correct docs change.
+
+## Required Workflow
+
+1. Read repository guidance: `AGENTS.md`, `CLAUDE.md`, and relevant local docs conventions.
+2. Identify the docs task type: new doc, refresh, SEO, API/reference, migration, launch, troubleshooting, or AX/LLM-facing docs.
+3. Gather sources from the best available tools:
+   - Local repo: `rg`, `git log`, source code, existing docs.
+   - GitHub: implementation PRs, issues, reviews, changed files.
+   - Linear: ticket scope, acceptance criteria, status, owner.
+   - Notion: specs, trackers, SEO recommendations.
+   - Slack: decision threads and owner context.
+4. Write a source packet with objective, audience, sources, decisions, unknowns, and required links.
+5. Choose a doc shape using Diataxis as a lens: tutorial, how-to, reference, explanation, or hybrid.
+6. Apply SEO rules: page-specific metadata, no hard-coded global docs suffix, concrete descriptions, no keyword stuffing.
+7. Check AX surfaces: snippets, `/docs-markdown`, `llms.txt`, and markdown conversion when relevant.
+8. Implement narrowly and validate with focused commands.
+9. Close the loop with circular links across GitHub, Linear, Notion, and Slack when tracked work is involved.
+
+## Non-Negotiables
+
+- Do not fabricate source context.
+- Do not silently skip Slack/Notion/Linear/GitHub context for high-risk docs work.
+- Do not hard-code global docs title suffixes in page metadata.
+- Do not introduce unrelated formatting churn.
+- Do not leave PRs/tickets/docs disconnected when the work is tracked.
+
+## Useful Default Prompt
+
+```text
+Use the Inngest docs writer workflow. Build a source packet from the repo plus available GitHub, Linear, Notion, and Slack context before drafting. Then implement the smallest correct docs change and include validation plus circular links.
+```

--- a/.agents/skills/inngest-docs-writer/references/seo-metadata.md
+++ b/.agents/skills/inngest-docs-writer/references/seo-metadata.md
@@ -1,0 +1,45 @@
+# SEO Metadata
+
+Use these rules for docs metadata and SEO-oriented docs updates.
+
+## Title Rules
+
+- `metaTitle` should be page-specific.
+- Do not hard-code the global docs suffix in individual docs metadata.
+- Do not add literal trailing suffixes such as `| Inngest Docs`, `| Docs`, or `- Inngest Documentation` to page-level `metaTitle`.
+- Let the central docs layout own the global suffix.
+- Before changing suffix behavior, inspect `shared/Docs/Layout.tsx` and confirm whether internal docs search needs crawler-side cleanup.
+
+## Description Rules
+
+- Descriptions should explain the specific page value in plain language.
+- Include concrete terms readers search for, but do not keyword stuff.
+- Avoid repeating the exact title in a way that wastes characters.
+- Prefer action/result language: "Learn how to...", "Configure...", "Reference for...".
+
+## Pat SEO Sweep Learnings
+
+- Spreadsheet/Notion recommendations are source material, not always literal implementation instructions.
+- If a recommendation says to append a suffix, check whether the app already appends one.
+- Validate metadata against source rows when doing large sweeps.
+- Keep metadata PRs narrow and easy to audit.
+- If a mistake lands, prefer targeted corrective PRs over broad reverts when other SEO work has landed since.
+
+## Validation
+
+Use focused regex sweeps when changing metadata:
+
+```bash
+rg -n 'export const metaTitle = ".* \| (Inngest Docs|Docs)"' pages/docs --glob '*.mdx'
+rg -n 'export const metaTitle = ".*(- Inngest Documentation|- Inngest Docs|\| Inngest Documentation)"' pages/docs --glob '*.mdx'
+```
+
+Run relevant local checks:
+
+```bash
+git diff --check
+pnpm exec tsc --noEmit --pretty false
+pnpm test:docs-markdown
+```
+
+Use the narrowest checks that cover the change. For pure MDX metadata changes, TypeScript and diff checks are often enough; for snippet/content changes, include docs markdown validation.

--- a/.agents/skills/inngest-docs-writer/references/source-discovery.md
+++ b/.agents/skills/inngest-docs-writer/references/source-discovery.md
@@ -1,0 +1,42 @@
+# Source Discovery
+
+Build a source packet before writing or editing docs.
+
+## Minimum Source Packet
+
+- User request and desired artifact.
+- Local files likely affected.
+- Relevant existing docs and examples.
+- Product/source code that defines the behavior.
+- GitHub PRs/issues that introduced or changed the behavior.
+- Linear ticket scope, owner, status, and acceptance criteria.
+- Notion spec, project tracker, SEO sheet, or planning page.
+- Slack thread decisions, especially from product/engineering/docs owners.
+- Open questions and assumptions.
+
+## Connector Workflow
+
+Use available connected tools in this order when relevant:
+
+1. **GitHub:** find implementation PRs, review comments, changed files, and current branch state.
+2. **Linear:** read the ticket, comments, status, labels, project, assignee, and related issues.
+3. **Notion:** fetch specs, trackers, SEO recommendations, launch notes, and project docs.
+4. **Slack:** read linked threads and search owner/channel context. If files are attached, read file metadata/content when available.
+5. **Local repo:** use `rg`, `rg --files`, `git log`, and existing MDX patterns.
+
+If a connector is unavailable, state the missing source and ask for a link/export when the risk is high. Do not invent source context.
+
+## Slack Notes
+
+- Read full threads, not only linked replies.
+- Preserve timestamps, authors, and links for decisions.
+- Use `slack_read_file` or equivalent for attachments when file IDs are available.
+- Treat Slack as decision context, not final product truth. Verify behavior against code or docs when possible.
+
+## Source Weight
+
+- **Code and merged PRs:** highest authority for current behavior.
+- **Product specs and owner decisions:** authority for intended behavior.
+- **Linear tickets:** authority for scope and acceptance.
+- **Slack:** authority for decisions and nuance; verify if ambiguous.
+- **SEO sheets/Notion recommendations:** authority for planned metadata, but check global layout behavior before applying literally.

--- a/.claude/skills/inngest-docs-writer
+++ b/.claude/skills/inngest-docs-writer
@@ -1,0 +1,1 @@
+../../.agents/skills/inngest-docs-writer

--- a/content/blog/eliminating-latency-ai-workflows.mdx
+++ b/content/blog/eliminating-latency-ai-workflows.mdx
@@ -63,7 +63,7 @@ Instead of blocking on each write, let the SDK orchestrate steps locally and exe
 
 You get speed on the happy path and safety on the failure path.
 
-This is the same insight behind write-ahead logging in databases. The log is the source of truth, but you don't block reads on every fsync. The difference is that here, the "log" is the checkpoint stream and the "reads" are step executions. Jay Kreps' [The Log: What Every Software Engineer Should Know](https://engineering.linkedin.com/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying) is the canonical reference on why this pattern works at scale.
+This is the same insight behind write-ahead logging in databases. The log is the source of truth, but you don't block reads on every fsync. The difference is that here, the "log" is the checkpoint stream and the "reads" are step executions. Jay Kreps' [The Log: What Every Software Engineer Should Know](https://web.archive.org/web/20131217183346/http://engineering.linkedin.com/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying) is the canonical reference on why this pattern works at scale.
 
 If you're building on Temporal, the closest equivalent is local activities. Local activities execute in-process on the workflow worker, avoiding the round-trip to the Temporal server. They do support retries and timeouts, but they're constrained by the workflow task timeout (default 10s), can't heartbeat, and if they run long or retry aggressively, they can delay signal delivery and query processing. You're fitting your activities into a box that works for short, fast operations.
 


### PR DESCRIPTION
## Summary

- Add a repo-local `inngest-docs-writer` skill for source-grounded documentation work.
- Capture the docs workflow we developed around source packets, SEO metadata, Diataxis-style content shapes, AX/LLM docs surfaces, implementation discipline, and circular closeout links.
- Include a portable agent brief that can be adapted for Claude Code or future agent systems without depending on Codex skill mechanics.

## Why

We have accumulated a lot of docs-writing process knowledge through the June 2026 SEO cleanup and the Pat/Dan follow-up work. This skill keeps that operating model close to the website/docs repo so new team members and future agents can reuse it instead of reconstructing it from Slack, Notion, Linear, or old PRs.

The core principle is: do not write docs from memory; build a source packet first from Notion, Slack, Linear, GitHub, and local repo context.

## Contents

- `.agents/skills/inngest-docs-writer/SKILL.md`
- `references/source-discovery.md`
- `references/seo-metadata.md`
- `references/content-shapes.md`
- `references/ax-docs.md`
- `references/implementation.md`
- `references/closeout.md`
- `references/portable-agent-brief.md`
- `agents/openai.yaml`

## Validation

- `python3 /Users/sterlingchin/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/inngest-docs-writer`
- `git diff --cached --check`
