### PR TITLE
fix: sitemap updates -- exclude redirected and noindex pages, add /product/how-inngest-works redirect

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -8,5 +8,24 @@ module.exports = {
     "/docs-markdown/*",
     "/api/*",
     "*/download-gate-form*",
+    // Pages that have been redirected — keep these out of the sitemap.
+    // The 301 redirects are defined in next.config.mjs (permanentRedirects).
+    // next-sitemap finds the underlying page files and would include these URLs
+    // without this exclusion list.
+    "/uses/durable-workflows",
+    "/uses/workflow-engine",
+    "/uses/serverless-cron-jobs",
+    "/compare-to-legacy-queues",
+    "/durable-endpoints",
+    "/platform",
+    "/careers",
+    "/launch-week",
+    "/launch-week/*",
+    "/ai-personalized-documentation",
+    "/product/how-inngest-works",
+    // Pages with noindex set in code — sitemap + noindex is contradictory.
+    "/content/ai-in-production-report-2026",
+    "/content/ai-in-production-report-2026/*",
+    "/resources/access/*",
   ],
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -199,6 +199,7 @@ const permanentRedirects = [
   ["/ai-personalized-documentation", "/docs/ai-dev-tools/agent-skills"],
   ["/ai/early-access", "/ai"],
   ["/launch-week", "/"],
+  ["/product/how-inngest-works", "/"],
   // The scheduled-jobs page moved under /uses; preserve the old URL.
   ["/scheduled-jobs", "/uses/scheduled-jobs"],
 ];

--- a/sitemap-redirected-pages.csv
+++ b/sitemap-redirected-pages.csv
@@ -1,0 +1,10 @@
+URL,Page File,Redirects To
+/uses/durable-workflows,app/(v0)/uses/durable-workflows/page.tsx,/platform/durable-execution
+/uses/workflow-engine,app/(v0)/uses/workflow-engine/page.tsx,/uses/webhooks
+/uses/serverless-cron-jobs,data/uses/serverless-cron-jobs.tsx (dynamic route),/uses/scheduled-jobs
+/compare-to-legacy-queues,app/(v0)/compare-to-legacy-queues/page.tsx,/platform/flow-control
+/durable-endpoints,app/(v0)/durable-endpoints/page.tsx,/platform/durable-execution
+/platform,app/(v0)/platform/page.tsx,/platform/durable-execution
+/careers,app/(v0)/careers/page.tsx,/about
+/launch-week,pages/launch-week/1/index.tsx,/
+/ai-personalized-documentation,pages/ai-personalized-documentation.tsx,/docs/ai-dev-tools/agent-skills


### PR DESCRIPTION
Summary
Cleaning up sitemap to remove pages that have been redirected/noindexed. Adding 1 redirect.

**Changes to next-sitemap.config.js**

Redirected pages excluded (next-sitemap finds the underlying page files even though they 301 at runtime):
/uses/durable-workflows, /uses/workflow-engine, /uses/serverless-cron-jobs
/compare-to-legacy-queues, /durable-endpoints, /platform
/careers, /launch-week, /ai-personalized-documentation, /product/how-inngest-works

**Noindex pages excluded (sitemap + noindex is contradictory):**
/content/ai-in-production-report-2026 and subpaths — robots: { index: false } set in page code
/resources/access/* (~30 URLs) — robots: "noindex" set in page code

**Changes to next.config.mjs**
Added 301 redirect: /product/how-inngest-works → /

Also includes sitemap-redirected-pages.csv — reference doc listing all redirected pages found during the audit