### PR TITLE
docs(patterns): add AI Evals section, move experiments pattern into it

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -188,6 +188,14 @@ const permanentRedirects = [
   ],
   ["/patterns/running-code-on-a-schedule", "/docs/guides/scheduled-functions"],
 
+  // run-experiments-in-production moved from the Durable Workflows category to
+  // the new AI Evals category (per Lauren's IA feedback). Old category URL is
+  // shared in Slack and linked from the experiments doc, so redirect it.
+  [
+    "/docs/patterns/durable/run-experiments-in-production",
+    "/docs/patterns/ai-evals/run-experiments-in-production",
+  ],
+
   // New IA: platform + use-case pages replacing legacy landing pages, plus
   // a few standalone LPs being retired.
   ["/uses/durable-workflows", "/platform/durable-execution"],

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -269,7 +269,7 @@ const sectionLearn: (NavGroup | NavLink)[] = [
         { title: "Wait for event", href: "/docs/features/inngest-functions/steps-workflows/wait-for-event" },
         { title: "Wait for signal", href: "/docs/features/inngest-functions/steps-workflows/wait-for-signal" },
         { title: "Invoke other functions", href: `/docs/guides/invoking-functions-directly` },
-        { title: "Step experiments", href: "/docs/features/inngest-functions/steps-workflows/step-experiments", tag: "new" },
+        { title: "Step experiments", href: "/docs/features/inngest-functions/steps-workflows/step-experiments" },
         { title: "AI steps (LLM calls)", href: "/docs/features/inngest-functions/steps-workflows/step-ai-orchestration" },
         { title: "Durable Fetch", href: tsRef("v4", "functions/fetch") },
       ]},

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -67,7 +67,7 @@ const sectionReference: (NavGroup | NavLink)[] = [
       { title: "Extended Traces", href: tsRef("v3", "extended-traces") },
       { title: "Referencing functions", href: `/docs/functions/references` },
       { title: "Testing", href: tsRef("v3", "testing") },
-      { title: "Durable Endpoints", href: tsRef("v3", "durable-endpoints"), tag: "new" },
+      { title: "Durable Endpoints", href: tsRef("v3", "durable-endpoints") },
       {
         title: "Steps",
         links: [
@@ -126,7 +126,7 @@ const sectionReference: (NavGroup | NavLink)[] = [
       { title: "Extended Traces", href: tsRef("v4", "extended-traces") },
       { title: "Referencing functions", href: tsRef("v4", "functions/references") },
       { title: "Testing", href: tsRef("v4", "testing") },
-      { title: "Durable Endpoints", href: tsRef("v4", "durable-endpoints"), tag: "new" },
+      { title: "Durable Endpoints", href: tsRef("v4", "durable-endpoints") },
       { title: "Deferred Functions", href: tsRef("v4", "functions/deferred-functions"), tag: "beta" },
       {
         title: "Steps",
@@ -259,7 +259,7 @@ const sectionLearn: (NavGroup | NavLink)[] = [
         { title: "Idempotency", href: `/docs/guides/handling-idempotency` },
         { title: "Logging", href: "/docs/guides/logging" },
       ]},
-      { title: "Durable Endpoints", tag: "new", links: [
+      { title: "Durable Endpoints", links: [
         { title: "Overview", href: `/docs/learn/durable-endpoints` },
         { title: "Streaming", href: "/docs/learn/durable-endpoints/streaming" },
       ]},

--- a/shared/Patterns/_patterns/run-experiments-in-production.mdx
+++ b/shared/Patterns/_patterns/run-experiments-in-production.mdx
@@ -1,7 +1,7 @@
 ---
 title: Run experiments in production
 subtitle: Use group.experiment() to split traffic, keep cohorts stable, compare variants, and roll changes forward safely.
-pattern: durable
+pattern: ai-evals
 tags: [Durability, Experiments, Architecture]
 ---
 

--- a/shared/Patterns/patternsData.ts
+++ b/shared/Patterns/patternsData.ts
@@ -38,8 +38,30 @@ export interface PatternSection extends PatternSectionMeta {
 
 const PATTERN_SECTIONS: PatternSectionMeta[] = [
   {
-    id: "durable",
+    // AI Evals: experiments today; scoring + evals patterns to follow.
+    // TODO(design): accent + viz below reuse the purplehaze palette and the
+    // "events" diagram as placeholders. Assign a dedicated AI Evals accent and
+    // visualization before the evals launch.
+    id: "ai-evals",
     number: "00",
+    name: "AI Evals",
+    kicker: "Experiment, score, pick winners",
+    description:
+      "Run experiments on live traffic, keep cohorts stable, and compare variants against real outcome signals. The substrate for evaluating models, prompts, and rewrites in production.",
+    viz: "events",
+    accentDeep: "#7147F1",
+    accent: {
+      text: "text-purplehaze-500",
+      border: "border-purplehaze-500",
+      bg: "bg-purplehaze-500/[0.08]",
+      gradient: "from-purplehaze-500 to-transparent",
+      hex: "#8B74F9",
+      rgb: "139 116 249",
+    },
+  },
+  {
+    id: "durable",
+    number: "01",
     name: "Durable Workflows",
     kicker: "Steps that don't lose state",
     description:
@@ -57,7 +79,7 @@ const PATTERN_SECTIONS: PatternSectionMeta[] = [
   },
   {
     id: "flow",
-    number: "01",
+    number: "02",
     name: "Flow Control",
     kicker: "Spike-proof the boring stuff",
     description:
@@ -75,7 +97,7 @@ const PATTERN_SECTIONS: PatternSectionMeta[] = [
   },
   {
     id: "events",
-    number: "02",
+    number: "03",
     name: "Event Coordination",
     kicker: "Choreograph the chaos",
     description:
@@ -93,7 +115,7 @@ const PATTERN_SECTIONS: PatternSectionMeta[] = [
   },
   {
     id: "schedule",
-    number: "03",
+    number: "04",
     name: "Scheduling",
     kicker: "Time as a first-class input",
     description:
@@ -111,7 +133,7 @@ const PATTERN_SECTIONS: PatternSectionMeta[] = [
   },
   {
     id: "jobs",
-    number: "04",
+    number: "05",
     name: "Background Jobs",
     kicker: "Off the request path",
     description:
@@ -125,28 +147,6 @@ const PATTERN_SECTIONS: PatternSectionMeta[] = [
       gradient: "from-blush-500 to-transparent",
       hex: "#F93E6A",
       rgb: "249 62 106",
-    },
-  },
-  {
-    // AI Evals: experiments today; scoring + evals patterns to follow.
-    // TODO(design): accent + viz below reuse the purplehaze palette and the
-    // "events" diagram as placeholders. Assign a dedicated AI Evals accent and
-    // visualization before the evals launch.
-    id: "ai-evals",
-    number: "05",
-    name: "AI Evals",
-    kicker: "Experiment, score, pick winners",
-    description:
-      "Run experiments on live traffic, keep cohorts stable, and compare variants against real outcome signals. The substrate for evaluating models, prompts, and rewrites in production.",
-    viz: "events",
-    accentDeep: "#7147F1",
-    accent: {
-      text: "text-purplehaze-500",
-      border: "border-purplehaze-500",
-      bg: "bg-purplehaze-500/[0.08]",
-      gradient: "from-purplehaze-500 to-transparent",
-      hex: "#8B74F9",
-      rgb: "139 116 249",
     },
   },
 ];

--- a/shared/Patterns/patternsData.ts
+++ b/shared/Patterns/patternsData.ts
@@ -127,6 +127,28 @@ const PATTERN_SECTIONS: PatternSectionMeta[] = [
       rgb: "249 62 106",
     },
   },
+  {
+    // AI Evals: experiments today; scoring + evals patterns to follow.
+    // TODO(design): accent + viz below reuse the purplehaze palette and the
+    // "events" diagram as placeholders. Assign a dedicated AI Evals accent and
+    // visualization before the evals launch.
+    id: "ai-evals",
+    number: "05",
+    name: "AI Evals",
+    kicker: "Experiment, score, pick winners",
+    description:
+      "Run experiments on live traffic, keep cohorts stable, and compare variants against real outcome signals. The substrate for evaluating models, prompts, and rewrites in production.",
+    viz: "events",
+    accentDeep: "#7147F1",
+    accent: {
+      text: "text-purplehaze-500",
+      border: "border-purplehaze-500",
+      bg: "bg-purplehaze-500/[0.08]",
+      gradient: "from-purplehaze-500 to-transparent",
+      hex: "#8B74F9",
+      rgb: "139 116 249",
+    },
+  },
 ];
 
 // Static pattern index. `category` matches a section id above; `slug` matches a
@@ -145,7 +167,7 @@ export const PATTERNS: PatternIndexItem[] = [
       "Break multi-step AI pipelines and complex business logic into durable, independently retried steps.",
   },
   {
-    category: "durable",
+    category: "ai-evals",
     slug: "run-experiments-in-production",
     title: "Run experiments in production",
     subtitle:


### PR DESCRIPTION
## Summary

Per Lauren's IA feedback in #dev-rel-docs ([thread](https://inngest.slack.com/archives/C068B3TL06L/p1782188891032179)): the experiments pattern doesn't belong under **Durable Workflows**. This adds a new **AI Evals** patterns category and moves `run-experiments-in-production` into it, as an early easter egg ahead of next week's evals launch.

## Changes

- `shared/Patterns/patternsData.ts`
  - Added a new `ai-evals` section (`AI Evals`, number `05`) to `PATTERN_SECTIONS`.
  - Changed `run-experiments-in-production` from `category: "durable"` to `category: "ai-evals"`.
- `shared/Patterns/_patterns/run-experiments-in-production.mdx`
  - Updated frontmatter `pattern: durable` → `pattern: ai-evals`.
- `next.config.mjs`
  - Added a permanent redirect from the old `/docs/patterns/durable/run-experiments-in-production` URL to the new `/docs/patterns/ai-evals/run-experiments-in-production` URL.

> [!NOTE]
> The new section's `accent` (reusing the purplehaze palette) and `viz` (reusing the `events` diagram) are placeholders, flagged with a `TODO(design)` in the data file. Swap for a dedicated AI Evals accent/diagram when design is ready.