### PR TITLE
docs: repoint experiments links to the AI Evals pattern page

### DIFF
--- a/content/blog/introducing-group-experiment.mdx
+++ b/content/blog/introducing-group-experiment.mdx
@@ -95,4 +95,4 @@ Experiments fit anywhere you want to know which implementation performed better 
 
 ## Get started
 
-`group.experiment()` is available in the Inngest TypeScript SDK `4.8.0` and later—upgrade if you're on an earlier release. See the [Step Experiments docs](/docs/features/inngest-functions/steps-workflows/running-experiments?ref=blog-introducing-group-experiment) to get started, and the [`group.experiment()` API reference](/docs/reference/typescript/v4/functions/group-experiment?ref=blog-introducing-group-experiment) for the full reference.
+`group.experiment()` is available in the Inngest TypeScript SDK `4.8.0` and later—upgrade if you're on an earlier release. See the [Run experiments in production](/docs/patterns/ai-evals/run-experiments-in-production?ref=blog-introducing-group-experiment) pattern to get started, and the [`group.experiment()` API reference](/docs/reference/typescript/v4/functions/group-experiment?ref=blog-introducing-group-experiment) for the full reference.

--- a/content/changelog/2026-06-23-experiments.mdx
+++ b/content/changelog/2026-06-23-experiments.mdx
@@ -12,4 +12,4 @@ Reach for them when you're rolling out a rewrite, migrating a vendor or database
 
 Experiments are available now in the Inngest TypeScript SDK (v4). Import `experiment` from `inngest` and call `group.experiment()` inside any function.
 
-See the [Running experiments guide](/docs/features/inngest-functions/steps-workflows/running-experiments?ref=changelog-experiments) for rollout patterns, and the [`group.experiment()` reference](/docs/reference/typescript/v4/functions/group-experiment?ref=changelog-experiments) for the full API.
+See the [Run experiments in production](/docs/patterns/ai-evals/run-experiments-in-production?ref=changelog-experiments) pattern for rollout patterns, and the [`group.experiment()` reference](/docs/reference/typescript/v4/functions/group-experiment?ref=changelog-experiments) for the full API.

--- a/pages/docs/features/inngest-functions/steps-workflows/deferred-scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/deferred-scoring.mdx
@@ -126,4 +126,4 @@ Inngest matches this event to any waiting scorer by the `ticketId` field. The sc
 ## Next steps
 
 - [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring) for inline scoring
-- [Run experiments](/docs/features/inngest-functions/steps-workflows/running-experiments) to compare variants using scores
+- [Run experiments](/docs/patterns/ai-evals/run-experiments-in-production) to compare variants using scores

--- a/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
@@ -101,4 +101,4 @@ Scores show up in two places:
 ## Next steps
 
 - [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring) for outcomes that take time to resolve
-- [Run experiments](/docs/features/inngest-functions/steps-workflows/running-experiments) to compare models or prompts with traffic splits
+- [Run experiments](/docs/patterns/ai-evals/run-experiments-in-production) to compare models or prompts with traffic splits

--- a/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
@@ -194,6 +194,6 @@ For AI model or prompt experiments, `withVariant: true` is often the simplest wa
 
 ## Related docs
 
-- [Run experiments in AI pipelines](/docs/features/inngest-functions/steps-workflows/running-experiments?ref=docs-step-experiments)
+- [Run experiments in production](/docs/patterns/ai-evals/run-experiments-in-production?ref=docs-step-experiments)
 - [`group.experiment()` reference](/docs/reference/typescript/v4/functions/group-experiment?ref=docs-step-experiments)
 - [Function versioning](/docs/learn/versioning?ref=docs-step-experiments)

--- a/pages/docs/reference/typescript/v4/functions/scoring.mdx
+++ b/pages/docs/reference/typescript/v4/functions/scoring.mdx
@@ -144,4 +144,4 @@ defer("score-feedback", {
 
 - [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring)
 - [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring)
-- [Run experiments](/docs/features/inngest-functions/steps-workflows/running-experiments)
+- [Run experiments](/docs/patterns/ai-evals/run-experiments-in-production)

--- a/shared/Patterns/_patterns/run-experiments-in-production.mdx
+++ b/shared/Patterns/_patterns/run-experiments-in-production.mdx
@@ -156,6 +156,5 @@ If the outcome is available during the run, pair the experiment with [scoring](/
 ## Related docs
 
 - [`group.experiment()` reference](/docs/reference/typescript/v4/functions/group-experiment?ref=docs-patterns-run-experiments-in-production)
-- [Run experiments in AI pipelines](/docs/features/inngest-functions/steps-workflows/running-experiments?ref=docs-patterns-run-experiments-in-production)
 - [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring?ref=docs-patterns-run-experiments-in-production)
 - [Function versioning](/docs/learn/versioning?ref=docs-patterns-run-experiments-in-production)


### PR DESCRIPTION
## Summary

PR #1685 ("rewrite running-experiments guide") removed the `running-experiments` how-to, but several inbound links still pointed at `/docs/features/inngest-functions/steps-workflows/running-experiments` — a now-deleted page. This repoints them to the pattern page and fixes link text that referenced the gone "AI pipelines" doc.

Destination: `/docs/patterns/ai-evals/run-experiments-in-production` (exists on `main` via #1719, with its redirect).

## Changes

Repointed (path swapped, `?ref` preserved):
- `pages/docs/features/inngest-functions/steps-workflows/scoring.mdx`
- `pages/docs/features/inngest-functions/steps-workflows/deferred-scoring.mdx`
- `pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx` — also reworded "Run experiments in AI pipelines" → "Run experiments in production"
- `pages/docs/reference/typescript/v4/functions/scoring.mdx`
- `content/changelog/2026-06-23-experiments.mdx` — reworded "Running experiments guide" → "Run experiments in production" pattern
- `content/blog/introducing-group-experiment.mdx` — reworded "Step Experiments docs" → "Run experiments in production" pattern

Special cases (per handoff):
- **Pattern page** (`shared/Patterns/_patterns/run-experiments-in-production.mdx`): removed the related-docs line rather than repoint it (would have self-linked). Other related links kept.
- **Nav entry** (item 6): moot — #1685 already removed the "Run experiments in AI pipelines" nav entry, so nothing to repoint.

## Validation

- `pnpm build` ✅
- Targeted `prettier --check` on all touched files ✅
- `git diff --check` ✅
- `grep` confirms zero remaining links to the deleted `running-experiments` page and no self-link on the pattern page.

## Open question for Ben

The old URL `/docs/features/inngest-functions/steps-workflows/running-experiments` is **not redirected** anywhere — #1685 deleted the page without a redirect, so that URL currently 404s for any external/bookmarked links. Worth adding a redirect (to the pattern, or wherever #1685 intended the content to live). Out of scope here, but flagging. Happy to add it to this PR if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)