### PR TITLE
fix(contact-form): pass lead_source, submitted_company_name, and firstTouch to Segment

### DIFF
--- a/utils/v1/contactSubmit.ts
+++ b/utils/v1/contactSubmit.ts
@@ -1,4 +1,5 @@
 import { analytics } from "@/utils/segment";
+import { readFirstTouch } from "src/shared/firstTouch";
 
 export const CONTACT_EVENT_NAME = "contact.form.sent";
 export const CONTACT_EVENT_VERSION = "2023-12-12.1";
@@ -131,8 +132,14 @@ export async function submitContactForm(
     console.warn("[contactSubmit] Inngest event failed", err);
   }
 
+  const firstTouch = readFirstTouch();
+
   try {
-    analytics.track("Form Submitted", {
+    const isSalesLead = formType === FORM_TYPE.SALES_LEAD_FORM;
+    const segmentEventName = isSalesLead
+      ? "Contact Sales Form Submitted"
+      : "Form Submitted";
+    analytics.track(segmentEventName, {
       email,
       name,
       form_type: formType,
@@ -140,10 +147,18 @@ export async function submitContactForm(
       what_can_we_help_you_with: message,
       form_source: "website",
       ref,
+      // Sales-lead-specific fields for Attio / CIO destination mappings.
+      ...(isSalesLead
+        ? {
+            lead_source: "contact_form",
+            submitted_company_name: company,
+          }
+        : {}),
+      ...(firstTouch || {}),
     });
     const gtmName = GTM_EVENT_NAMES[formType];
     if (gtmName && typeof window !== "undefined") {
-      window.dataLayer?.push({ event: gtmName, ref, survey });
+      window.dataLayer?.push({ event: gtmName, ref, survey, ...(firstTouch || {}) });
     }
   } catch (err) {
     console.warn("[contactSubmit] analytics failed", err);


### PR DESCRIPTION
## Problem

The `/contact` page was redesigned to use `SalesForm` → `submitContactForm` (`utils/v1/contactSubmit.ts`), but that utility was missing several sales-lead-specific attributes that the original `ContactForm.tsx` was sending to Segment/Attio/CIO.

## Changes

- **Wrong event name**: `"Form Submitted"` → `"Contact Sales Form Submitted"` for sales leads
- **Missing `lead_source: "contact_form"`**: required for Attio/CIO destination mappings
- **`submitted_company_name`**: `company` was being sent under the wrong key
- **First-touch attribution**: `readFirstTouch()` was never called, dropping cookie-stored UTM data from Segment and GTM payloads→→