### PR TITLE
docs(experiments): clarify group.experiment() counts as a single step

### DIFF
--- a/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
@@ -65,6 +65,8 @@ Only the selected variant runs. The other variant callbacks are skipped.
 
 The experiment selection is itself a durable, memoized step. When a function run reaches `group.experiment()` for the first time, Inngest evaluates the `select` strategy and stores the selected variant. If the run retries or replays later, it uses the same selected variant again.
 
+Because the selection is a single step, each `group.experiment()` counts as one step toward your function run and billing metrics. Any steps you run inside the selected variant are metered separately, like any other step.
+
 Variant callbacks can contain normal step tools, including `step.run()`, `step.invoke()`, `step.waitForEvent()`, and `step.sendEvent()`. Each step inside the selected variant is retried and memoized like any other step.
 
 <Callout>


### PR DESCRIPTION
## Summary

Per Tony (Slack): a clarification was dropped from the Step Experiments Notion notes —

> Each group.experiment counts towards a single step in your function run and billing metrics.

This restores it in the **Step experiments** doc, in the "How selection works" section (which already describes the selection as a durable, memoized step). Wording is consistent with the existing reference (`group-experiment.mdx`), which calls the selection "memoized as a durable step."

## Change

`pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx` — added:

> Because the selection is a single step, each `group.experiment()` counts as one step toward your function run and billing metrics. Any steps you run inside the selected variant are metered separately, like any other step.

## Validation

- `git diff --check` ✅
- `prettier --check` on the file ✅
- `pnpm test:docs-markdown` ✅ (12/12)

## Note

Scoped to the canonical Step Experiments doc. Happy to mirror the line into the `group.experiment()` reference too if you want it stated in both places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)