### PR TITLE
OTel fixes

### DIFF
--- a/pages/docs/examples/open-telemetry.mdx
+++ b/pages/docs/examples/open-telemetry.mdx
@@ -11,7 +11,7 @@ OpenTelemetry lets Inngest connect what happens inside a function run to the lib
 
 Inngest uses OpenTelemetry for two separate features:
 
-- **AI metadata extraction:** Extract AI metadata from OpenTelemetry spans instrumented with Open Inference and attach it to the step where the model call happened. This is enabled by default with `aiMetadata: true`.
+- **AI metadata extraction:** Extract AI metadata from OpenTelemetry spans with OpenTelemetry GenAI attributes and attach it to the step where the model call happened. This is enabled by default with `aiMetadata: true`.
 - **Extended Traces:** Export spans from inside your function run into [Inngest Traces](/docs/platform/monitor/traces#extended-traces), so database queries, HTTP calls, AI requests, and custom spans appear in the run timeline.
 
 This guide first shows how to set up OpenTelemetry in your process. After that, it shows how to use that setup for AI metadata extraction and Extended Traces.
@@ -22,7 +22,7 @@ Use [`@inngest/otel`](https://www.npmjs.com/package/@inngest/otel) if you want I
 
 ### Automatic setup with `@inngest/otel`
 
-If your application does not already configure OpenTelemetry, use [`@inngest/otel`](https://www.npmjs.com/package/@inngest/otel) to install the Node.js provider and common instrumentations.
+If your application does not already configure OpenTelemetry, install and use [`@inngest/otel`](https://www.npmjs.com/package/@inngest/otel) to setup a Node.js provider and common instrumentations.
 
 Preload it before your application:
 

--- a/pages/docs/examples/open-telemetry.mdx
+++ b/pages/docs/examples/open-telemetry.mdx
@@ -22,7 +22,7 @@ Use [`@inngest/otel`](https://www.npmjs.com/package/@inngest/otel) if you want I
 
 ### Automatic setup with `@inngest/otel`
 
-If your application does not already configure OpenTelemetry, install and use [`@inngest/otel`](https://www.npmjs.com/package/@inngest/otel) to setup a Node.js provider and common instrumentations.
+If your application does not already configure OpenTelemetry, install and use [`@inngest/otel`](https://www.npmjs.com/package/@inngest/otel) to set up a Node.js provider and common instrumentations.
 
 Preload it before your application:
 

--- a/pages/docs/reference/typescript/v3/extended-traces.mdx
+++ b/pages/docs/reference/typescript/v3/extended-traces.mdx
@@ -18,7 +18,7 @@ If you want Inngest to set up OpenTelemetry for you, use [`@inngest/otel`](https
 
 ## Basic Usage
 
-Use this path when your application does not already configure OpenTelemetry. Install and use `@inngest/otel` to setup a Node.js OpenTelemetry provider and common instrumentations before your application code starts, and `extendedTracesMiddleware()` attaches to that provider.
+Use this path when your application does not already configure OpenTelemetry. Install and use `@inngest/otel` to set up a Node.js OpenTelemetry provider and common instrumentations before your application code starts, and `extendedTracesMiddleware()` attaches to that provider.
 
 Preload it before your application:
 

--- a/pages/docs/reference/typescript/v3/extended-traces.mdx
+++ b/pages/docs/reference/typescript/v3/extended-traces.mdx
@@ -18,7 +18,7 @@ If you want Inngest to set up OpenTelemetry for you, use [`@inngest/otel`](https
 
 ## Basic Usage
 
-Use this path when your application does not already configure OpenTelemetry. `@inngest/otel` installs a Node.js OpenTelemetry provider and common instrumentations before your application code starts, and `extendedTracesMiddleware()` attaches to that provider.
+Use this path when your application does not already configure OpenTelemetry. Install and use `@inngest/otel` to setup a Node.js OpenTelemetry provider and common instrumentations before your application code starts, and `extendedTracesMiddleware()` attaches to that provider.
 
 Preload it before your application:
 
@@ -165,7 +165,7 @@ provider.register();
 
 ## Instrumentation
 
-`@inngest/otel` automatically instruments common Node.js libraries when it is loaded before your application code. It registers the default instrumentations from [`@opentelemetry/auto-instrumentations-node`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node) and adds [Anthropic instrumentation](https://www.npmjs.com/package/@traceloop/instrumentation-anthropic).
+`@inngest/otel` automatically instruments common Node.js libraries when it is loaded before your application code. It instruments common Node packages, OpenAI, Anthropic, and Google Generative AI.
 
 If you configure OpenTelemetry yourself, continue to manage your own instrumentation list. Check the `@opentelemetry/auto-instrumentations-node` docs for the current supported instrumentation list and default-disabled entries.
 

--- a/pages/docs/reference/typescript/v4/client/create.mdx
+++ b/pages/docs/reference/typescript/v4/client/create.mdx
@@ -72,7 +72,7 @@ const inngest = new Inngest({
     A stack of [middleware](/docs/features/middleware) to add to the client.
   </Property>
   <Property name="aiMetadata" type="boolean">
-    Automatically extract AI metadata from OpenTelemetry spans instrumented with Open Inference in step runs. Metadata is attached to its step. Defaults to `true`.
+    Automatically extract AI metadata from OpenTelemetry spans with OpenTelemetry GenAI attributes. Metadata is attached to its step. Defaults to `true`.
 
     Set this to `false` to opt out of the SDK's built-in AI metadata extraction. This does not affect [Extended Traces](/docs/reference/typescript/v4/extended-traces).
   </Property>

--- a/pages/docs/reference/typescript/v4/extended-traces.mdx
+++ b/pages/docs/reference/typescript/v4/extended-traces.mdx
@@ -15,7 +15,7 @@ If you want Inngest to set up OpenTelemetry for you, use [`@inngest/otel`](https
 
 ## Basic Usage
 
-Use this path when your application does not already configure OpenTelemetry. Install and use `@inngest/otel` to setup a Node.js OpenTelemetry provider and common instrumentations before your application code starts, and `extendedTracesMiddleware()` attaches to that provider.
+Use this path when your application does not already configure OpenTelemetry. Install and use `@inngest/otel` to set up a Node.js OpenTelemetry provider and common instrumentations before your application code starts, and `extendedTracesMiddleware()` attaches to that provider.
 
 Preload it before your application:
 

--- a/pages/docs/reference/typescript/v4/extended-traces.mdx
+++ b/pages/docs/reference/typescript/v4/extended-traces.mdx
@@ -15,7 +15,7 @@ If you want Inngest to set up OpenTelemetry for you, use [`@inngest/otel`](https
 
 ## Basic Usage
 
-Use this path when your application does not already configure OpenTelemetry. `@inngest/otel` installs a Node.js OpenTelemetry provider and common instrumentations before your application code starts, and `extendedTracesMiddleware()` attaches to that provider.
+Use this path when your application does not already configure OpenTelemetry. Install and use `@inngest/otel` to setup a Node.js OpenTelemetry provider and common instrumentations before your application code starts, and `extendedTracesMiddleware()` attaches to that provider.
 
 Preload it before your application:
 
@@ -166,7 +166,7 @@ provider.register();
 
 ## Instrumentation
 
-`@inngest/otel` automatically instruments common Node.js libraries when it is loaded before your application code. It registers the default instrumentations from [`@opentelemetry/auto-instrumentations-node`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node) and adds [Anthropic instrumentation](https://www.npmjs.com/package/@traceloop/instrumentation-anthropic).
+`@inngest/otel` automatically instruments common Node.js libraries when it is loaded before your application code. It instruments common Node packages, OpenAI, Anthropic, and Google Generative AI.
 
 If you configure OpenTelemetry yourself, continue to manage your own instrumentation list. Check the `@opentelemetry/auto-instrumentations-node` docs for the current supported instrumentation list and default-disabled entries. See the [OpenTelemetry setup guide](/docs/examples/open-telemetry) for general setup, AI metadata extraction, and CommonJS and ESM preload examples.
 


### PR DESCRIPTION
- Replace OpenInference with OpenTelemetry GenAI.
- Mention installing `@inngest/otel`.
- List instrumentations in `@inngest/otel`.