### PR TITLE
Homepage: tabbed durability section + hero/copy updates

### DIFF
--- a/components/v1/pages/Home.tsx
+++ b/components/v1/pages/Home.tsx
@@ -1,13 +1,12 @@
 import PageShell from "@/components/v1/PageShell";
 import Customers from "@/components/v1/sections/Home/Customers";
-import FeatureCards from "@/components/v1/sections/Home/FeatureCards";
+import DurabilityInCode from "@/components/v1/sections/Home/DurabilityInCode";
 import Hero from "@/components/v1/sections/Home/Hero";
 import HowItWorks from "@/components/v1/sections/Home/HowItWorks";
 import ItDoesntHaveToBeHard from "@/components/v1/sections/Home/ItDoesntHaveToBeHard";
 import LogoMarquee from "@/components/v1/sections/Home/LogoMarquee";
 import LogoStrip from "@/components/v1/sections/Home/LogoStrip";
 import Quote from "@/components/v1/sections/Home/Quote";
-import ScaleInstantly from "@/components/v1/sections/Home/ScaleInstantly";
 import StartBuilding from "@/components/v1/sections/Home/StartBuilding";
 import TrustedInBigLeagues from "@/components/v1/sections/Home/TrustedInBigLeagues";
 
@@ -36,8 +35,7 @@ export default function Home() {
       <Hero />
       <LogoStrip contained />
       <Quote />
-      <FeatureCards />
-      <ScaleInstantly />
+      <DurabilityInCode />
       <Customers />
       <ItDoesntHaveToBeHard />
       <HowItWorks />

--- a/components/v1/sections/Home/DurabilityInCode.tsx
+++ b/components/v1/sections/Home/DurabilityInCode.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState } from "react";
+import ScaleInstantly from "./ScaleInstantly";
+import {
+  type DurabilityTabId,
+  DEFAULT_DURABILITY_TAB,
+} from "./durabilityTabs";
+
+/**
+ * Owns the shared selection for the "Durability belongs in code" section.
+ * The three feature cards render as a tablist inside ScaleInstantly's
+ * container, directly above the content they drive; selecting a card
+ * swaps the panel's intro copy, dashboard video, and capability tiles.
+ * "Retries & Reliability" is selected on load.
+ */
+export default function DurabilityInCode() {
+  const [activeTab, setActiveTab] =
+    useState<DurabilityTabId>(DEFAULT_DURABILITY_TAB);
+
+  return <ScaleInstantly activeTab={activeTab} onSelect={setActiveTab} />;
+}

--- a/components/v1/sections/Home/FeatureCards.tsx
+++ b/components/v1/sections/Home/FeatureCards.tsx
@@ -5,11 +5,23 @@ import Link from "next/link";
 import { onCursorSpotlightMove, CURSOR_SPOTLIGHT_SEED } from "@/utils/v1/cursorFx";
 import { animate, motion, useMotionValue, useTransform } from "motion/react";
 import { springs } from "@/utils/v1/springs";
+import {
+  type DurabilityTabId,
+  DURABILITY_PANEL_ID,
+  durabilityTabButtonId,
+} from "./durabilityTabs";
 
 /**
  * Three feature cards. Inactive cards sit on the dark elevated surface
  * with a frost/60 border; hover swaps in the salmon gradient + soft-
  * light noise overlay and grows the visible card vertically.
+ *
+ * On the home page these cards act as a TABLIST: clicking one selects it
+ * (persistent salmon flood via `data-active`) and drives the content in
+ * the "Durability belongs in code" panel below (see ScaleInstantly).
+ * Hovering a non-selected card previews the flood; on leave the grid
+ * settles back onto the selected card. Selection is controlled by the
+ * parent (DurabilityInCode) via `activeTab` / `onSelect`.
  *
  * Layout: flush stack at every breakpoint (vertical below sm,
  * horizontal 3-col at sm+). Cards share their seam border so the
@@ -25,20 +37,23 @@ import { springs } from "@/utils/v1/springs";
  */
 
 export interface FeatureCard {
+  /** Stable identity — also the tab id when the grid is in select mode. */
+  id: DurabilityTabId;
   label: string;
   vector: string;
   vectorWidth: number;
   vectorHeight: number;
-  /** Optional URL — when set the entire card becomes a clickable link. */
+  /** Optional URL — when set (and the grid is NOT in select mode) the
+   *  entire card becomes a clickable link. */
   href?: string;
   /** Designer-locked breaks at lg+ (rendered as `block whitespace-nowrap`). */
   bodyLines: string[];
 }
 
-const CARDS: FeatureCard[] = [
+export const CARDS: FeatureCard[] = [
   {
+    id: "retries",
     label: "Retries & Reliability",
-    href: "/platform/durable-execution",
     vector: "/assets/v1/feature-cards/retries.svg",
     vectorWidth: 85,
     vectorHeight: 70.51, // viewBox 208.397 × 172.823
@@ -49,8 +64,8 @@ const CARDS: FeatureCard[] = [
     ],
   },
   {
+    id: "flow-control",
     label: "Flow Control",
-    href: "/platform/flow-control",
     vector: "/assets/v1/feature-cards/flow-control.svg",
     vectorWidth: 85,
     vectorHeight: 59.4, // viewBox 205.865 × 143.85
@@ -61,8 +76,8 @@ const CARDS: FeatureCard[] = [
     ],
   },
   {
-    label: "Observability",
-    href: "/platform/observability",
+    id: "observability",
+    label: "Agent Observability",
     vector: "/assets/v1/feature-cards/observability.svg",
     vectorWidth: 85,
     vectorHeight: 69.7, // viewBox 205.848 × 168.771
@@ -74,17 +89,15 @@ const CARDS: FeatureCard[] = [
   },
 ];
 
-// How many px the surface extends above and below the row when a
-// card is active. Driven by motion's imperative `animate()` writing
-// `--surface-extra-y` on the article; sibling overlays read the
-// gated `--surface-y` view so geometry stays 0 below lg.
-const SURFACE_EXTRA_Y_PX = 12;
+// Surface grow + lift are disabled for the tab bar — the boxes stay
+// flush in the panel (no expansion on hover/select), per design. Kept
+// the spring plumbing wired at 0 so the structure is easy to re-enable.
+const SURFACE_EXTRA_Y_PX = 0;
 
 // Hover-OUT release uses `springs.glide` — over-damped spring with
 // zero overshoot, so the card and icon settle cleanly without any
 // post-release jello wobble.
 const RELEASE_BOUNCE = springs.glide;
-const ICON_RELEASE = springs.glide;
 
 // `top` / `bottom` inline style for every overlay span that extends
 // with the surface. `--surface-y` is the gated view of
@@ -99,29 +112,42 @@ const followsExtraY: React.CSSProperties = {
 // active card finishes shrinking before the next one grows.
 const RETRACT_MS = 360;
 
-export default function FeatureCards() {
-  return (
-    <section
-      aria-label="Platform features"
-      className="relative z-10 isolate mx-auto flex w-full max-w-[1440px] flex-col items-center px-6 py-20 sm:px-8"
-    >
-      <FeatureCardsGrid cards={CARDS} />
-    </section>
-  );
-}
-
 /**
  * The card row + serialised hover hand-off, extracted from the default
- * section so it can be reused under a different heading/section (e.g.
- * CompareTemporal/WhyChoose) without inheriting this section's padding
- * or aria-label. Supply your own `cards`.
+ * section so it can be reused under a different heading/section without
+ * inheriting this section's padding or aria-label. Supply your own
+ * `cards`.
+ *
+ * Select mode (pass `onSelect`): the grid renders as a tablist, rests on
+ * the `selectedId` card when idle, and previews on hover — settling back
+ * onto the selected card on leave. Click commits a new selection.
  */
-export function FeatureCardsGrid({ cards }: { cards: FeatureCard[] }) {
+export function FeatureCardsGrid({
+  cards,
+  selectedId,
+  onSelect,
+}: {
+  cards: FeatureCard[];
+  selectedId?: DurabilityTabId;
+  onSelect?: (id: DurabilityTabId) => void;
+}) {
+  const selectMode = !!onSelect;
+  // The card the grid rests on when nothing is hovered. In select mode
+  // that's the selected tab; otherwise fully idle (home-page hover-only).
+  const idleId: string | null = selectMode ? (selectedId ?? null) : null;
+
   // Serialised hover hand-off: pendingId tracks intent, activeId is
   // what's on screen. Switching siblings retracts first then expands
   // after RETRACT_MS — beats the dual-spring fight on rapid sweeps.
-  const [pendingId, setPendingId] = useState<string | null>(null);
-  const [activeId, setActiveId] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(idleId);
+  const [activeId, setActiveId] = useState<string | null>(idleId);
+
+  // When the parent changes the selection, snap our idle target to it so
+  // a hover-out settles onto the newly selected card.
+  useEffect(() => {
+    if (selectMode) setPendingId(selectedId ?? null);
+  }, [selectMode, selectedId]);
+
   useEffect(() => {
     if (pendingId === activeId) return;
     if (activeId === null) {
@@ -135,18 +161,26 @@ export function FeatureCardsGrid({ cards }: { cards: FeatureCard[] }) {
   }, [pendingId, activeId]);
 
   return (
-    <div className="has-hover-dim grid w-full grid-cols-1 sm:grid-cols-3 sm:items-stretch sm:[width:round(down,100%,3px)]">
+    <div
+      role={selectMode ? "tablist" : undefined}
+      aria-label={selectMode ? "Durability capabilities" : undefined}
+      className="has-hover-dim grid w-full grid-cols-1 sm:grid-cols-3 sm:items-stretch sm:[width:round(down,100%,3px)]"
+    >
       {cards.map((card, idx) => (
         <Card
-          key={card.label}
+          key={card.id}
           card={card}
           isFirst={idx === 0}
           isLast={idx === cards.length - 1}
-          isActive={activeId === card.label}
-          onEnter={() => setPendingId(card.label)}
+          isActive={activeId === card.id}
+          selected={selectMode && selectedId === card.id}
+          onEnter={() => setPendingId(card.id)}
           onLeave={() =>
-            setPendingId((prev) => (prev === card.label ? null : prev))
+            setPendingId((prev) =>
+              selectMode ? idleId : prev === card.id ? null : prev
+            )
           }
+          onSelect={onSelect ? () => onSelect(card.id) : undefined}
         />
       ))}
     </div>
@@ -158,37 +192,34 @@ function Card({
   isFirst,
   isLast,
   isActive,
+  selected,
   onEnter,
   onLeave,
+  onSelect,
 }: {
   card: FeatureCard;
   isFirst: boolean;
   isLast: boolean;
   isActive: boolean;
+  selected: boolean;
   onEnter: () => void;
   onLeave: () => void;
+  onSelect?: () => void;
 }) {
-  // Shared-seam border collapse so card-to-card joins are one 1 px
-  // stroke, not two stacked. Mobile (vertical): non-last cards drop
-  // their BOTTOM border — the card below draws the seam as its own
-  // top border, which renders on top of its own bg. (Reversing this
-  // direction — having the card above draw it — lets the below card's
-  // bg cover the line at fractional pixel positions, a subpixel
-  // rendering hazard.) Sm+ (horizontal): non-first cards drop their
-  // left border, same idea rotated 90°.
-  const innerEdgeFlat = [
-    "rounded-none",
-    isLast ? "" : "border-b-0 sm:border-b",
-    isFirst ? "" : "sm:border-l-0",
-  ]
+  // Tabs sit FLUSH inside the panel, so the panel's own gradient ring
+  // already frames the bar's outer edges (top + sides) and its rounded
+  // corners. Each tab therefore draws only INTERIOR separators — never a
+  // full box — so nothing doubles the panel ring or fights its corner
+  // radius. Edges drawn: a bottom rule under the row on every card
+  // (the tab-bar/content divider, and the inter-tab rule when stacked
+  // below sm), plus a left rule on non-first cards at sm+ (the vertical
+  // separators between the three tabs).
+  const dividerEdges = ["border-b", isFirst ? "" : "sm:border-l"]
     .filter(Boolean)
     .join(" ");
-  // Overlay layers (salmon / noise / spotlight) inherit the corner-
-  // flattening but MUST NOT get the surface's `border-b` utility —
-  // without an explicit `border-color`, that utility falls back to
-  // `currentcolor` which inherits as near-white, producing a 1 px
-  // white line at the bottom of every hovered card. Strip the
-  // border-edge classes for these layers.
+  // Overlay layers (salmon / noise / spotlight) are square — the panel
+  // clips the bar's outer corners, so the overlays never need their own
+  // radius.
   const overlayEdgeFlat = "rounded-none";
 
   const ease = "ease-v1-in";
@@ -230,7 +261,7 @@ function Card({
   useEffect(() => {
     const controls = animate(
       liftY,
-      isActive ? -8 : 0,
+      0, // lift disabled — tab boxes stay flush (no -8px hover rise)
       isActive ? springs.lift : RELEASE_BOUNCE,
     );
     return () => controls.stop();
@@ -240,6 +271,10 @@ function Card({
   return (
     <motion.article
       data-feature-card
+      // Mirrors the hover state so the active/selected card floods salmon
+      // + noise without a cursor: overlays key off `group-data-[active=true]`.
+      // Spotlight stays hover-only (it tracks the cursor).
+      data-active={isActive ? "true" : undefined}
       tabIndex={-1}
       onPointerMove={onCursorSpotlightMove}
       onPointerEnter={onEnter}
@@ -271,23 +306,15 @@ function Card({
         isActive ? "z-20" : elevated ? "z-10" : ""
       }`}
     >
-      {/* Base surface — gray bg + frost border. Stays gray; the
-          salmon flood lives on a sibling overlay that cross-fades
-          via opacity instead of swapping a non-transitionable
-          `background-image`. Border + shadow ring transition on
-          hover, geometry (top/bottom) is driven by the JS spring
-          via `--surface-extra-y`. */}
+      {/* Base surface — same charcoal gradient fill as the panel below,
+          so an idle tab reads as the same material. Separation is just
+          thin interior dividers (`dividerEdges`); the panel's ring frames
+          the outer edges. Dividers fade to transparent on hover/select
+          where the salmon flood takes over. */}
       <span
         aria-hidden="true"
         data-card-surface
-        style={followsExtraY}
-        // `border-color` is intentionally NOT in the transition list —
-        // the surface span extends above/below the card on hover via
-        // `--surface-extra-y`, and a slowly-fading frost border on the
-        // extended top/bottom edges read as white strips floating in
-        // the gap above/below the card. Snap the border to transparent
-        // the moment hover engages.
-        className={`pointer-events-none absolute inset-0 -z-10 rounded border border-v1-frost/60 bg-v1-surfaceElevated motion-safe:transition-[background-color,box-shadow,border-radius] motion-safe:duration-[700ms] motion-safe:ease-v1-lift group-hover:!rounded group-hover:border-transparent group-hover:shadow-[var(--v1-shadow-card-hover)] group-focus-within:!rounded group-focus-within:border-transparent ${innerEdgeFlat}`}
+        className={`pointer-events-none absolute inset-0 -z-10 border-v1-frost/15 bg-v1-gradient-charcoal motion-safe:transition-colors motion-safe:duration-[400ms] group-hover:border-transparent group-focus-within:border-transparent group-data-[active=true]:border-transparent ${dividerEdges}`}
       />
 
       {/* Salmon gradient overlay — same geometry as the base surface,
@@ -297,7 +324,7 @@ function Card({
       <span
         aria-hidden="true"
         style={followsExtraY}
-        className={`pointer-events-none absolute inset-0 -z-10 rounded bg-v1-accent-salmon-gradient opacity-0 motion-safe:transition-[opacity,border-radius] motion-safe:duration-[600ms] motion-safe:ease-v1-lift group-hover:!rounded group-hover:opacity-100 group-focus-within:!rounded group-focus-within:opacity-100 ${overlayEdgeFlat}`}
+        className={`pointer-events-none absolute inset-0 -z-10 bg-v1-accent-salmon-gradient opacity-0 motion-safe:transition-opacity motion-safe:duration-[600ms] motion-safe:ease-v1-lift group-hover:opacity-100 group-focus-within:opacity-100 group-data-[active=true]:opacity-100 ${overlayEdgeFlat}`}
       />
 
       {/* Soft-light noise — only visible on hover, blended over the
@@ -311,7 +338,7 @@ function Card({
             "url(/assets/v1/textures/.compressed/noise-dark.webp)",
           mixBlendMode: "soft-light",
         }}
-        className={`pointer-events-none absolute inset-0 -z-10 bg-cover bg-center opacity-0 motion-safe:transition-[opacity,border-radius] ${dur} ${ease} group-hover:!rounded group-hover:opacity-100 group-focus-within:!rounded group-focus-within:opacity-100 ${overlayEdgeFlat}`}
+        className={`pointer-events-none absolute inset-0 -z-10 bg-cover bg-center opacity-0 motion-safe:transition-opacity ${dur} ${ease} group-hover:opacity-100 group-focus-within:opacity-100 group-data-[active=true]:opacity-100 ${overlayEdgeFlat}`}
       />
 
       {/* Cursor-tracked spotlight — radial gradient anchored to the
@@ -324,7 +351,7 @@ function Card({
           background:
             "radial-gradient(360px circle at var(--mx) var(--my), rgba(255, 210, 195, 0.32), transparent 65%)",
         }}
-        className={`pointer-events-none absolute inset-0 -z-10 opacity-0 motion-safe:transition-[opacity,border-radius] motion-safe:duration-[500ms] ${ease} group-hover:!rounded group-hover:opacity-100 group-focus-within:!rounded group-focus-within:opacity-100 ${overlayEdgeFlat}`}
+        className={`pointer-events-none absolute inset-0 -z-10 opacity-0 motion-safe:transition-opacity motion-safe:duration-[500ms] ${ease} group-hover:opacity-100 group-focus-within:opacity-100 ${overlayEdgeFlat}`}
       />
 
       {/* Icon sits in a fixed-height container (matches the tallest
@@ -355,7 +382,7 @@ function Card({
               width: `clamp(60px, 7vw, ${card.vectorWidth}px)`,
               height: "auto",
             }}
-            className={`block opacity-55 motion-safe:transition-opacity ${dur} ${ease} group-hover:opacity-100 group-focus-within:opacity-100`}
+            className={`block opacity-55 motion-safe:transition-opacity ${dur} ${ease} group-hover:opacity-100 group-focus-within:opacity-100 group-data-[active=true]:opacity-100`}
           />
         </div>
         <h3 className="text-balance text-v1-frost text-v1-heading-xs lg:text-v1-heading-card">
@@ -371,7 +398,7 @@ function Card({
           (1024) up to 18px at xl+, so the longest locked line
           ("Automatic traces, metrics, and logs from every part")
           fits its column at every lg+ width. */}
-      <p className="w-full text-pretty text-v1-frost text-v1-body-md leading-[1.5] motion-safe:transition-colors group-hover:!text-white group-focus-within:!text-white lg:text-[clamp(0.8125rem,1.25vw,1.125rem)]">
+      <p className="w-full text-pretty text-v1-frost text-v1-body-md leading-[1.5] motion-safe:transition-colors group-hover:!text-white group-focus-within:!text-white group-data-[active=true]:!text-white lg:text-[clamp(0.8125rem,1.25vw,1.125rem)]">
         {card.bodyLines.map((line, i) => (
           <span key={i} className="lg:block lg:whitespace-nowrap">
             {line}
@@ -380,16 +407,28 @@ function Card({
         ))}
       </p>
 
-      {/* Stretched link — covers the entire card surface so the whole
-          card is clickable. Pointer events pass through to the article
-          for spotlight + hover effects; only clicks are captured. */}
-      {card.href && (
+      {/* Stretched hit target covering the whole card. In select mode
+          it's a tab `<button>` that drives the panel below; otherwise a
+          link (when `href` is set). Pointer events pass through for the
+          spotlight + hover effects; only clicks/focus are captured. */}
+      {onSelect ? (
+        <button
+          type="button"
+          role="tab"
+          id={durabilityTabButtonId(card.id)}
+          aria-selected={selected}
+          aria-controls={DURABILITY_PANEL_ID}
+          aria-label={card.label}
+          onClick={onSelect}
+          className="absolute inset-0 z-10 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-v1-frost"
+        />
+      ) : card.href ? (
         <Link
           href={card.href}
           aria-label={card.label}
           className="absolute inset-0 z-10"
         />
-      )}
+      ) : null}
     </motion.article>
   );
 }

--- a/components/v1/sections/Home/Hero.tsx
+++ b/components/v1/sections/Home/Hero.tsx
@@ -41,12 +41,12 @@ const HERO_CODE = [
   "      },",
   "    );|",
   "",
-  "■ step.invoke()",
+  "■ step.score()",
   "",
-  '    const result = await step.invoke("call-another-fn", {',
-  "      function: otherFunction,",
-  "      data: { userId: event.data.userId },",
-  "    });|",
+  '    await inngest.score({ name: "model-confidence",',
+  "      value: confidence });",
+  "",
+  "    return result;|",
 ].join("\n");
 
 export default function Hero() {

--- a/components/v1/sections/Home/HeroCodeCanvas.tsx
+++ b/components/v1/sections/Home/HeroCodeCanvas.tsx
@@ -11,7 +11,7 @@ import { HeroCodeScene } from "@/lib/animations/scenes/HeroCodeScene";
  * features layered on via its own options/methods —
  *
  *   1. `loop: false` — the reel plays through every function ONCE
- *      during the intro then freezes on the last one (step.invoke),
+ *      during the intro then freezes on the last one (step.score),
  *      handing control to the user instead of cycling forever.
  *   2. Clickable titles — an invisible <button> overlay per title row
  *      (polled from `getTitleBounds()`); clicking jumps the reel to

--- a/components/v1/sections/Home/HowItWorks.tsx
+++ b/components/v1/sections/Home/HowItWorks.tsx
@@ -22,8 +22,8 @@ interface Step {
 const STEPS: Step[] = [
   {
     number: "01",
-    title: "Start locally",
-    body: "Start locally in one command. Install the SDK, define a function, and deploy alongside your existing app.",
+    title: "Install the SDK",
+    body: "Write functions that know when to run, wait, fan-out, and throttle—during any event, at any scale.",
     iconSrc: "/assets/v1/how-it-works/icon-1.svg",
     iconWidth: 192,
     iconHeight: 232,
@@ -31,8 +31,8 @@ const STEPS: Step[] = [
   },
   {
     number: "02",
-    title: "Run anywhere",
-    body: "Deploy to your favorite cloud provider — serverless platforms, traditional servers, or anywhere else. If your app runs there, your Inngest functions can too.",
+    title: "Deploy alongside your app",
+    body: "Deploy within your existing app, on your favorite cloud provider—serverless, traditional, or anywhere.",
     iconSrc: "/assets/v1/how-it-works/icon-2.svg",
     iconWidth: 338,
     iconHeight: 136,
@@ -40,8 +40,8 @@ const STEPS: Step[] = [
   },
   {
     number: "03",
-    title: "Ship unbreakable code",
-    body: "Write functions that know when to run, wait, fan-out, and throttle during any event, at any scale, anywhere.",
+    title: "Observe and optimize",
+    body: "The data that makes code durable is the same used to make it better. Fix fast, and continuously improve.",
     iconSrc: "/assets/v1/how-it-works/icon-3.svg",
     iconWidth: 220,
     iconHeight: 247,

--- a/components/v1/sections/Home/Quote.tsx
+++ b/components/v1/sections/Home/Quote.tsx
@@ -28,11 +28,12 @@ const InngestLogoCanvas = dynamic(
 // narrow viewports don't blow out the rail. Joined with spaces they
 // form the full quote.
 const LINES = [
-  "How you build apps and agents will",
-  "change. How they run shouldn't.",
-  "Inngest moves durability out of",
+  "How you build agents will change.",
+  "How they run shouldn't.",
+  "Inngest moves durability and",
+  "observability out of separate",
   "infrastructure and into your",
-  "codebase, so what you build today",
+  "codebase, so what you write today",
   "still runs tomorrow."
 ] as const;
 const QUOTE = LINES.join(" ");

--- a/components/v1/sections/Home/ScaleInstantly.tsx
+++ b/components/v1/sections/Home/ScaleInstantly.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { motion } from "motion/react";
 import Link from "next/link";
 import { reveals } from "@/utils/v1/reveals";
@@ -8,6 +7,13 @@ import { BlackReveal } from "@/components/v1/sections/shared/BlackReveal";
 import GradientFrame from "@/components/v1/sections/shared/GradientFrame";
 import Section from "@/components/v1/sections/shared/Section";
 import { V1_SECTION_TITLE } from "@/components/v1/sections/shared/sectionTitle";
+import { CARDS, FeatureCardsGrid } from "./FeatureCards";
+import {
+  type DurabilityTabId,
+  DEFAULT_DURABILITY_TAB,
+  DURABILITY_PANEL_ID,
+  durabilityTabButtonId,
+} from "./durabilityTabs";
 
 interface Capability {
   title: string;
@@ -19,137 +25,276 @@ interface Capability {
   href?: string;
 }
 
-const CAPABILITIES: Capability[] = [
-  {
-    title: "AI Agents",
-    body: "Pause mid-execution, wait for input, then resume exactly where you left off.",
-    icon: "/assets/v1/scale-instantly/ai-agents.svg",
-    iconWidth: 27.77,
-    iconHeight: 32,
-    href: "/ai",
-  },
-  {
-    title: "API Endpoints",
-    body: "Long-running endpoints that survive timeouts, failures, and deploys.",
-    icon: "/assets/v1/scale-instantly/api-endpoints.svg",
-    iconWidth: 30.02,
-    iconHeight: 25.71,
-    href: "/docs/learn/durable-endpoints",
-  },
-  {
-    title: "Workflows",
-    body: "Each step retries independently. No failed run restarts from scratch.",
-    icon: "/assets/v1/scale-instantly/workflows.svg",
-    iconWidth: 32,
-    iconHeight: 32,
-    href: "/ai",
-  },
-  {
-    title: "Schedules",
-    body: "Missed runs recover automatically. Every execution is logged and replayable.",
-    icon: "/assets/v1/scale-instantly/schedules.svg",
-    iconWidth: 32,
-    iconHeight: 12.85,
-    href: "/uses/scheduled-jobs",
-  },
-  {
-    title: "Serverless",
-    body: "Functions persist state across invocations without a database.",
-    icon: "/assets/v1/scale-instantly/serverless.svg",
-    iconWidth: 32,
-    iconHeight: 20.52,
-    href: "/docs/reference/typescript/v4/extended-traces#serverless",
-  },
-  {
-    title: "Events",
-    body: "Fan out thousands of jobs per event. Every one tracked, retriable, and replayable.",
-    icon: "/assets/v1/scale-instantly/events.svg",
-    iconWidth: 21.65,
-    iconHeight: 32,
-    href: "/uses/webhooks",
-  },
-];
+interface TabContent {
+  /** Lead-in sentence (large frost heading-style paragraph). */
+  intro: string;
+  /** Supporting paragraphs (each rendered as its own block). */
+  body: string[];
+  /** Dashboard video shown to the right of the intro copy. */
+  videoSrc: string;
+  /** The six capability tiles below the header. */
+  capabilities: Capability[];
+}
 
-export default function ScaleInstantly() {
+// ── Retries & Reliability ──────────────────────────────────────────────
+// Real content (the original "Durability belongs in code" copy).
+const RETRIES_CONTENT: TabContent = {
+  intro: "Inngest collapses event-driven complexity into APIs in your codebase.",
+  body: [
+    "Because durability lives in code—not tied to any specific infrastructure pattern—the same primitives that power your background jobs also power agents and apps. And because Inngest handles execution, you get full observability by default.",
+    "No new infrastructure. No new instrumentation. No new architecture when there’s a new ‘right way’ to build in 6 weeks’ time.",
+  ],
+  videoSrc:
+    "https://cdn.inngest.com/homepage/june-2026-redesign-dashboard-tour-v2.mp4",
+  capabilities: [
+    {
+      title: "AI Agents",
+      body: "Pause mid-execution, wait for input, then resume exactly where you left off.",
+      icon: "/assets/v1/scale-instantly/ai-agents.svg",
+      iconWidth: 27.77,
+      iconHeight: 32,
+      href: "/ai",
+    },
+    {
+      title: "API Endpoints",
+      body: "Long-running endpoints that survive timeouts, failures, and deploys.",
+      icon: "/assets/v1/scale-instantly/api-endpoints.svg",
+      iconWidth: 30.02,
+      iconHeight: 25.71,
+      href: "/docs/learn/durable-endpoints",
+    },
+    {
+      title: "Workflows",
+      body: "Each step retries independently. No failed run restarts from scratch.",
+      icon: "/assets/v1/scale-instantly/workflows.svg",
+      iconWidth: 32,
+      iconHeight: 32,
+      href: "/ai",
+    },
+    {
+      title: "Schedules",
+      body: "Missed runs recover automatically. Every execution is logged and replayable.",
+      icon: "/assets/v1/scale-instantly/schedules.svg",
+      iconWidth: 32,
+      iconHeight: 12.85,
+      href: "/uses/scheduled-jobs",
+    },
+    {
+      title: "Serverless",
+      body: "Functions persist state across invocations without a database.",
+      icon: "/assets/v1/scale-instantly/serverless.svg",
+      iconWidth: 32,
+      iconHeight: 20.52,
+      href: "/docs/reference/typescript/v4/extended-traces#serverless",
+    },
+    {
+      title: "Events",
+      body: "Fan out thousands of jobs per event. Every one tracked, retriable, and replayable.",
+      icon: "/assets/v1/scale-instantly/events.svg",
+      iconWidth: 21.65,
+      iconHeight: 32,
+      href: "/uses/webhooks",
+    },
+  ],
+};
+
+// Icons + video are still placeholders for the two non-retries tabs.
+// TODO(jb): supply per-tab icons (these reuse the Retries icons by index),
+// a per-tab dashboard video (these reuse the Retries video), and tile
+// hrefs (none set yet). `icon(i)` borrows the Retries tile icon at index i.
+const icon = (i: number) => {
+  const c = RETRIES_CONTENT.capabilities[i];
+  return { icon: c.icon, iconWidth: c.iconWidth, iconHeight: c.iconHeight };
+};
+
+// ── Flow Control ────────────────────────────────────────────────────────
+const FLOW_CONTROL_CONTENT: TabContent = {
+  intro: "The control layer queues are missing",
+  body: [
+    "Basic queues have no idea what to do when you’ve got multiple users competing for the same resource. Noisy neighbors, hand-rolled rate limits, priority queue sprawl, wasted compute… Inngest’s flow control features ensure every user gets their fair share, without extra work.",
+  ],
+  videoSrc: RETRIES_CONTENT.videoSrc,
+  capabilities: [
+    {
+      title: "Concurrency Control",
+      body: "Every tenant gets their fair share, no matter how much work one of them throws at your app.",
+      ...icon(0),
+    },
+    {
+      title: "Throttling & Rate Limiting",
+      body: "Absorb traffic spikes without dropping work—excess runs queue and drain at your rate.",
+      ...icon(1),
+    },
+    {
+      title: "Debouncing",
+      body: "Don’t burn compute on redundant work. Collapse bursts of identical events into one execution.",
+      ...icon(2),
+    },
+    {
+      title: "Dynamic Prioritization",
+      body: "Decide which work should take priority without starving the rest.",
+      ...icon(3),
+    },
+    {
+      title: "Batch Processing",
+      body: "Reduce invocation costs on high-volume workloads by ensuring whatever comes first triggers the run.",
+      ...icon(4),
+    },
+    {
+      title: "Declarative Cancellation",
+      body: "Cancel in-flight runs automatically if a matching event occurs.",
+      ...icon(5),
+    },
+  ],
+};
+
+// ── Agent Observability ─────────────────────────────────────────────────
+const OBSERVABILITY_CONTENT: TabContent = {
+  intro: "Judge on outcomes, not output",
+  body: [
+    "How do you know if your agent works? If you want to know which variant actually performed better, you used to have to stitch together data from multiple systems, implement human reviews, and build a layer of instrumentation on top. Inngest captures all of this data by default, so you can add scoring the same way you add retries.",
+  ],
+  videoSrc: RETRIES_CONTENT.videoSrc,
+  capabilities: [
+    {
+      title: "Scoring",
+      body: "One shot was never enough. We let you use real production outcomes to eval variants.",
+      ...icon(0),
+    },
+    {
+      title: "Live Experiments",
+      body: "Test what works against live production traffic, or in a sandbox.",
+      ...icon(1),
+    },
+    {
+      title: "100% not 1%",
+      body: "Track outcomes across every run, without needing to sample.",
+      ...icon(2),
+    },
+    {
+      title: "Datasets",
+      body: "Generate datasets of good and bad runs for evals and offline replay.",
+      ...icon(3),
+    },
+    {
+      title: "Sessions",
+      body: "Group multiple agent loops or turns as a single conversation, thread, or however you choose.",
+      ...icon(4),
+    },
+    // TODO(jb): the source listed “Scoring” twice — replace this sixth tile
+    // with the intended capability.
+    {
+      title: "[Needs copy]",
+      body: "[Placeholder] Sixth Agent Observability capability goes here.",
+      ...icon(5),
+    },
+  ],
+};
+
+const TAB_CONTENT: Record<DurabilityTabId, TabContent> = {
+  retries: RETRIES_CONTENT,
+  "flow-control": FLOW_CONTROL_CONTENT,
+  observability: OBSERVABILITY_CONTENT,
+};
+
+export default function ScaleInstantly({
+  activeTab = DEFAULT_DURABILITY_TAB,
+  onSelect,
+}: {
+  activeTab?: DurabilityTabId;
+  /** When provided, the three feature cards render inside this section as
+   *  a tablist driving the panel below. */
+  onSelect?: (id: DurabilityTabId) => void;
+}) {
+  const content = TAB_CONTENT[activeTab];
   return (
     <Section aria-label="Durability belongs in code" className="relative">
       <GradientFrame
         variant="charcoal"
         className="rounded-md"
-        innerClassName="relative flex flex-col gap-[29px] px-4 pb-[72px] pt-11 lg:gap-20 lg:px-11 lg:pt-16"
+        innerClassName="relative flex flex-col pb-[72px]"
       >
-        <Header />
-        <CapabilityGrid />
+        {/* Tabs — the three feature cards form a full-width bar flush to
+            the panel's top edge (no surrounding padding) so they read as
+            the panel's own tab strip. */}
+        <FeatureCardsGrid
+          cards={CARDS}
+          selectedId={activeTab}
+          onSelect={onSelect}
+        />
+
+        {/* Heading + content sit below the tab bar with the panel's
+            normal inset padding. role=tabpanel wires this content to the
+            tablist above; `key` replays the reveal animations on tab
+            change so the new copy fades in rather than swapping in place. */}
+        <div className="px-4 pt-11 lg:px-11 lg:pt-16">
+          <motion.h2 {...reveals.heading} className={V1_SECTION_TITLE}>
+            Durability belongs in code
+          </motion.h2>
+
+          <div
+            key={activeTab}
+            id={DURABILITY_PANEL_ID}
+            role="tabpanel"
+            aria-labelledby={durabilityTabButtonId(activeTab)}
+            className="mt-8 flex flex-col gap-[29px] lg:mt-12 lg:gap-20"
+          >
+            <Header content={content} />
+            <CapabilityGrid capabilities={content.capabilities} />
+          </div>
+        </div>
       </GradientFrame>
     </Section>
   );
 }
 
-function Header() {
+function Header({ content }: { content: TabContent }) {
   return (
-    <div className="flex flex-col gap-12">
-      <motion.h2 {...reveals.heading} className={V1_SECTION_TITLE}>
-        Durability belongs in code
-      </motion.h2>
-      <div
-        className="
-          grid grid-cols-1 gap-4
-          lg:grid-cols-[448fr_774fr] lg:items-start lg:gap-x-4 lg:gap-y-10
-        "
-      >
+    <div
+      className="
+        grid grid-cols-1 gap-4
+        lg:grid-cols-[448fr_774fr] lg:items-start lg:gap-x-4 lg:gap-y-10
+      "
+    >
         <div className="flex flex-col gap-6 lg:pr-8 lg:pt-11">
           <motion.p
             {...reveals.body}
             className="text-v1-heading-sm !text-[clamp(1.25rem,4vw,1.625rem)] !leading-[1.2] text-v1-frost"
           >
-            Inngest collapses event-driven complexity into APIs in your
-            codebase.
+            {content.intro}
           </motion.p>
           <motion.p
             {...reveals.body}
             className="text-v1-body-lg-loose !text-[clamp(1rem,3vw,1.125rem)] !leading-[1.45] text-v1-frost"
           >
-            <span className="block">
-              Because durability lives in code&mdash;not tied to any specific
-              infrastructure pattern&mdash;the same primitives that power your
-              background jobs also power agents and apps. And because Inngest
-              handles execution, you get full observability by default.
-            </span>
-            <span className="mt-[1.5em] block">
-              No new infrastructure. No new instrumentation. No new architecture
-              when there&rsquo;s a new &lsquo;right way&rsquo; to build in 6
-              weeks&rsquo; time.
-            </span>
+            {content.body.map((paragraph, i) => (
+              <span key={i} className={i === 0 ? "block" : "mt-[1.5em] block"}>
+                {paragraph}
+              </span>
+            ))}
           </motion.p>
         </div>
         <GradientFrame className="relative rounded-md" variant="charcoal">
           <BlackReveal block>
-            <DashboardVideo />
+            <DashboardVideo src={content.videoSrc} />
           </BlackReveal>
         </GradientFrame>
       </div>
-    </div>
   );
 }
 
-function DashboardVideo() {
+function DashboardVideo({ src }: { src: string }) {
   return (
     <div
       className="relative w-full overflow-hidden bg-v1-jetBlack"
       style={{ aspectRatio: "1980 / 1080" }}
     >
-      <video
-        controls
-        autoPlay
-        loop
-        muted
-        src="https://cdn.inngest.com/homepage/june-2026-redesign-dashboard-tour-v2.mp4"
-      />
+      <video controls autoPlay loop muted src={src} />
     </div>
   );
 }
 
-function CapabilityGrid() {
+function CapabilityGrid({ capabilities }: { capabilities: Capability[] }) {
   return (
     <ul
       className="
@@ -157,7 +302,7 @@ function CapabilityGrid() {
         lg:grid-cols-3 lg:gap-[58px]
       "
     >
-      {CAPABILITIES.map((c, i) => (
+      {capabilities.map((c, i) => (
         <CapabilityTile key={c.title} capability={c} index={i} />
       ))}
     </ul>

--- a/components/v1/sections/Home/TrustedInBigLeagues.tsx
+++ b/components/v1/sections/Home/TrustedInBigLeagues.tsx
@@ -13,7 +13,7 @@ import { appendRef } from "@/utils/v1/ref";
 import { useIsDesktop } from "@/utils/v1/hooks/useIsDesktop";
 
 /**
- * "Scale instantly, fix fast" + "Stuff your CISO needs to see"
+ * "Scale instantly, improve constantly" + "Stuff your CISO needs to see"
  * share one charcoal outer card.
  */
 
@@ -37,18 +37,18 @@ const TOPICS: Topic[] = [
     docsHref: "/docs/guides/flow-control",
   },
   {
-    id: "traces",
-    title: "Full traces and metrics",
-    body: "Replay failures in bulk for step-level insight into what went wrong. No spans required.",
-    visualization: <TraceWaterfall />,
-    docsHref: "/docs/platform/monitor/inspecting-function-runs",
-  },
-  {
     id: "troubleshoot",
     title: "Faster troubleshooting",
     body: "Store and track everything that happens in your product inside your own OLAP environment.",
     visualization: <SqlBlock />,
     docsHref: "/docs/platform/replay",
+  },
+  {
+    id: "traces",
+    title: "Traces, metrics, evals",
+    body: "Step-level insights and scores for every run and session.",
+    visualization: <TraceWaterfall />,
+    docsHref: "/docs/platform/monitor/inspecting-function-runs",
   },
 ];
 
@@ -113,7 +113,7 @@ export default function TrustedInBigLeagues() {
   return (
     <Section
       ref={sectionRef}
-      aria-label="Scale instantly, fix fast"
+      aria-label="Scale instantly, improve constantly"
       className="relative"
     >
       <GradientFrame
@@ -153,7 +153,7 @@ function TrustedBlock({
         {...reveals.heading}
         className={cn("text-balance", V1_SECTION_TITLE)}
       >
-        Scale instantly, fix fast
+        Scale instantly, improve constantly
       </motion.h2>
 
       <div className="flex flex-col gap-[28px] lg:pb-[19px]">

--- a/components/v1/sections/Home/durabilityTabs.ts
+++ b/components/v1/sections/Home/durabilityTabs.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared tab identity for the "Durability belongs in code" experience.
+ *
+ * The three feature cards (FeatureCards) act as a tablist that drives the
+ * content rendered in the ScaleInstantly panel below them. Both components
+ * key off these ids, so they live here to keep the two in sync.
+ */
+export const DURABILITY_TAB_IDS = [
+  "retries",
+  "flow-control",
+  "observability",
+] as const;
+
+export type DurabilityTabId = (typeof DURABILITY_TAB_IDS)[number];
+
+export const DEFAULT_DURABILITY_TAB: DurabilityTabId = "retries";
+
+/** DOM id of the tab button for a given tab — used to wire `aria-controls`
+ *  on the tabs and `aria-labelledby` on the panel. */
+export const durabilityTabButtonId = (id: DurabilityTabId) =>
+  `durability-tab-${id}`;
+
+/** DOM id of the single tabpanel (the ScaleInstantly section). */
+export const DURABILITY_PANEL_ID = "durability-panel";


### PR DESCRIPTION
## Summary

Homepage updates, stacked on `jb/ai-additions`.

### Hero
- Replace the `step.invoke()` bullet (and its code block) with `step.score()` in the hero reel animation.

### Copy
- **How it works** steps reworded: *Install the SDK* / *Deploy alongside your app* / *Observe and optimize*.
- Trust section: heading → **"Scale instantly, improve constantly"**; reordered the tabs and renamed the third to **"Traces, metrics, evals"** with new body copy.
- **Quote** section copy refreshed.

### "Durability belongs in code" → tabbed section
The three feature cards (Retries & Reliability, Flow Control, Agent Observability) now act as a **tablist** that drives the content of the panel below — intro copy, dashboard video, and the six capability tiles all swap per tab. "Retries & Reliability" is selected on load.

- Lifted shared `activeTab` state into a new `DurabilityInCode` wrapper; added a shared `durabilityTabs` module for tab ids + ARIA wiring (`role="tablist"`/`tab`/`tabpanel`).
- Unified into a **single container**: heading sits below a full-width, flush tab bar.
- Removed the cards' hover grow/lift; idle tabs share the panel's charcoal fill with thin interior dividers (panel ring frames the outer edges → no doubled stroke / corner artifacts). Selected/hovered tab gets the salmon flood.
- **Flow Control** and **Agent Observability** copy added (fixed a few source typos).

### Still placeholder (flagged with `TODO`s)
- Flow Control + Agent Observability **icons** (reusing Retries icons by index) and **dashboard video** (reusing Retries video).
- Capability **tile links** for the two new tabs.
- Agent Observability's **6th tile** — the source listed "Scoring" twice, so the 6th slot is a `[Needs copy]` placeholder pending the intended capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)