### PR TITLE
Fix posting dates for Node.js and Analogue blog cards

### DIFF
--- a/content/blog/analogue-customer-story.mdx
+++ b/content/blog/analogue-customer-story.mdx
@@ -4,7 +4,7 @@ heading: "Why Analogue Never Drops an Order, Even During Flash Sales"
 subtitle: "Analogue uses Inngest to power order fulfillment, multi-warehouse shipping, repairs, and analytics—keeping every async workflow reliable through flash sales."
 focus: false
 image: /assets/blog/analogue-customer-story/featured-image/featured-image.png
-date: "2026-06-24"
+date: "2026-06-25"
 category: engineering
 author: Lauren Craigie
 ---

--- a/content/blog/node-worker-threads-production.mdx
+++ b/content/blog/node-worker-threads-production.mdx
@@ -2,7 +2,7 @@
 heading: "Node.js worker threads in production"
 subtitle: "Spawning a worker is easy. Making it reliable means designing a protocol, packaging the worker file, proxying callbacks, handling crashes, and shutting down cleanly."
 showSubtitle: true
-date: 2026-06-25
+date: 2026-06-22
 author: Aaron Harper
 category: "engineering"
 image: /assets/blog/node-worker-threads-production/cover.png


### PR DESCRIPTION
## Summary
- Sets the Node.js worker threads in production post to **2026-06-22**
- Sets the Analogue customer story card to **2026-06-25**

## Test plan
- [ ] Visit `/blog` and confirm the Node.js post shows 06/22/2026
- [ ] Confirm the Analogue card shows 06/25/2026


Made with [Cursor](https://cursor.com)