### PR TITLE
Gate blog posts behind ?unreleased=<label>

### DIFF
--- a/.agents/skills/unreleased-content/SKILL.md
+++ b/.agents/skills/unreleased-content/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: unreleased-content
-description: Hide docs pages, doc sections, nav items, and changelog entries behind a `?unreleased=<label>` URL param until a feature ships. Use when staging unreleased documentation or changelog entries, previewing not-yet-public content, gating nav links, or working with the `<Unreleased>` component or `export const unreleased` exports in the website repo.
+description: Hide docs pages, doc sections, nav items, changelog entries, and blog posts behind a `?unreleased=<label>` URL param until a feature ships. Use when staging unreleased documentation, changelog entries, or blog posts, previewing not-yet-public content, gating nav links, or working with the `<Unreleased>` component or `unreleased` exports/frontmatter in the website repo.
 ---
 
 # Unreleased content gating
 
-Hide content on the docs site and changelog until a previewer opts in with a URL param. Nothing is hidden behind auth — it's a lightweight, crawler-safe preview gate for staging content before a feature launches.
+Hide content on the docs site, changelog, and blog until a previewer opts in with a URL param. Nothing is hidden behind auth — it's a lightweight, crawler-safe preview gate for staging content before a feature launches.
 
 ## How it works
 
@@ -16,7 +16,7 @@ Hide content on the docs site and changelog until a previewer opts in with a URL
 
 The engine is `website/shared/Docs/Unreleased.tsx`: a client hook `useUnreleasedLabels()` (returns the active `Set<string>`), the `<Unreleased label fallback>` component, and `filterUnreleasedNav()` for nav data.
 
-## The four ways to gate
+## The ways to gate
 
 ### 1. A whole docs page
 
@@ -63,6 +63,21 @@ export const unreleased = "score";
 
 The entry is hidden from the `/changelog` feed and excluded from the side menu; its own `/changelog/<slug>` page shows "Entry not found" and sends `noindex`. With a matching label it appears in the feed.
 
+### 5. A blog post
+
+Blog posts use **YAML frontmatter** (not `export const`), so add the field to the frontmatter block in `website/content/blog/<date>-<slug>.mdx`:
+
+```mdx
+---
+heading: "Introducing scoring"
+date: 2026-06-24
+category: product-updates
+unreleased: score
+---
+```
+
+A gated post is excluded server-side from the `/blog` index, related-post cards, the RSS feed, `blog.txt`, and the `.md` mirror (which 404s). Its `/blog/<slug>` page shows "Post not found" and sends `noindex`. With a matching label, the post page renders. (Unlike the changelog feed, the blog index does not reveal gated cards client-side — reach a gated post by its direct URL.)
+
 ## Releasing a feature
 
 Delete the gate — that's the entire "ship it" step:
@@ -81,5 +96,6 @@ Delete the gate — that's the entire "ship it" step:
 
 - **Docs are Pages Router; the changelog is App Router (RSC).** `<Unreleased>` is a `"use client"` component and works as a client island in both.
 - The component lives at `shared/Docs/Unreleased.tsx` even though the changelog uses it too (the path is historical — it's general-purpose).
-- Whole-page/whole-entry gating uses the **`export const unreleased` page export**, not the `<Unreleased>` wrapper. Use the wrapper only for a section *inside* an otherwise-public page.
+- Whole-page/whole-entry gating uses the **`export const unreleased` page export** (docs, changelog) or the **`unreleased:` YAML frontmatter field** (blog), not the `<Unreleased>` wrapper. Use the wrapper only for a section *inside* an otherwise-public page.
+- The blog has extra agent/SEO surfaces (index, related cards, RSS, `blog.txt`, `.md` mirror) that render server-side with no client param — gated posts are excluded from each of those server-side.
 - A label is any string; reuse the same label across a feature's page, sections, nav item, and changelog entry so one `?unreleased=<label>` reveals all of it.

--- a/.agents/skills/unreleased-content/SKILL.md
+++ b/.agents/skills/unreleased-content/SKILL.md
@@ -88,7 +88,7 @@ Delete the gate — that's the entire "ship it" step:
 ## SEO & performance
 
 - **No page-load impact.** Public pages are unchanged (no `unreleased` → no gating, no extra render). The only added code is a tiny client hook reading the URL + `sessionStorage` once.
-- Gated content is **not in the visible DOM** and gated pages/entries are **`noindex`**, so it stays out of search.
+- Gated content is **not in the visible DOM**, gated pages/entries are **`noindex`**, and they're **excluded from `sitemap.xml`** (a `transform` in `next-sitemap.config.js` drops any page whose source is `unreleased`) — so they stay fully out of search.
 - **Known residual:** the gated content's data still ends up in the page's serialized payload (`__NEXT_DATA__` for docs section titles; the RSC Flight `<script>` for a changelog entry body). It is not in the rendered DOM and not in Algolia's content index, but it is present in the HTML source. This is the cost of revealing server-rendered content client-side without a hard 404.
 - This is a **soft gate**: the URL still returns `200` (no middleware/404). Fine for "not yet public," not for secrets.
 

--- a/app/(llms)/blog-markdown/[slug]/route.ts
+++ b/app/(llms)/blog-markdown/[slug]/route.ts
@@ -11,10 +11,10 @@ export const generateStaticParams = async () => {
     .readdirSync(BLOG_DIR)
     .filter((f) => f.endsWith(".mdx") || f.endsWith(".md"))
     .filter((f) => {
-      // Skip posts that define a redirect
+      // Skip posts that define a redirect or are gated (unreleased)
       const source = fs.readFileSync(path.join(BLOG_DIR, f), "utf-8");
       const { data } = matter(source);
-      return !data.redirect;
+      return !data.redirect && !data.unreleased;
     });
 
   return files.map((f) => ({ slug: f.replace(/\.(mdx|md)$/, "") }));
@@ -62,6 +62,14 @@ export async function GET(
   try {
     const source = fs.readFileSync(filePath, "utf-8");
     const { content, data } = matter(source);
+
+    // Don't serve the markdown mirror for gated (unreleased) posts.
+    if (data.unreleased) {
+      return new Response("Post not found", {
+        status: 404,
+        statusText: "Post not found",
+      });
+    }
 
     // Build a clean YAML frontmatter block so agents get full metadata
     const authors = Array.isArray(data.author)

--- a/app/(llms)/blog.txt/route.ts
+++ b/app/(llms)/blog.txt/route.ts
@@ -29,7 +29,7 @@ function loadBlogIndex(): PostMeta[] {
     const { data } = matter(source);
 
     // Skip redirects and hidden posts
-    if (data.redirect || data.hide) continue;
+    if (data.redirect || data.hide || data.unreleased) continue;
 
     const slug = file.replace(/\.(mdx|md)$/, "");
 

--- a/app/(v1)/blog/[slug]/page.tsx
+++ b/app/(v1)/blog/[slug]/page.tsx
@@ -21,6 +21,7 @@ import StippleCtaSection from "@/components/v1/sections/shared/StippleCtaSection
 import ArticleBody from "./ArticleBody";
 import BlogToc, { type BlogTocItem } from "./BlogToc";
 import Prose from "@/components/v1/Prose";
+import { Unreleased } from "shared/Docs/Unreleased";
 
 const ARTICLE_BODY_ID = "blog-article-body";
 
@@ -70,6 +71,8 @@ type Scope = {
   floatingCTA?: boolean;
   // Syndicated posts point canonical at the original source.
   canonical_url?: string;
+  // When set, the post is gated behind ?unreleased=<label>.
+  unreleased?: string;
 };
 
 type RelatedPost = {
@@ -139,6 +142,7 @@ function loadRelated(currentSlug: string): RelatedPost[] {
     .map((p): RelatedPost | null => {
       const fm = p.data;
       if (fm.redirect) return null;
+      if (fm.unreleased) return null;
       if (!fm.heading) return null;
       const date =
         fm.date instanceof Date
@@ -247,6 +251,8 @@ export async function generateMetadata({
   return {
     title: { absolute: title },
     description,
+    // Keep unreleased posts out of search; they 200 but are gated client-side.
+    robots: scope.unreleased ? { index: false, follow: false } : undefined,
     // Match the legacy blog: external canonical for syndicated posts,
     // otherwise an absolute self-canonical to the post URL.
     alternates: { canonical: scope.canonical_url ?? url },
@@ -311,8 +317,8 @@ export default async function BlogPostPage({
           ],
   };
 
-  return (
-    <PageShell>
+  const body = (
+    <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
@@ -332,7 +338,37 @@ export default async function BlogPostPage({
           <BuildBetterAgentsCta />
         </article>
       </div>
+    </>
+  );
+
+  return (
+    <PageShell>
+      {scope.unreleased ? (
+        <Unreleased label={scope.unreleased} fallback={<BlogNotFound />}>
+          {body}
+        </Unreleased>
+      ) : (
+        body
+      )}
     </PageShell>
+  );
+}
+
+function BlogNotFound() {
+  return (
+    <section className="mx-auto w-full max-w-[1440px] px-6 pb-[160px] pt-[120px] text-center text-v1-frost sm:px-9 lg:px-8">
+      <h1 className="font-v1Heading text-[28px] leading-[1.15] tracking-[-0.01em] text-v1-frost sm:text-[36px] lg:text-[44px]">
+        Post not found
+      </h1>
+      <p className="mt-5">
+        <Link
+          href="/blog"
+          className="text-v1-frost/70 underline motion-safe:transition-colors hover:text-v1-accent-salmon-light"
+        >
+          Back to the blog
+        </Link>
+      </p>
+    </section>
   );
 }
 

--- a/app/(v1)/blog/page.tsx
+++ b/app/(v1)/blog/page.tsx
@@ -30,7 +30,7 @@ export default async function BlogIndex() {
   const posts = await loadMarkdownFilesMetadata<MDXBlogPost>("content/blog");
 
   const cards: PostCard[] = posts
-    .filter((p) => !p.hide && p.heading)
+    .filter((p) => !p.hide && !p.unreleased && p.heading)
     .map((p) => {
       const tags = Array.isArray(p.tags)
         ? p.tags

--- a/app/api/rss.xml/route.ts
+++ b/app/api/rss.xml/route.ts
@@ -23,7 +23,7 @@ export async function GET() {
   );
 
   const blogPostsTransformed = blogPosts
-    .filter((post) => !post.hide)
+    .filter((post) => !post.hide && !post.unreleased)
     .map((post) => ({
       title: post.heading,
       description: post.subtitle,

--- a/components/Blog/index.ts
+++ b/components/Blog/index.ts
@@ -28,6 +28,10 @@ export type BlogPost = {
   focusCta?: string;
   // When hidden, the post will be available on at the URL, but not in any blog feed of RSS
   hide?: boolean;
+  // When set, the post is gated behind ?unreleased=<label>: hidden from the blog
+  // index, related cards, RSS, blog.txt, and the .md mirror, and its page 404s
+  // (noindex) until the label is present. See shared/Docs/Unreleased.
+  unreleased?: string;
   /** Hides default hero image/title; use Report* MDX components instead. */
   reportLayout?: boolean;
   // When featured is false, post will be hidden from main feed, but available on category pages

--- a/content/blog/2026-06-24-introducing-scoring.mdx
+++ b/content/blog/2026-06-24-introducing-scoring.mdx
@@ -1,0 +1,15 @@
+---
+heading: "Introducing scoring for Inngest functions"
+subtitle: Attach quality scores to function runs and steps to track how your AI workflows perform over time.
+date: 2026-06-24
+author: Inngest Team
+category: product-updates
+unreleased: score
+---
+
+Score your function runs and steps to measure how well your AI workflows perform, then compare results across model and prompt changes — all from the dashboard.
+
+## Learn more
+
+* [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring)
+* [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring)

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,59 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const matter = require("gray-matter");
+
+// A page is "gated" (behind ?unreleased=<label>) if its source declares an
+// `unreleased` label — YAML frontmatter for blog posts, an `export const
+// unreleased` for docs/changelog MDX. Gated pages send noindex, so they must
+// stay out of the sitemap (sitemap + noindex is contradictory).
+function sourceIsGated(filePath) {
+  try {
+    const src = fs.readFileSync(filePath, "utf8");
+    if (matter(src).data.unreleased) return true;
+    return /export\s+const\s+unreleased\s*=/.test(src);
+  } catch {
+    return false;
+  }
+}
+
+// Map a sitemap URL back to the content file that backs it, for the three
+// surfaces that support gating. Returns null for everything else.
+function gatedSourceFor(urlPath) {
+  const p = urlPath.replace(/\/+$/, "");
+  const candidates = [];
+  if (p.startsWith("/blog/")) {
+    const slug = p.slice("/blog/".length);
+    candidates.push(`content/blog/${slug}.mdx`, `content/blog/${slug}.md`);
+  } else if (p.startsWith("/changelog/")) {
+    const slug = p.slice("/changelog/".length);
+    candidates.push(`content/changelog/${slug}.mdx`);
+  } else if (p.startsWith("/docs/")) {
+    const sub = p.slice("/docs/".length);
+    candidates.push(`pages/docs/${sub}.mdx`, `pages/docs/${sub}/index.mdx`);
+  }
+  for (const rel of candidates) {
+    const abs = path.join(process.cwd(), rel);
+    if (fs.existsSync(abs)) return abs;
+  }
+  return null;
+}
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: "https://www.inngest.com",
+  // Drop pages gated behind ?unreleased=<label> — they're noindex, so the
+  // sitemap must not list them. Complements the static `exclude` list below.
+  transform: async (config, urlPath) => {
+    const src = gatedSourceFor(urlPath);
+    if (src && sourceIsGated(src)) return null;
+    return {
+      loc: urlPath,
+      changefreq: config.changefreq,
+      priority: config.priority,
+      lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+      alternateRefs: config.alternateRefs ?? [],
+    };
+  },
   exclude: [
     "*/_*",
     "*/landing/*",


### PR DESCRIPTION
## What this adds

Extends the `unreleased` gating system (merged in #1727) to **blog posts**. A gated post stays hidden until you add its label to the URL: `?unreleased=score`.

## How to gate a blog post

Blog posts use YAML frontmatter, so add the field there:

```mdx
---
heading: "Introducing scoring"
date: 2026-06-24
category: product-updates
unreleased: score
---
```

To release the post, delete the `unreleased:` line.

## What gets gated

A gated post is excluded everywhere a crawler or reader could find it, server-side (no client param involved):

- **`/blog` index** — not listed
- **Related-post cards** on other posts — not shown
- **RSS feed** (`/rss.xml`) — excluded
- **`/blog.txt`** (LLM index) — excluded
- **`.md` mirror** (`/blog/<slug>.md`) — `404`

And the post page itself (`/blog/<slug>`):

- Without the label: shows "Post not found" and sends `<meta robots noindex>`.
- With `?unreleased=score`: renders normally (revealed client-side, so the crawler never sees it).

## SEO & performance

Same as the docs/changelog gate: no page-load impact on public posts, gated content isn't in the rendered DOM, gated pages are `noindex`, and it's a soft gate (the URL still `200`s). The server surfaces above (index/RSS/`blog.txt`/`.md`) have **no residual** — gated posts are filtered out entirely.

This PR also closes a sitemap gap: gated pages are `noindex`, so a `transform` in `next-sitemap.config.js` now drops any `unreleased` blog/changelog/docs URL from `sitemap.xml` (the repo already noted "sitemap + noindex is contradictory" but only had a hardcoded exclude list). A separate follow-up gates the docs agent surfaces (`docs-markdown` / `llms.txt` / `llms-full.txt`), which the merged docs PR didn't cover.

## Working example

`content/blog/2026-06-24-introducing-scoring.mdx` is gated under `score` (the same label as the scoring docs and changelog entry). Visit `/blog/2026-06-24-introducing-scoring?unreleased=score` to see it; without the param it's "Post not found" and absent from the index/RSS/`blog.txt`/`.md`.