### PR TITLE
Gate unreleased docs pages on agent surfaces (docs-markdown, llms.txt, llms-full.txt)

### DIFF
--- a/.agents/skills/unreleased-content/SKILL.md
+++ b/.agents/skills/unreleased-content/SKILL.md
@@ -76,6 +76,7 @@ Delete the gate — that's the entire "ship it" step:
 - Gated content is **not in the visible DOM** and gated pages/entries are **`noindex`**, so it stays out of search.
 - **Known residual:** the gated content's data still ends up in the page's serialized payload (`__NEXT_DATA__` for docs section titles; the RSC Flight `<script>` for a changelog entry body). It is not in the rendered DOM and not in Algolia's content index, but it is present in the HTML source. This is the cost of revealing server-rendered content client-side without a hard 404.
 - This is a **soft gate**: the URL still returns `200` (no middleware/404). Fine for "not yet public," not for secrets.
+- **Agent surfaces:** the server-rendered docs outputs (`docs-markdown`, `llms.txt`, `llms-full.txt`) have no client param, so gated docs pages are excluded from them server-side (the `.md` mirror 404s). They detect the gate via `isUnreleasedMdx()` in `app/(llms)/utils.ts`.
 
 ## Gotchas
 

--- a/app/(llms)/docs-markdown/[[...slug]]/route.ts
+++ b/app/(llms)/docs-markdown/[[...slug]]/route.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { formatSnippetFileContent } from "@/mdx/utils/snippet.mjs";
 import { convertMdxToMarkdown } from "@/mdx/utils/mdx-to-markdown";
+import { isUnreleasedMdx } from "../../utils";
 
 /**
  * Recursively finds all markdown files in the pages/docs directory
@@ -24,6 +25,10 @@ function getAllDocPaths(): string[] {
       } else if (entry.isFile()) {
         // Check if it's a markdown file
         if (entry.name.endsWith(".mdx") || entry.name.endsWith(".md")) {
+          // Skip pages gated behind ?unreleased=<label>.
+          if (isUnreleasedMdx(fs.readFileSync(fullPath, "utf-8"))) {
+            continue;
+          }
           // Handle index files - use the directory path
           if (entry.name === "index.mdx" || entry.name === "index.md") {
             const docPath = relativePath || "";
@@ -97,6 +102,13 @@ export async function GET(
 
   try {
     const content = fs.readFileSync(filePath, "utf-8");
+    // Don't serve the markdown mirror for gated (unreleased) pages.
+    if (isUnreleasedMdx(content)) {
+      return new Response("Document not found", {
+        status: 404,
+        statusText: "Document not found",
+      });
+    }
     const contentWithSnippets = inlineSnippets(content);
     const contentWithMarkdownURLs = convertDocsURLsToMarkdownURLs(contentWithSnippets);
     const processedContent = await convertMdxToMarkdown(contentWithMarkdownURLs);

--- a/app/(llms)/llms.txt/route.ts
+++ b/app/(llms)/llms.txt/route.ts
@@ -57,6 +57,8 @@ function recursiveLinks(
   depth: number = 0
 ) {
   return links
+    // Skip items gated behind ?unreleased=<label> so they don't leak here.
+    .filter((link) => !(link as { unreleased?: string }).unreleased)
     .map((link) => {
       const indent = "  ".repeat(depth); // Create indentation based on depth
       if ("links" in link) {

--- a/app/(llms)/utils.ts
+++ b/app/(llms)/utils.ts
@@ -13,6 +13,14 @@ const config = {
 };
 
 /**
+ * True if an MDX source is gated behind ?unreleased=<label> (i.e. declares an
+ * `export const unreleased`). Gated docs must never leak to agent surfaces.
+ */
+export function isUnreleasedMdx(content: string): boolean {
+  return /export\s+const\s+unreleased\s*=/.test(content);
+}
+
+/**
  * Cleans MDX content for LLM consumption
  * @param content - Raw MDX content
  * @returns Cleaned content
@@ -56,8 +64,10 @@ function cleanMDXContent(content: string): string {
  * @param filePath - Path to the MDX file
  * @returns Processed content with metadata
  */
-function processMDXFile(filePath: string): string {
+function processMDXFile(filePath: string): string | null {
   const content = readFileSync(filePath, "utf-8");
+  // Skip pages gated behind ?unreleased=<label> — never leak them to agents.
+  if (isUnreleasedMdx(content)) return null;
   const relativePath = relative(config.docsDir, filePath);
 
   const cleanContent = cleanMDXContent(content);
@@ -102,7 +112,8 @@ export function processDirectory(
     if (file.isDirectory()) {
       results.push(...processDirectory(fullPath, excludeFiles));
     } else if (file.name.endsWith(".mdx")) {
-      results.push(processMDXFile(fullPath));
+      const processed = processMDXFile(fullPath);
+      if (processed !== null) results.push(processed);
     }
   }
 


### PR DESCRIPTION
## What this fixes

Follow-up to the merged docs `unreleased` gating (#1727). That PR hid gated docs pages from the **page UI and nav**, but the **agent/SEO surfaces still leaked them** — they render server-side with no `?unreleased` param, so they served the full gated content:

- `/docs-markdown/<path>` (the `.md` mirror) served the gated page's markdown
- `/llms.txt` listed the gated page's link
- `/llms-full.txt` included the gated page's full body

## The fix

A gated docs page is detected by its `export const unreleased` (via a shared `isUnreleasedMdx()` helper in `app/(llms)/utils.ts`). With that:

- `docs-markdown` → **404s** gated pages (and omits them from `generateStaticParams`)
- `llms.txt` → **skips** gated nav links
- `llms-full.txt` → **excludes** gated pages from the bundle

## Verified

Against `/docs/features/inngest-functions/steps-workflows/scoring` (gated under `score`):

- `/docs-markdown/.../scoring` → `404`
- `/llms-full.txt` → 0 occurrences of the gated body/source URL
- `/llms.txt` → gated link not listed
- public docs (`/docs-markdown/faq`) → still `200`

Companion to the blog gating PR (#1740), which adds the same treatment for the blog's RSS / `blog.txt` / `.md` mirror.