### PR TITLE
[codex] Fix gated scoring docs links

### DIFF
--- a/content/changelog/2026-06-05-deferred-functions.mdx
+++ b/content/changelog/2026-06-05-deferred-functions.mdx
@@ -10,6 +10,6 @@ Reach for them when work should happen *because of* a run, not *as part of* it: 
 - **Fully independent runs** — Each call triggers its own run with its own retries, concurrency, and step state. Multiple parents can target the same deferred function.
 - **Works inside steps** — Call `defer(...)` directly in a handler or from inside `step.run()`.
 
-Deferred Functions are available now in beta via `createDefer` from `inngest/experimental` in the TypeScript SDK. A great use case is the new [deferred LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=changelog-deferred-functions).
+Deferred Functions are available now in beta via `createDefer` from `inngest/experimental` in the TypeScript SDK. A great use case is the new [deferred LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=changelog-deferred-functions&unreleased=score).
 
 See the [Deferred Functions reference](/docs/reference/typescript/v4/functions/deferred-functions?ref=changelog-deferred-functions) for the full API.

--- a/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
@@ -160,8 +160,8 @@ With `withVariant: true`, the returned shape is `{ result, variant }`.
 
 An experiment tells you which variant ran. It does not decide which variant is best for you. Attach your own outcome signal:
 
-- Use [scoring](/docs/features/inngest-functions/steps-workflows/scoring?ref=docs-step-experiments) when the score is known during the run.
-- Use [deferred scoring](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=docs-step-experiments) when the outcome arrives later.
+- Use [scoring](/docs/features/inngest-functions/steps-workflows/scoring?ref=docs-step-experiments&unreleased=score) when the score is known during the run.
+- Use [deferred scoring](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=docs-step-experiments&unreleased=score) when the outcome arrives later.
 - Emit analytics events from a `step.run()` when your team already uses an external analytics warehouse.
 
 For AI model or prompt experiments, `withVariant: true` is often the simplest way to include the selected variant in your scoring or analytics payload.

--- a/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
+++ b/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
@@ -22,7 +22,7 @@ Use deferred functions for work that should happen *because of* a run, not *as p
 | `step.sendEvent(...)`           | No                  | Yes (any matching fn)     |
 | `defer(id, { function, data })` | No                  | Yes (single typed target) |
 
-A common use case is an [LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring) that runs against the output of an agent run.
+A common use case is an [LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring?unreleased=score) that runs against the output of an agent run.
 
 ---
 

--- a/shared/Patterns/_patterns/run-experiments-in-production.mdx
+++ b/shared/Patterns/_patterns/run-experiments-in-production.mdx
@@ -142,7 +142,7 @@ await step.run("track-selected-variant", () =>
 );
 ```
 
-If the outcome is available during the run, pair the experiment with [scoring](/docs/features/inngest-functions/steps-workflows/scoring?ref=docs-patterns-run-experiments-in-production). If the outcome arrives later, use a deferred scorer or your analytics system.
+If the outcome is available during the run, pair the experiment with [scoring](/docs/features/inngest-functions/steps-workflows/scoring?ref=docs-patterns-run-experiments-in-production&unreleased=score). If the outcome arrives later, use a deferred scorer or your analytics system.
 
 ## Best practices
 
@@ -156,5 +156,5 @@ If the outcome is available during the run, pair the experiment with [scoring](/
 ## Related docs
 
 - [`group.experiment()` reference](/docs/reference/typescript/v4/functions/group-experiment?ref=docs-patterns-run-experiments-in-production)
-- [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring?ref=docs-patterns-run-experiments-in-production)
+- [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring?ref=docs-patterns-run-experiments-in-production&unreleased=score)
 - [Function versioning](/docs/learn/versioning?ref=docs-patterns-run-experiments-in-production)


### PR DESCRIPTION
## Summary

Updates public docs and changelog links that point at gated scoring docs so they include `unreleased=score`.

## Why

A Slack thread reported that the experiments docs link to scoring and deferred scoring pages, but those pages now return the docs not-found fallback unless the `score` unreleased label is present. The scoring pages are intentionally gated, but released docs that already link to them need to carry the reveal parameter.

## Impact

Readers following links from experiments/pattern docs, deferred-functions reference, or the deferred-functions changelog can reach the scoring docs instead of landing on a 404-style page.

## Validation

- `pnpm exec prettier --check content/changelog/2026-06-05-deferred-functions.mdx pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx pages/docs/reference/typescript/v4/functions/deferred-functions.mdx shared/Patterns/_patterns/run-experiments-in-production.mdx`
- `pnpm test:docs-markdown`
- `git diff --check`

Note: `pnpm link-check:offline` could not run locally because the installed `lychee 0.24.2` fails to parse this repo's current `lychee.toml` (`include_fragments = false` expects a newer config shape).