### PR TITLE
Document step.score's id argument

### DIFF
--- a/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
@@ -34,7 +34,7 @@ export default inngest.createFunction(
     });
 
     // Score this run based on whether guardrails passed
-    await step.score({ name: "guardrail-pass", value: passed ? 1 : 0 });
+    await step.score("score-guardrail-pass", { name: "guardrail-pass", value: passed ? 1 : 0 });
 
     return { summary, passed };
   }

--- a/pages/docs/reference/typescript/v4/functions/scoring.mdx
+++ b/pages/docs/reference/typescript/v4/functions/scoring.mdx
@@ -52,21 +52,28 @@ await inngest.score({
 
 ---
 
-## `step.score(options)`
+## `step.score(id, options)`
 
 Score the current run from within a step context. Same options as `inngest.score()` but `runId` is automatically set to the current run.
 
 <Properties>
-  <Property name="name" type="string" required>
-    Score label.
+  <Property name="id" type="string" required>
+    The ID of the step that scores the current run. Similar to `step.run`, this ID is used to memoize step state across function versions.
   </Property>
-  <Property name="value" type="number" required>
-    Score value.
+  <Property name="options" type="object" required>
+    <Properties nested>
+      <Property name="name" type="string" required>
+        Score label.
+      </Property>
+      <Property name="value" type="number" required>
+        Score value.
+      </Property>
+    </Properties>
   </Property>
 </Properties>
 
 ```ts
-await step.score({ name: "guardrail-pass", value: 1 });
+await step.score("score-guardrail-pass", { name: "guardrail-pass", value: 1 });
 ```
 
 ---


### PR DESCRIPTION
- step.score requires an id argument but we omit it in the docs