### PR TITLE
refactor: update scoring changelog

### DIFF
--- a/components/v1/sections/Changelog/mdxConfig.tsx
+++ b/components/v1/sections/Changelog/mdxConfig.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Image, { type ImageProps } from "next/image";
 import { type MDXComponents } from "mdx/types";
+import { Unreleased } from "shared/Docs/Unreleased";
 
 // Cloud (#eaeaea) is the body colour for this page; there is no v1
 // token for it, so it's used as a literal here and on the entry date.
@@ -33,6 +34,9 @@ export const mdxComponents: MDXComponents = {
       {...(props as ImageProps)}
     />
   ),
+  // Gate inline content behind ?unreleased=<label> (e.g. scoring references in
+  // an otherwise-public entry). Whole-entry gating uses the `unreleased` export.
+  Unreleased,
 };
 
 // Body wrapper. CircularXX 16/24 cloud, 16px between top-level blocks.

--- a/content/changelog/2026-06-05-deferred-functions.mdx
+++ b/content/changelog/2026-06-05-deferred-functions.mdx
@@ -10,6 +10,6 @@ Reach for them when work should happen *because of* a run, not *as part of* it: 
 - **Fully independent runs** — Each call triggers its own run with its own retries, concurrency, and step state. Multiple parents can target the same deferred function.
 - **Works inside steps** — Call `defer(...)` directly in a handler or from inside `step.run()`.
 
-Deferred Functions are available now in beta via `createDefer` from `inngest/experimental` in the TypeScript SDK. A great use case is the new [deferred LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=changelog-deferred-functions).
+Deferred Functions are available now in beta via `createDefer` from `inngest/experimental` in the TypeScript SDK.<Unreleased label="score"> A great use case is the new [deferred LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=changelog-deferred-functions).</Unreleased>
 
 See the [Deferred Functions reference](/docs/reference/typescript/v4/functions/deferred-functions?ref=changelog-deferred-functions) for the full API.

--- a/content/changelog/2026-06-24-scoring.mdx
+++ b/content/changelog/2026-06-24-scoring.mdx
@@ -1,8 +1,0 @@
-export const title = "Score function runs";
-export const date = "2026-06-24";
-export const unreleased = "score";
-
-Attach quality scores to function runs and steps to track how your AI workflows perform over time, then compare them across model and prompt changes.
-
-* [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring)
-* [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring)

--- a/content/changelog/2026-06-30-scoring.mdx
+++ b/content/changelog/2026-06-30-scoring.mdx
@@ -1,0 +1,17 @@
+export const title = "Scoring: judge how well your AI actually performed";
+export const date = "2026-06-30";
+export const unreleased = "score";
+
+Scoring lets you attach a named quality signal to a function run, a step, or an experiment variant. It shines for AI evals: run an LLM-as-a-judge over a result and write the verdict back as a score with `inngest.score({ name, value })`, or defer the judge entirely so a slow model call never blocks the run that produced the output. A score is just a named number or boolean, so it tracks ordinary product signals too, from click-through and saves to conversions and error rates.
+
+Reach for it whenever you need to judge _how well_ code ran, not just whether it succeeded: LLM-as-a-judge evals, deterministic guardrails (length, format, refusal checks), engagement signals, and human ratings. Scores are how you turn an [experiment](/docs/patterns/ai-evals/run-experiments-in-production?ref=changelog-scoring) into a _winner_.
+
+- **Score right at the execution layer.** Scores land on the run itself, alongside the rest of the execution metadata Inngest already captures, not in a separate metrics pipeline. `inngest.score()` writes immediately, and `step.score("id", { name, value })` records the score as a durable, memoized step.
+- **Defer expensive scorers.** `createScorer()` turns an LLM-as-a-judge, or any other eval, into a deferred function. Trigger it with `defer()` from your run and the score is written for you, off the critical path, without blocking the result a user sees.
+- **Score variants from anywhere.** `inngest.score.experiment()` credits a score to the experiment variant that produced a result, even when the signal arrives much later in a separate run: a click, a rating, or a judge's verdict.
+
+Scoring is available now in beta in the Inngest TypeScript SDK. Install the latest with `npm install inngest@latest`. `inngest.score()` lives on the client. `step.score()` needs `scoreMiddleware()`, which, along with `createScorer`, is imported from `inngest/experimental`.
+
+- [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring?ref=changelog-scoring)
+- [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=changelog-scoring)
+- [`inngest.score()` reference](/docs/reference/typescript/v4/functions/scoring?ref=changelog-scoring)

--- a/pages/docs/features/inngest-functions/steps-workflows/deferred-scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/deferred-scoring.mdx
@@ -29,14 +29,14 @@ export const feedbackScorer = createScorer(
   inngest,
   {
     id: "feedback-scorer",
-    schema: z.object({ ticketId: z.string(), runId: z.string() }),
+    schema: z.object({ ticketId: z.string() }),
   },
   async ({ event, step }) => {
     // Wait up to 7 days for the user to give feedback
     const feedback = await step.waitForEvent("wait-for-feedback", {
       event: "support/feedback.received",
       timeout: "7d",
-      if: `async.data.ticketId == '${event.data.input.ticketId}'`,
+      if: `async.data.ticketId == '${event.data.ticketId}'`,
     });
 
     if (!feedback) {
@@ -80,7 +80,6 @@ export default inngest.createFunction(
       function: feedbackScorer,
       data: {
         ticketId: event.data.ticketId,
-        runId: event.data.runId,
       },
     });
 
@@ -88,6 +87,8 @@ export default inngest.createFunction(
   }
 );
 ```
+
+You don't need to pass the parent run's ID in `data`. The SDK threads it through automatically, so the scorer's return value is attributed to the run that deferred it. If you need to write scores explicitly, the parent run ID is available in the handler on `ctx.parents[0].runId`.
 
 ## How deferred scoring works
 

--- a/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
@@ -19,9 +19,15 @@ This is useful for anything where "did it work?" isn't a binary answer: AI accur
 
 ## Score the current run
 
-Inside a function, call `inngest.score()` or `step.score()` with a name and a numeric value.
+Inside a function, call `inngest.score()` or `step.score()` with a name and a value. The value can be a number or a boolean.
+
+`step.score()` is a durable, memoized step, so it takes a step ID as its first argument and requires `scoreMiddleware()` (from `inngest/experimental`) on the client:
 
 ```ts
+import { scoreMiddleware } from "inngest/experimental";
+
+const inngest = new Inngest({ id: "my-app", middleware: [scoreMiddleware()] });
+
 export default inngest.createFunction(
   { id: "summarize-ticket", triggers: { event: "support/ticket.created" } },
   async ({ event, step }) => {
@@ -34,14 +40,14 @@ export default inngest.createFunction(
     });
 
     // Score this run based on whether guardrails passed
-    await step.score("score-guardrail-pass", { name: "guardrail-pass", value: passed ? 1 : 0 });
+    await step.score("score-guardrail-pass", { name: "guardrail-pass", value: passed });
 
     return { summary, passed };
   }
 );
 ```
 
-`step.score()` attaches the score to the current run. Use it when you know the outcome before the function finishes.
+`step.score()` attaches the score to the current run. Its first argument is a durable step ID that memoizes the write, so a retry or replay can't record it twice. Use it when you know the outcome before the function finishes.
 
 ---
 

--- a/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
@@ -1,4 +1,4 @@
-import { Callout } from "src/shared/Docs/mdx";
+import { Callout, Unreleased } from "src/shared/Docs/mdx";
 
 export const metaTitle = "Step Experiments | Run Variants in Durable Functions"
 export const description = "Use group.experiment() to run one of several durable workflow variants, choose traffic with weighted, bucket, custom, or fixed selection, and track outcomes."
@@ -132,7 +132,7 @@ select: experiment.fixed("candidate")
 
 - **`result`**: the value returned by the selected variant's callback.
 - **`variant`**: the name of the selected variant, as a string. Useful for logging, analytics, or downstream decisions.
-- **`experimentRef`**: a replay-stable handle of shape `{ experimentName, variant }`. Pass it to [`inngest.score.experiment()`](/docs/reference/typescript/v4/functions/scoring?ref=docs-step-experiments#inngest-score-experiment-options) to attribute a score to the variant that produced this result, even later and from a separate run.
+- **`experimentRef`**: a replay-stable handle of shape `{ experimentName, variant }`.<Unreleased label="score"> Pass it to [`inngest.score.experiment()`](/docs/reference/typescript/v4/functions/scoring?ref=docs-step-experiments#inngest-score-experiment-options) to attribute a score to the variant that produced this result, even later and from a separate run.</Unreleased>
 
 ```typescript
 const { result, variant, experimentRef } = await group.experiment("copy-style", {
@@ -157,6 +157,8 @@ await step.run("track-experiment", () =>
 return result;
 ```
 
+<Unreleased label="score">
+
 ### Scoring a variant with `experimentRef`
 
 `experimentRef` is how a score gets credited to the variant that produced a result. Because you hold the ref, you can score the variant right away, or save it and score much later when the real signal lands: a click, a rating, or an LLM-judge verdict, often from a different run entirely.
@@ -176,15 +178,26 @@ await inngest.score.experiment({ name: "length-ok", value: true, experiment: exp
 
 See the [scoring reference](/docs/reference/typescript/v4/functions/scoring?ref=docs-step-experiments) for the full attribution rules, including when you must pass `runId`.
 
+</Unreleased>
+
 ## Track outcomes
 
 An experiment tells you which variant ran. It does not decide which variant is best for you. Attach your own outcome signal:
 
+<Unreleased label="score">
+
 - Use [scoring](/docs/features/inngest-functions/steps-workflows/scoring?ref=docs-step-experiments) when the score is known during the run.
 - Use [deferred scoring](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=docs-step-experiments) when the outcome arrives later.
+
+</Unreleased>
+
 - Emit analytics events from a `step.run()` when your team already uses an external analytics warehouse.
 
+<Unreleased label="score">
+
 For AI model or prompt experiments, the `experimentRef` returned by `group.experiment()` is the cleanest way to attribute a score back to the variant that produced the result, since it works even when the score arrives from a later run.
+
+</Unreleased>
 
 ## Notes and best practices
 
@@ -200,19 +213,28 @@ For AI model or prompt experiments, the `experimentRef` returned by `group.exper
 | Issue | Solution |
 |-------|----------|
 | **Setup** | |
-| Experiments and scoring are not available. | Your SDK version must be at least `4.8.0`. |
+| Experiments are not available. | Your SDK version must be at least `4.8.0`. |
 | **Variant selection** | |
 | The same user sees different variants across runs. | `experiment.weighted()` is seeded by run ID, not user ID. Use `experiment.bucket(userId, { weights })` for sticky user-level assignment. |
 | `select()` returns a variant that does not exist. | Make sure `experiment.fixed()`, `experiment.custom()`, or custom selector output exactly matches a key in `variants`. Typos fail the run. |
 | `experiment.bucket()` gives surprising skew. | Confirm the bucket value is not `null` or `undefined`. Missing values hash as an empty string, so they all collapse into the same deterministic bucket. |
-| **Scoring** | |
+| **Reading results** | |
+| A 50/50 split looks uneven. | Small samples are noisy. Fire more events before assuming selection is wrong. |
+| Two functions use the same experiment name and the dashboard feels confusing. | This is allowed, and the backend scopes detail views by function. Still, prefer distinct experiment names when humans will compare them in the list or docs. |
+
+<Unreleased label="score">
+
+### Scoring
+
+| Issue | Solution |
+|-------|----------|
+| Scoring is not available. | Your SDK version must be at least `4.8.0`. |
 | `step.score()` is missing or throws. | Register `scoreMiddleware()` on the Inngest client: `middleware: [scoreMiddleware()]`. |
 | Scores run, but do not attach to the experiment. | For in-callback scoring, call `step.score()` inside the selected variant callback. For outside-callback scoring, use `inngest.score.experiment()` with the returned `experimentRef`. |
 | Score values are rejected. | Score value must be a finite number or boolean. Do not pass strings, objects, `NaN`, or `Infinity`. |
 | Boolean scores look like numbers in aggregate views. | Boolean scores are valid and aggregate numerically. Treat `true` as `1` and `false` as `0` when interpreting averages. |
-| **Reading results** | |
-| A 50/50 split looks uneven. | Small samples are noisy. Fire more events before assuming selection is wrong. |
-| Two functions use the same experiment name and the dashboard feels confusing. | This is allowed, and the backend scopes detail views by function. Still, prefer distinct experiment names when humans will compare them in the list or docs. |
+
+</Unreleased>
 
 ## Related docs
 

--- a/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
@@ -34,7 +34,7 @@ export default inngest.createFunction(
       fetchDocument(event.data.documentId)
     );
 
-    const summary = await group.experiment("model-comparison", {
+    const { result: summary } = await group.experiment("model-comparison", {
       variants: {
         gpt4o: () =>
           step.run("summarize-gpt4o", () =>
@@ -126,12 +126,16 @@ Use `experiment.fixed()` when you want one variant every time. This is useful fo
 select: experiment.fixed("candidate")
 ```
 
-## Return the selected variant
+## The return value
 
-By default, `group.experiment()` returns the selected variant's result. Set `withVariant: true` when you also need the selected variant name for logging, analytics, scoring, or downstream decisions.
+`group.experiment()` always returns `{ result, variant, experimentRef }`:
+
+- **`result`**: the value returned by the selected variant's callback.
+- **`variant`**: the name of the selected variant, as a string. Useful for logging, analytics, or downstream decisions.
+- **`experimentRef`**: a replay-stable handle of shape `{ experimentName, variant }`. Pass it to [`inngest.score.experiment()`](/docs/reference/typescript/v4/functions/scoring?ref=docs-step-experiments#inngest-score-experiment-options) to attribute a score to the variant that produced this result, even later and from a separate run.
 
 ```typescript
-const outcome = await group.experiment("copy-style", {
+const { result, variant, experimentRef } = await group.experiment("copy-style", {
   variants: {
     short: () => step.run("short-copy", () => generateShortCopy(event.data)),
     detailed: () =>
@@ -140,21 +144,37 @@ const outcome = await group.experiment("copy-style", {
   select: experiment.bucket(event.data.userId, {
     weights: { short: 50, detailed: 50 },
   }),
-  withVariant: true,
 });
 
 await step.run("track-experiment", () =>
   analytics.track("experiment.variant_selected", {
     experiment: "copy-style",
-    variant: outcome.variant,
+    variant,
     userId: event.data.userId,
   })
 );
 
-return outcome.result;
+return result;
 ```
 
-With `withVariant: true`, the returned shape is `{ result, variant }`.
+### Scoring a variant with `experimentRef`
+
+`experimentRef` is how a score gets credited to the variant that produced a result. Because you hold the ref, you can score the variant right away, or save it and score much later when the real signal lands: a click, a rating, or an LLM-judge verdict, often from a different run entirely.
+
+```typescript
+const { result, experimentRef } = await group.experiment("summary-strategy", {
+  variants: { /* ... */ },
+  select: experiment.weighted({ questionLed: 50, factLed: 50 }),
+});
+
+// Score now, from the same run that served the variant
+await inngest.score.experiment({ name: "length-ok", value: true, experiment: experimentRef });
+
+// ...or persist experimentRef (and this run's ID) and score it later from a separate run:
+// await inngest.score.experiment({ name: "clickthrough", value: 1, experiment: ref, runId });
+```
+
+See the [scoring reference](/docs/reference/typescript/v4/functions/scoring?ref=docs-step-experiments) for the full attribution rules, including when you must pass `runId`.
 
 ## Track outcomes
 
@@ -164,7 +184,7 @@ An experiment tells you which variant ran. It does not decide which variant is b
 - Use [deferred scoring](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=docs-step-experiments) when the outcome arrives later.
 - Emit analytics events from a `step.run()` when your team already uses an external analytics warehouse.
 
-For AI model or prompt experiments, `withVariant: true` is often the simplest way to include the selected variant in your scoring or analytics payload.
+For AI model or prompt experiments, the `experimentRef` returned by `group.experiment()` is the cleanest way to attribute a score back to the variant that produced the result, since it works even when the score arrives from a later run.
 
 ## Notes and best practices
 

--- a/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
+++ b/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
@@ -1,4 +1,4 @@
-import { Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge } from "src/shared/Docs/mdx";
+import { Callout, Properties, Property, Row, Col, CodeGroup, VersionBadge, Unreleased } from "src/shared/Docs/mdx";
 
 
 export const metaTitle = "Deferred Functions | Fire-and-Forget Background Tasks"
@@ -22,7 +22,11 @@ Use deferred functions for work that should happen *because of* a run, not *as p
 | `step.sendEvent(...)`           | No                  | Yes (any matching fn)     |
 | `defer(id, { function, data })` | No                  | Yes (single typed target) |
 
+<Unreleased label="score">
+
 A common use case is an [LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring) that runs against the output of an agent run.
+
+</Unreleased>
 
 ---
 

--- a/pages/docs/reference/typescript/v4/functions/scoring.mdx
+++ b/pages/docs/reference/typescript/v4/functions/scoring.mdx
@@ -1,8 +1,7 @@
 import { Callout, Properties, Property, Row, Col } from "src/shared/Docs/mdx";
 
-
-export const metaTitle = "step.ai.score() | Score AI Outputs (TypeScript SDK v4)"
-export const description = "Attach numeric quality scores to AI function runs and steps to track performance across model versions."
+export const metaTitle = "inngest.score() | Score AI Outputs (TypeScript SDK v4)"
+export const description = "Attach numeric or boolean quality scores to AI function runs, steps, and experiment variants to track LLM-as-a-judge evals and performance across model versions."
 export const unreleased = "score"
 
 # Scoring
@@ -23,8 +22,8 @@ Score a run or step. Can be called inside or outside a function.
   <Property name="name" type="string" required>
     A label for the score. Use consistent names across runs for aggregation. Examples: `"accuracy"`, `"user-feedback"`, `"guardrail-pass"`.
   </Property>
-  <Property name="value" type="number" required>
-    The score value. Numeric. Use 0-1 for percentages, integers for counts, or any range that fits your use case.
+  <Property name="value" type="number | boolean" required>
+    The score value. A finite number or a boolean. Use `0`-`1` for percentages, integers for counts, booleans for pass/fail guardrails, or any range that fits your use case.
   </Property>
   <Property name="runId" type="string">
     The run to score. Required when scoring from outside a function. Omit when scoring the current run from inside a function.
@@ -52,35 +51,80 @@ await inngest.score({
 
 ---
 
+## `inngest.score.experiment(options)`
+
+Attribute a score to the experiment variant that produced a result. `group.experiment()` returns an `experimentRef`, which identifies the experiment and the variant that was served. Pass it here to credit the score to that variant.
+
+The signal you want to score often arrives much later, from somewhere else entirely: a click, a rating, an LLM-judge verdict. Because you pass the `experimentRef` yourself, you can credit any of these back to the variant that produced the output, even hours later from a separate run.
+
+<Properties>
+  <Property name="name" type="string" required>
+    Score label.
+  </Property>
+  <Property name="value" type="number | boolean" required>
+    Score value. A finite number or a boolean.
+  </Property>
+  <Property name="experiment" type="ExperimentRef" required>
+    The `experimentRef` returned by `group.experiment()`. Identifies the experiment and the served variant. Shape: `{ experimentName: string, variant: string }`.
+  </Property>
+  <Property name="runId" type="string">
+    The run to attach the score to. Required when scoring from outside the run that produced the result; omit to use the current run.
+  </Property>
+</Properties>
+
+<Callout variant="info">
+  Scoring an experiment from a different run than the one that served the variant? Pass that run's `runId` so the score shows up in the experiment view — otherwise it attaches to the run you're scoring from and won't appear under the experiment.
+</Callout>
+
+```ts
+// Inside the function that runs the experiment
+const { result, experimentRef } = await group.experiment("summary-strategy", {
+  variants: { /* ... */ },
+  select: experiment.weighted({ questionLed: 50, factLed: 50 }),
+});
+
+// Persist experimentRef + runId (e.g. on your record) so later runs can score it
+
+// From a separate, later run (a click, rating, or deferred judge)
+await inngest.score.experiment({
+  name: "clickthrough",
+  value: 1,
+  experiment: experimentRef, // restored from your store
+  runId: summarizeRunId,
+});
+```
+
+---
+
 ## `step.score(id, options)`
 
-Score the current run from within a step context. Same options as `inngest.score()` but `runId` is automatically set to the current run.
+Score the current run from within a step context, as a durable, memoized step. `runId` is automatically set to the current run. Requires `scoreMiddleware()` (from `inngest/experimental`) on the client.
 
 <Properties>
   <Property name="id" type="string" required>
-    The ID of the step that scores the current run. Similar to `step.run`, this ID is used to memoize step state across function versions.
+    A durable step ID used to memoize this score write, so a replay or retry can't write it twice. Must be unique within the run.
   </Property>
   <Property name="options" type="object" required>
     <Properties nested>
       <Property name="name" type="string" required>
         Score label.
       </Property>
-      <Property name="value" type="number" required>
-        Score value.
+      <Property name="value" type="number | boolean" required>
+        Score value. A finite number or a boolean.
       </Property>
     </Properties>
   </Property>
 </Properties>
 
 ```ts
-await step.score("score-guardrail-pass", { name: "guardrail-pass", value: 1 });
+await step.score("score-guardrail-pass", { name: "guardrail-pass", value: true });
 ```
 
 ---
 
 ## `createScorer(client, config, handler)`
 
-Create a reusable deferred scorer. Returns an Inngest function that can be triggered via `defer()`.
+Create a reusable deferred scorer: a separate function, triggered via `defer()`, that evaluates a result without blocking or slowing the run that produced it. Use it when scoring is expensive or slow, such as an LLM-as-a-judge call or waiting on a signal that arrives later.
 
 Imported from `inngest/experimental`.
 
@@ -93,15 +137,17 @@ Imported from `inngest/experimental`.
       <Property name="id" type="string" required>
         Unique identifier for the scorer function.
       </Property>
-      <Property name="schema" type="ZodSchema" required>
-        Zod schema defining the input data the scorer expects.
+      <Property name="schema" type="StandardSchema">
+        A [Standard Schema](https://standardschema.dev) (e.g. Zod) describing the input data the scorer expects. Optional; when set, the `data` passed to `defer()` is validated against it and the handler's `event.data` is typed from it.
       </Property>
     </Properties>
   </Property>
   <Property name="handler" type="function" required>
-    Async function that receives `event` and `step`, and returns `{ name: string, value: number }`.
+    Async function that receives `event`, `step`, and `parents`. Return `{ name, value }` and the score is written for you, attributed to the parent run, and to the served variant when the scorer was deferred with an `experiment` ref. Return `null` or `undefined` to write nothing.
   </Property>
 </Properties>
+
+The handler's `event.data` is the payload sent via `defer()`, typed from `schema`. The simplest scorer returns one score and lets the SDK attribute it:
 
 ```ts
 import { createScorer } from "inngest/experimental";
@@ -111,8 +157,26 @@ export const verbosityScorer = createScorer(
   inngest,
   { id: "verbosity-scorer", schema: z.object({ text: z.string() }) },
   async ({ event }) => {
-    const wordCount = event.data.input.text.split(" ").length;
+    const wordCount = event.data.text.split(" ").length;
     return { name: "verbosity", value: wordCount };
+  }
+);
+```
+
+To emit several scores, or to attribute explicitly, write them yourself with `inngest.score.experiment()`. The parent run and its served variant are on `ctx.parents[0]`, so there's no need to persist them:
+
+```ts
+export const judgeScorer = createScorer(
+  inngest,
+  { id: "judge-summary", schema: z.object({ summary: z.string() }) },
+  async ({ event, step, parents }) => {
+    const judged = await step.run("judge", () => judge(event.data.summary));
+
+    const { experiment, runId } = parents[0];
+    await inngest.score.experiment({ name: "faithfulness", value: judged.faithfulness, experiment, runId });
+    await inngest.score.experiment({ name: "spoiler", value: judged.spoiler, experiment, runId });
+
+    return null; // scores already written above
   }
 );
 ```
@@ -135,14 +199,20 @@ Trigger a deferred scorer from inside a function. Available as a handler argumen
       <Property name="data" type="object" required>
         Input data matching the scorer's schema.
       </Property>
+      <Property name="experiment" type="ExperimentRef">
+        The `experimentRef` from `group.experiment()`. Pass it to attribute the scorer's result to the served variant; surfaced on the scorer's `ctx.parents[0].experiment`.
+      </Property>
     </Properties>
   </Property>
 </Properties>
 
+`defer()` is fire-and-forget: it returns `void`, so there's nothing to `await`.
+
 ```ts
 defer("score-feedback", {
   function: feedbackScorer,
-  data: { ticketId: "tk_123", runId: "run_456" },
+  data: { ticketId: "tk_123" },
+  experiment: experimentRef, // optional; credits the score to the served variant
 });
 ```
 


### PR DESCRIPTION
Update the scoring changelog to include more details about the features we're releasing.

Updates a few pieces of outdated documentation.