### PR TITLE
Document scoreMiddleware

### DIFF
--- a/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
@@ -19,7 +19,10 @@ This is useful for anything where "did it work?" isn't a binary answer: AI accur
 
 ## Score the current run
 
-Inside a function, call `inngest.score()` or `step.score()` with a name and a numeric value.
+Inside a function, call `step.score()` to score the current run durably within a step or `inngest.score()` to score without a step.
+Use these when you know the outcome of a run before before the runs finishes.
+
+### `inngest.score`
 
 ```ts
 export default inngest.createFunction(
@@ -34,14 +37,49 @@ export default inngest.createFunction(
     });
 
     // Score this run based on whether guardrails passed
-    await step.score("score-guardrail-pass", { name: "guardrail-pass", value: passed ? 1 : 0 });
+    await inngest.score({ name: "guardrail-pass", value: passed ? 1 : 0 });
 
     return { summary, passed };
   }
 );
 ```
 
-`step.score()` attaches the score to the current run. Use it when you know the outcome before the function finishes.
+### `step.score`
+
+First, add `scoreMiddleware()` on your Inngest client. Without it, `step.score()` will throw.
+
+```ts
+import { Inngest } from "inngest";
+import { scoreMiddleware } from "inngest/experimental";
+
+export const inngest = new Inngest({
+  id: "my-app",
+  middleware: [scoreMiddleware()],
+});
+```
+
+Then, call `step.score` within a function with an ID for the step, score name, and value.
+
+
+```ts
+export default inngest.createFunction(
+  { id: "summarize-ticket", triggers: { event: "support/ticket.created" } },
+  async ({ event, step }) => {
+    const summary = await step.run("generate-summary", async () => {
+      return await generateSummary(event.data.content);
+    });
+
+    const passed = await step.run("check-guardrails", async () => {
+      return validateOutput(summary);
+    });
+
+    // Score this run durably based on whether guardrails passed
+    await step.score("score-guardrail-pass", { name: "guardrail-pass", value: passed ? 1 : 0 });
+
+    return { summary, passed };
+  }
+);
+```
 
 ---
 

--- a/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/step-experiments.mdx
@@ -186,7 +186,7 @@ For AI model or prompt experiments, `withVariant: true` is often the simplest wa
 | `select()` returns a variant that does not exist. | Make sure `experiment.fixed()`, `experiment.custom()`, or custom selector output exactly matches a key in `variants`. Typos fail the run. |
 | `experiment.bucket()` gives surprising skew. | Confirm the bucket value is not `null` or `undefined`. Missing values hash as an empty string, so they all collapse into the same deterministic bucket. |
 | **Scoring** | |
-| `step.score()` is missing or throws. | Register `scoreMiddleware()` on the Inngest client: `middleware: [scoreMiddleware()]`. |
+| `step.score()` is missing or throws. | Register [`scoreMiddleware()`](/docs/reference/typescript/v4/functions/scoring#score-middleware) on the Inngest client: `middleware: [scoreMiddleware()]`. |
 | Scores run, but do not attach to the experiment. | For in-callback scoring, call `step.score()` inside the selected variant callback. For outside-callback scoring, use `inngest.score.experiment()` with the returned `experimentRef`. |
 | Score values are rejected. | Score value must be a finite number or boolean. Do not pass strings, objects, `NaN`, or `Infinity`. |
 | Boolean scores look like numbers in aggregate views. | Boolean scores are valid and aggregate numerically. Treat `true` as `1` and `false` as `0` when interpreting averages. |

--- a/pages/docs/reference/typescript/v4/functions/scoring.mdx
+++ b/pages/docs/reference/typescript/v4/functions/scoring.mdx
@@ -56,6 +56,8 @@ await inngest.score({
 
 Score the current run from within a step context. Same options as `inngest.score()` but `runId` is automatically set to the current run.
 
+`step.score` requires setting up `scoreMiddleware`.
+
 <Properties>
   <Property name="id" type="string" required>
     The ID of the step that scores the current run. Similar to `step.run`, this ID is used to memoize step state across function versions.
@@ -72,8 +74,40 @@ Score the current run from within a step context. Same options as `inngest.score
   </Property>
 </Properties>
 
+First setup `scoreMiddleware`:
+
+```ts
+import { Inngest } from "inngest";
+import { scoreMiddleware } from "inngest/experimental";
+
+export const inngest = new Inngest({
+  id: "my-app",
+  middleware: [scoreMiddleware()],
+});
+```
+
+Then, call `step.score` within a function:
+
 ```ts
 await step.score("score-guardrail-pass", { name: "guardrail-pass", value: 1 });
+```
+
+---
+
+## `scoreMiddleware()`
+
+Enables `step.score()` on your functions. Register it on your Inngest client. Without it, `step.score()` will throw.
+
+Imported from `inngest/experimental`. Takes no arguments.
+
+```ts
+import { Inngest } from "inngest";
+import { scoreMiddleware } from "inngest/experimental";
+
+export const inngest = new Inngest({
+  id: "my-app",
+  middleware: [scoreMiddleware()],
+});
 ```
 
 ---


### PR DESCRIPTION
- Users need to register scoreMiddleware before using step.score
- Let's document that more explicitly in our examples and function docs