### PR TITLE
Add Score agent accuracy pattern (gated behind ?unreleased=score)

### DIFF
--- a/pages/api/patterns/[pattern]/md.ts
+++ b/pages/api/patterns/[pattern]/md.ts
@@ -6,6 +6,7 @@ type PatternFrontmatter = {
   title?: string;
   subtitle?: string;
   tags?: string[];
+  unreleased?: string;
 };
 
 export default async function handler(
@@ -23,6 +24,11 @@ export default async function handler(
   try {
     const data = await loadMarkdownFile("shared/Patterns/_patterns", slug);
     const metadata = (data.metadata ?? {}) as PatternFrontmatter;
+    // No ?unreleased opt-in on this endpoint, so gated patterns 404.
+    if (metadata.unreleased) {
+      res.status(404).send("Pattern not found");
+      return;
+    }
     const body = (data as { content: string }).content;
     const markdown = patternMarkdown(
       metadata.title ?? slug,

--- a/pages/api/patterns/md.ts
+++ b/pages/api/patterns/md.ts
@@ -11,6 +11,7 @@ type PatternFrontmatter = {
   title?: string;
   subtitle?: string;
   pattern?: string;
+  unreleased?: string;
 };
 
 export default async function handler(
@@ -24,6 +25,9 @@ export default async function handler(
   const bySection = new Map<string, PatternItem[]>();
   for (const entry of entries) {
     if (!entry.pattern || !entry.title || !entry.subtitle) continue;
+    // Keep unreleased patterns out of the agent/markdown index. This endpoint
+    // has no ?unreleased opt-in, so gated patterns are always excluded here.
+    if (entry.unreleased) continue;
     const list = bySection.get(entry.pattern) ?? [];
     list.push({
       slug: entry.slug,

--- a/pages/docs/patterns/[category]/[slug]/index.tsx
+++ b/pages/docs/patterns/[category]/[slug]/index.tsx
@@ -6,6 +6,7 @@ import { GetStaticPaths, GetStaticProps } from "next";
 import { loadMarkdownFile } from "utils/markdown";
 import {
   PATTERNS,
+  getPattern,
   getPatternSections,
   getSection,
 } from "../../../../../shared/Patterns/patternsData";
@@ -48,6 +49,8 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
   const pageData = await loadMarkdownFile("shared/Patterns/_patterns", slug);
   const md = (pageData.metadata ?? {}) as PatternFrontmatter;
 
+  // `getPatternSections()` excludes unreleased patterns, so a public pattern's
+  // prev/next never links to a gated sibling server-side.
   const patterns = getPatternSections().find((s) => s.id === category)?.patterns ?? [];
   const i = patterns.findIndex((p) => p.slug === slug);
   const prev = i > 0 ? patterns[i - 1] : null;
@@ -65,6 +68,9 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
       sectionName: section.name,
       accentHex: section.accent.hex,
       accentDeep: section.accentDeep,
+      // Gates the whole page in the docs Layout (Page not found + noindex) until
+      // ?unreleased=<label> matches. See shared/Docs/Layout.tsx.
+      unreleased: getPattern(category, slug)?.unreleased ?? null,
       prev,
       next,
       description: md.subtitle ?? "",

--- a/pages/docs/patterns/[category]/index.tsx
+++ b/pages/docs/patterns/[category]/index.tsx
@@ -10,6 +10,7 @@ import {
 import Viz from "../../../../shared/Patterns/Viz";
 import AgentView from "../../../../shared/Patterns/AgentView";
 import { categoryMarkdown } from "../../../../shared/Patterns/markdown";
+import { useUnreleasedLabels } from "../../../../shared/Docs/Unreleased";
 import "../../../../shared/Patterns/patterns-docs.css";
 
 function Arrow({ s = 14 }: { s?: number }) {
@@ -46,7 +47,7 @@ export const getStaticProps: GetStaticProps = async (ctx) => {
 
 export default function CategoryPage({ category }: { category: string }) {
   const router = useRouter();
-  const sections = getPatternSections();
+  const sections = getPatternSections(useUnreleasedLabels());
   const idx = sections.findIndex((s) => s.id === category);
   const section = sections[idx];
   if (!section) return null;

--- a/pages/docs/patterns/index.tsx
+++ b/pages/docs/patterns/index.tsx
@@ -10,6 +10,7 @@ import {
 import Viz from "../../../shared/Patterns/Viz";
 import AgentView from "../../../shared/Patterns/AgentView";
 import { indexMarkdown } from "../../../shared/Patterns/markdown";
+import { useUnreleasedLabels } from "../../../shared/Docs/Unreleased";
 import "../../../shared/Patterns/patterns-docs.css";
 
 const META_DESCRIPTION =
@@ -52,7 +53,7 @@ function scope(s: { accent: { hex: string }; accentDeep: string }) {
 
 export default function PatternsLanding() {
   const router = useRouter();
-  const sections = getPatternSections();
+  const sections = getPatternSections(useUnreleasedLabels());
 
   if (router.query.view === "agent") {
     return (

--- a/shared/Patterns/_patterns/score-agent-accuracy.mdx
+++ b/shared/Patterns/_patterns/score-agent-accuracy.mdx
@@ -1,0 +1,97 @@
+---
+title: Score agent accuracy
+subtitle: Grade an agent against a known answer (exact match, set overlap, or numeric tolerance) and record the score on the run that produced it.
+pattern: ai-evals
+tags: [AI, Evals, Observability]
+unreleased: score
+---
+
+Agents fail quietly. A misrouted ticket, a wrong extracted value, or a fix that touched the wrong files looks like a successful run: no exception is thrown, the function returns `200`, and the trace is green. The only thing that went wrong is the answer.
+
+When you have ground truth (a labeled category, an expected value, the set of files a fix actually touched), accuracy is the most direct score you can record. You compare what the agent produced against the known answer and attach a `0`–`1` score to the run.
+
+Inngest records the score where the run already executed, so it sits next to the trace, inputs, and outputs that produced it. The known answer can be available at runtime, or it can arrive later as an outcome event. When it arrives later, you [score the run by its ID](/docs/features/inngest-functions/steps-workflows/scoring?ref=docs-patterns-score-agent-accuracy) instead of guessing at runtime.
+
+Use this pattern when you have a labeled set, a golden answer, or a verifiable result the agent should match: classification, extraction, routing, or file localization.
+
+## Which accuracy measure?
+
+| The answer is | Measure | Score |
+|---|---|---|
+| A single category or label | Exact match | `1` if equal, else `0` |
+| A set of items (files, tags, citations) | Overlap (Jaccard) | Fraction of the set the agent got right |
+| A number | Within tolerance | `1` inside the band, scaled or `0` outside |
+| Free text against a reference | Similarity | Embedding distance, or an LLM judge |
+
+The first three are exact, cheap, and deterministic. Reach for them whenever the answer has a definite shape:
+
+- **Exact match** fits a single category or label: score `1` when the agent's choice equals the known answer, else `0`. This is the measure for classification and routing.
+- **Overlap (Jaccard)** fits set-valued answers like cited files, extracted entities, or applied tags: score the fraction of the correct set the agent got, so partial credit tells you *how* wrong, not just *that* it was wrong. It's also the right shape for file localization, where you compare the files the agent proposed against the set the merged fix actually touched.
+- **Tolerance** fits numeric estimates and forecasts: score `1` inside an acceptable band, then decay toward `0` as the error grows.
+
+Free-text similarity is the fuzzy case; when there's no single correct string, grade it with a model instead (that's an LLM judge, not accuracy).
+
+## A worked example
+
+Define each measure once as a pure function, so the same check is reusable across functions and [experiment](/docs/patterns/ai-evals/run-experiments-in-production?ref=docs-patterns-score-agent-accuracy) variants:
+
+```typescript
+// measures.ts: define once, reuse everywhere
+export const exactMatch = (a: string, b: string): number => (a === b ? 1 : 0);
+
+// Jaccard: |intersection| / |union|, in [0, 1]
+export const jaccard = (a: string[], b: string[]): number => {
+  const A = new Set(a);
+  const B = new Set(b);
+  const shared = [...A].filter((x) => B.has(x)).length;
+  return shared / (A.size + B.size - shared);
+};
+
+// Full credit within `band`, decaying to 0 past it
+export const tolerance = (predicted: number, actual: number, band = 0.1) => {
+  const error = Math.abs(predicted - actual) / actual;
+  return error <= band ? 1 : Math.max(0, 1 - error);
+};
+```
+
+Then call the measure that matches your answer shape from inside the run, scoring only when ground truth is present so unlabeled production traffic doesn't drag the metric down:
+
+```typescript
+import { inngest } from "./client";
+import { exactMatch } from "./measures";
+
+export default inngest.createFunction(
+  { id: "route-ticket", triggers: { event: "support/ticket.created" } },
+  async ({ event, step }) => {
+    const team = await step.run("route", () => route(event.data));
+
+    if (event.data.knownTeam) {
+      await step.score("score-routing-accuracy", {
+        name: "routing-accuracy",
+        value: exactMatch(team, event.data.knownTeam),
+      });
+    }
+
+    return team;
+  }
+);
+```
+
+`step.score()` attaches the score to the current run. The first argument is a stable step `id`, which memoizes the score across retries and replays the same way `step.run()` IDs do; `name` is the series the score aggregates under in dashboards. Swap `exactMatch` for `jaccard` or `tolerance` when the answer is a set or a number.
+
+When the correct answer only emerges after the run finishes (a human corrects the output, a downstream system confirms the result), move the check into a [deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=docs-patterns-score-agent-accuracy) that waits for the outcome event and scores the original run by its ID.
+
+## Best practices
+
+- Only score accuracy when you actually have ground truth. If you're scoring against a model's opinion, that's an LLM judge, not accuracy. Keep the two as separate score names so the trends don't blur.
+- Prefer partial-credit measures (overlap, tolerance) over exact match for anything set- or value-shaped. They tell you how wrong, not just that it was wrong.
+- Keep the score name stable so accuracy stays in one trend series. A renamed score starts a new, disconnected line.
+- Give each score step a stable `id`. Like `step.run()`, it memoizes across retries and replays so a score isn't counted twice.
+- When the correct answer only emerges later, score the run by its `runId` instead of forcing a guess at runtime.
+
+## Related docs
+
+- [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring?ref=docs-patterns-score-agent-accuracy)
+- [Build a deferred scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring?ref=docs-patterns-score-agent-accuracy) for outcomes that arrive after the run
+- [`inngest.score()` reference](/docs/reference/typescript/v4/functions/scoring?ref=docs-patterns-score-agent-accuracy)
+- [Run experiments in production](/docs/patterns/ai-evals/run-experiments-in-production?ref=docs-patterns-score-agent-accuracy)

--- a/shared/Patterns/patternsData.ts
+++ b/shared/Patterns/patternsData.ts
@@ -12,6 +12,10 @@ export interface PatternItem {
   slug: string;
   title: string;
   subtitle: string;
+  // When set, the pattern is hidden until the viewer opts in with
+  // ?unreleased=<label> (see shared/Docs/Unreleased.tsx). Mirror this in the
+  // pattern's MDX frontmatter so the markdown/agent surfaces gate it too.
+  unreleased?: string;
 }
 
 export interface PatternSectionMeta {
@@ -181,6 +185,14 @@ export const PATTERNS: PatternIndexItem[] = [
       "Use group.experiment() to split traffic, keep cohorts stable, compare variants, and roll changes forward safely.",
   },
   {
+    category: "ai-evals",
+    slug: "score-agent-accuracy",
+    title: "Score agent accuracy",
+    subtitle:
+      "Grade an agent against a known answer (exact match, set overlap, or numeric tolerance) and record the score on the run that produced it.",
+    unreleased: "score",
+  },
+  {
     category: "flow",
     slug: "flash-sales-and-bursty-workflows",
     title: "Flash sales and bursty workflows",
@@ -232,12 +244,17 @@ export const PATTERNS: PatternIndexItem[] = [
 ];
 
 // Build the full sections-with-patterns list, in display order, dropping any
-// section that has no patterns.
-export function getPatternSections(): PatternSection[] {
+// section that has no patterns. Patterns gated behind `?unreleased=<label>` are
+// excluded unless their label is in `labels`. Defaults to no labels, so server
+// rendering and agent/markdown surfaces never expose unreleased patterns; pass
+// the active labels from useUnreleasedLabels() on the client to reveal them.
+export function getPatternSections(
+  labels: Set<string> = new Set()
+): PatternSection[] {
   return PATTERN_SECTIONS.flatMap((meta) => {
-    const patterns = PATTERNS.filter((p) => p.category === meta.id).map(
-      ({ slug, title, subtitle }) => ({ slug, title, subtitle })
-    );
+    const patterns = PATTERNS.filter((p) => p.category === meta.id)
+      .filter((p) => !p.unreleased || labels.has(p.unreleased))
+      .map(({ slug, title, subtitle }) => ({ slug, title, subtitle }));
     if (patterns.length === 0) return [];
     return [{ ...meta, patterns }];
   });


### PR DESCRIPTION
New AI Evals pattern explaining how to grade an agent against ground truth (exact match, Jaccard overlap, numeric tolerance) and record the score on the run that produced it.

Gated behind ?unreleased=score: hidden from the nav, landing, category pages, and the markdown/agent surfaces server-side, revealed client-side when the label is present. Adds an optional `unreleased` field to the pattern index and filters it through getPatternSections().