### PR TITLE
point sign-in back to app

### DIFF
--- a/components/v1/nav-config.ts
+++ b/components/v1/nav-config.ts
@@ -253,5 +253,6 @@ export const NAV_SECONDARY: NavItem[] = [
   },
 ];
 
-export const SIGN_IN_URL = process.env.NEXT_PUBLIC_SIGNIN_URL ?? "#";
+export const SIGN_IN_URL =
+  process.env.NEXT_PUBLIC_APP_HOST ?? process.env.NEXT_PUBLIC_SIGNIN_URL ?? "#";
 export const SIGN_UP_URL = process.env.NEXT_PUBLIC_SIGNUP_URL ?? "#";


### PR DESCRIPTION
Looks like the redesign pointed the main sign-in link to the sign-in page again. Users that use that button as their main login are starting to report being forced to sign in every time again. 