### PR TITLE
feat: global promo banner for Agent Evals

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -79,6 +79,13 @@ export default function RootLayout({
           href="/assets/v1/fonts/ABCWhyte-Regular.woff2"
           crossOrigin="anonymous"
         />
+        <link
+          rel="preload"
+          as="font"
+          type="font/woff2"
+          href="/assets/v1/fonts/ABCWhyteMono-Regular.woff2"
+          crossOrigin="anonymous"
+        />
         <link rel="stylesheet" href="https://fonts-cdn.inngest.com/fonts.css" />
         <Script
           id="js-inngest-queue-init"

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -1,11 +1,4 @@
 import React from "react";
-import { RiRocket2Fill } from "@remixicon/react";
-
-type Props = {
-  href: string;
-  children: React.ReactNode;
-  className?: string;
-};
 
 /**
   Hide the page banner on specific pages by including this at the top of page.tsx:
@@ -17,32 +10,41 @@ type Props = {
   `}</style>
  */
 
-const Banner: React.FC<Props> = ({ href, children, className }) => (
-  <a
-    href={href}
-    // use the .page-banner class to hide it on select pages via CSS
-    className={`page-banner group flex w-full items-center justify-center gap-2.5 border-b border-[rgb(var(--color-primary-subtle))]
-                px-6 py-2 text-base
-                text-basis transition-all ${className}`}
-    style={{
-      backgroundImage: `
-        linear-gradient(270deg, rgba(2, 117, 177, 0.80) 0%, rgba(21, 158, 136, 0.80) 0.02%, rgba(102, 189, 139, 0.80) 17.5%, rgba(45, 159, 101, 0.80) 100%)`,
-    }}
-  >
-    <span className="rotate-45">
-      <RiRocket2Fill className="h-4 w-4 group-hover:animate-[wiggle_200ms_ease-in-out_infinite]" />
-    </span>
-    <span>{children}</span>
-  </a>
-);
+// Matches the v1 feature card salmon: bg-v1-accent-salmon-gradient = rgb(247, 98, 70)
+const BANNER_BG = "rgb(247, 98, 70)";
+
+// Inline SVG feTurbulence noise — zero network request, seamlessly tileable at any scale.
+// Replaces the 203KB noise-dark.webp which pixelates badly on a thin full-width strip.
+const NOISE_BG =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.72' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='0.18'/%3E%3C/svg%3E\")";
 
 export default function AnnouncementBanner() {
   return (
-    <Banner href="/blog/ai-in-production-report-2026?ref=site-banner">
-      What are the most confident teams using to build AI? →{" "}
-      <strong className="underline underline-offset-2">
-        2026 Benchmark Report
-      </strong>
-    </Banner>
+    // hidden on mobile/tablet, flex on desktop (lg+). Server-rendered — no CLS, no LCP impact.
+    <div
+      className="page-banner relative hidden lg:flex w-full items-center justify-center overflow-hidden px-6 py-1.5 font-v1Heading text-sm text-white"
+      style={{ backgroundColor: BANNER_BG }}
+    >
+      {/* Inline SVG noise overlay — soft-light grain with zero added bytes or requests */}
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage: NOISE_BG,
+          backgroundSize: "200px 200px",
+          mixBlendMode: "soft-light",
+        }}
+      />
+      <span className="relative">
+        Introducing{" "}
+        <a
+          href="/blog/introducing-agent-evals?ref=site-banner"
+          className="font-semibold underline underline-offset-2 transition-opacity hover:opacity-80"
+        >
+          Agent Evals
+        </a>
+        : Score your agents on real outcomes.
+      </span>
+    </div>
   );
 }

--- a/components/v1/Header.tsx
+++ b/components/v1/Header.tsx
@@ -13,6 +13,7 @@ import Link from "@/components/v1/Link";
 import Button from "@/components/v1/Button";
 import Logo from "@/components/v1/Logo";
 import MobileMenu from "@/components/v1/MobileMenu";
+import AnnouncementBanner from "src/components/AnnouncementBanner";
 import NavMenuPanel from "@/components/v1/NavMenuPanel";
 import {
   NAV_PRIMARY,
@@ -235,6 +236,8 @@ export default function Header() {
       style={wipeFillStyle}
       data-ink-nav={inkNav ? "" : undefined}
     >
+      {/* Promo banner — hidden on /blog (LCP risk) and when header is compacted */}
+      {!compact && !pathname?.startsWith("/blog") && <AnnouncementBanner />}
       {/* Full-bleed container: the bar spans the full page width with
           only the gutters insetting it, so the left group (logo + nav)
           anchors to the left edge and the right group (Open Source /


### PR DESCRIPTION
Updates the global announcement banner to promote Agent Evals.

Changes:

- New copy + link to /blog/introducing-agent-evals?ref=site-banner
- Matches v1 design system: salmon-gradient bg (rgb(247,98,70)), font-v1Heading, inline SVG feTurbulence noise grain (zero network request — replaces 203KB webp approach from PR #1578)
- Desktop-only (hidden lg:flex) — no mobile layout impact
- Banner lives inside the fixed <header> on v1 pages — zero document-flow CLS risk
- Excluded from /blog/* routes (LCP sensitivity)
- Hides automatically when header compacts on scroll
- Added missing ABCWhyteMono-Regular.woff2 preload to app/layout.tsx — this font was already used by v1 Header nav items but wasn't preloaded, net improvement regardless of the banner