### PR TITLE
Document `group.parallel`/`waitForEvent` Interaction

### DIFF
--- a/pages/docs/features/inngest-functions/steps-workflows/wait-for-event.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/wait-for-event.mdx
@@ -160,6 +160,10 @@ Check out the [`step.wait_for_event()` Python reference.](/docs/reference/python
 
 
 <Callout variant={'warning'}>
+Inside a `group.parallel()` race, a losing `step.waitForEvent()` is not cancelled: it keeps the run active until its `timeout` is reached, so keep timeouts tight. See the [step parallelism guide](/docs/guides/step-parallelism) for details.
+</Callout>
+
+<Callout variant={'warning'}>
 **Preventing race conditions**
 
 The "wait for event" method begins listening for new events from when the code is executed. This means that events sent before the function is executed will not be handled by the wait.

--- a/pages/docs/guides/step-parallelism.mdx
+++ b/pages/docs/guides/step-parallelism.mdx
@@ -110,7 +110,7 @@ You can disable optimized parallelism by setting `optimizeParallelism: false` on
 
 **Important considerations:**
 
-- **`Promise.race` behavior**: With optimized parallelism (the default in v4), `Promise.race` waits for all parallel steps to complete before resolving. If you need early resolution behavior, use `group.parallel()`:
+- **`Promise.race` behavior**: With optimized parallelism (the default in v4), `Promise.race` waits for all parallel steps to complete before resolving. If you need early resolution behavior, use `group.parallel()`, though note that early resolution [does not cancel the remaining steps](#racing-steps-are-not-cancelled):
 
 ```ts
 const winner = await group.parallel(async () => {
@@ -189,6 +189,12 @@ async def fn(ctx: inngest.Context) -> None:
 **Without specifying `parallel_mode`**, the steps will run in the order: `a`, `x`, `b`, `y` (optimized mode). Everything is still correct, but step `b` doesn't run until step `x` completes.
 
 **With `parallel_mode=inngest.ParallelMode.RACE`**, the steps run in the expected order: `a`, `b`, `x`, `y`, but with the performance trade-off of more requests.
+
+### Racing steps are not cancelled
+
+Race mode changes *when* Inngest re-invokes your function: as soon as any step in the group settles, instead of waiting for all of them. The losing steps are *not* cancelled and continue to run.
+
+This is most visible with [`step.waitForEvent()`](/docs/features/inngest-functions/steps-workflows/wait-for-event). A losing `waitForEvent` remains an active server-side pause, so the run stays in a `Running` state until that wait reaches its own `timeout`, even though your function code proceeded past the race earlier. Because the losing wait's timeout bounds the run's lifetime, use the tightest `waitForEvent` timeout that works for your use case when racing waits.
 
 ## Chunking jobs
 

--- a/pages/docs/reference/typescript/v4/functions/step-wait-for-event.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-wait-for-event.mdx
@@ -88,14 +88,17 @@ Use `step.waitForEvent()` to pause your function's execution until a matching ev
 </Callout>
 
 <Callout variant="warning">
-  **No `in` operator support. Use multiple equality checks with `||` instead.** CEL's `in` operator is not supported with `if` expressions, instead, use multiple equality checks (`==`) with an or operator (`||`) to achieve the same result.
+**No `in` operator support. Use multiple equality checks with `||` instead.** CEL's `in` operator is not supported with `if` expressions, instead, use multiple equality checks (`==`) with an or operator (`||`) to achieve the same result.
 
-  {`// Do not use this:
-  // async.data.function_id in ["app-test-a", "app-test-b"]
-  // Use this:
-  (async.data.function_id == "app-test-a" || async.data.function_id == "app-test-b")`}
+```plaintext
+// Do not use this:
+// async.data.function_id in ["app-test-a", "app-test-b"]
 
-  See [GitHub issue #3907](https://github.com/inngest/inngest/issues/3907) for tracking.
+// Use this:
+(async.data.function_id == "app-test-a" || async.data.function_id == "app-test-b")
+```
+
+See [GitHub issue #3907](https://github.com/inngest/inngest/issues/3907) for tracking.
 </Callout>
 
 <Callout>

--- a/pages/docs/reference/typescript/v4/functions/step-wait-for-event.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-wait-for-event.mdx
@@ -97,3 +97,7 @@ Use `step.waitForEvent()` to pause your function's execution until a matching ev
 
   See [GitHub issue #3907](https://github.com/inngest/inngest/issues/3907) for tracking.
 </Callout>
+
+<Callout>
+  Inside a `group.parallel()` race, a losing `step.waitForEvent()` is not cancelled: it remains an active pause and keeps the run in a `Running` state until its `timeout` is reached. See the [step parallelism guide](/docs/guides/step-parallelism) for details.
+</Callout>

--- a/pages/docs/reference/typescript/v4/migrations/v3-to-v4.mdx
+++ b/pages/docs/reference/typescript/v4/migrations/v3-to-v4.mdx
@@ -292,7 +292,7 @@ If the `serve` function does not support streaming then it throws an error. Prev
 
 "Optimized parallelism" significantly reduces the number of requests necessary to run parallel steps (steps in `Promise.all`, `Promise.allSettled`, etc.). This decrease in requests can dramatically improve CPU usage, memory usage, and function run duration.
 
-The primary downside is the change in `Promise.race` behavior. `Promise.race` will wait for *all* promises to settle before resolving. The correct "winner" is returned, but the `Promise.race` will *not* immediately resolve on the first winner. If you were relying on the early resolution behavior, use the new `group.parallel()` helper. This will disable optimized parallelism for groups of steps:
+The primary downside is the change in `Promise.race` behavior. `Promise.race` will wait for *all* promises to settle before resolving. The correct "winner" is returned, but the `Promise.race` will *not* immediately resolve on the first winner. If you were relying on the early resolution behavior, use the new `group.parallel()` helper. This will disable optimized parallelism for groups of steps. Note that early resolution does not cancel the remaining steps; see the [step parallelism guide](/docs/guides/step-parallelism) for details:
 
 ```typescript
 // Old behavior (no longer works as expected with optimized parallelism)


### PR DESCRIPTION
Add documentation that covers how `group.parallel({ mode: "race" })` and `waitForEvent` interact with one another, based on the issues encountered by this user: https://github.com/inngest/inngest-js/issues/1617