### PR TITLE
Replace roadmap links

### DIFF
--- a/components/RedesignedLanding/FooterLinks.tsx
+++ b/components/RedesignedLanding/FooterLinks.tsx
@@ -52,10 +52,6 @@ export const navigation = {
   company: [
     { name: "Blog", href: "/blog?ref=footer-links" },
     { name: "Changelog", href: "/changelog?ref=footer-links" },
-    {
-      name: "Roadmap",
-      href: "https://roadmap.inngest.com/roadmap?ref=footer-links",
-    },
     { name: "About", href: "/about?ref=footer-links" },
     { name: "Careers", href: "/careers?ref=footer-links" },
   ],

--- a/components/v1/sections/ContactForm/topics.ts
+++ b/components/v1/sections/ContactForm/topics.ts
@@ -20,7 +20,7 @@ export const GENERAL_TOPICS: Topic[] = [
   },
   {
     title: "Community & Questions",
-    body: "Questions about how Inngest works? Our Discord community — including the team — is the fastest way to get answers.",
+    body: "Questions about how Inngest works? Our Discord community is the fastest way to get answers.",
     action: {
       label: "Join us on Discord",
       href: "https://www.inngest.com/discord",

--- a/content/blog/2023-12-22-2023-wrapped.mdx
+++ b/content/blog/2023-12-22-2023-wrapped.mdx
@@ -19,7 +19,7 @@ Meanwhile, we’d like to invite you to join us for our last retrospective.
 
 ## Engineering
 
-We made tons of progress this year and each milestone was a testament of the work to our world-class team. Reading back the [changelog](https://roadmap.inngest.com/changelog) from the year makes it seem like every week we shipped new major features, tools, and improvements. But what if I told you that we actually did that, and that’s not even the full picture?
+We made tons of progress this year and each milestone was a testament of the work to our world-class team. Reading back the [changelog](https://www.inngest.com/changelog?ref=blog) from the year makes it seem like every week we shipped new major features, tools, and improvements. But what if I told you that we actually did that, and that’s not even the full picture?
 
 The list of releases is quite long so let’s focus only on the milestones.
 

--- a/content/blog/2024-01-12-extending-the-range-of-your-astro-app.mdx
+++ b/content/blog/2024-01-12-extending-the-range-of-your-astro-app.mdx
@@ -87,7 +87,7 @@ Being language and framework agnostic, Inngest works across your entire system. 
 
 You can also [send an event](/docs/events) from an Astro site that triggers an Inngest function in *another* codebase.
 
-In other words, a function owned by the product team can live in the Astro site and other functions in your backend codebase. At the moment, Inngest has three SDKs available ([TypeScript/JavaScript](/docs/reference/typescript), [Python](/docs/reference/python), [Go](https://pkg.go.dev/github.com/inngest/inngestgo)) but others are planned as well -- check [our roadmap](https://roadmap.inngest.com/roadmap).
+In other words, a function owned by the product team can live in the Astro site and other functions in your backend codebase. At the moment, Inngest has three SDKs available ([TypeScript/JavaScript](/docs/reference/typescript), [Python](/docs/reference/python), [Go](https://pkg.go.dev/github.com/inngest/inngestgo)) but others are planned as well.
 
 ## Get started now
 

--- a/content/blog/announcing-batch-keys.mdx
+++ b/content/blog/announcing-batch-keys.mdx
@@ -85,4 +85,4 @@ The `sendPostLikesNotifications()` is now called with post-specific batches, as 
 
 With enhanced batch composition, you can now create batches that perfectly match your product needs. No custom logic, no fairness issues. Keep building great features with confidence.
 
-Batch Keys is a unique feature that tackles complex use cases while improving the developer experience. Take a [look and participate in our roadmap](https://roadmap.inngest.com/roadmap?ref=footer) as we continue to push the limits of Inngest's Flow Control capabilities!
+Batch Keys is a unique feature that tackles complex use cases while improving the developer experience. Take a look as we continue to push the limits of Inngest's Flow Control capabilities!

--- a/content/blog/announcing-function-runs-search.mdx
+++ b/content/blog/announcing-function-runs-search.mdx
@@ -10,7 +10,7 @@ author: Tony Holdstock-Brown
 category: product-updates
 ---
 
-Today, we're excited to release one of our [most requested features](https://roadmap.inngest.com/roadmap): **Function Run Search**. We've had this in our beta program for a few weeks with hugely positive feedback.
+Today, we're excited to release one of our most requested features: **Function Run Search**. We've had this in our beta program for a few weeks with hugely positive feedback.
 Let's talk about what you're getting.
 
 The Inngest Platform Runs view now features a search bar similar to the traditional log search experiences you've probably already encountered. This search bar lets you **search and filter runs** based on:

--- a/content/blog/announcing-inngest-seed-financing.mdx
+++ b/content/blog/announcing-inngest-seed-financing.mdx
@@ -43,7 +43,7 @@ This approach enables Inngest to support serverless platforms like Vercel, class
 
 We're leveraging this new capital to make it easier for every developer to ship reliable workflows without thinking about infrastructure.
 
-We've started by growing our world class team and [our roadmap is full with new functionality](https://roadmap.inngest.com/roadmap) that will enable you to build better products, faster. We're planning on building on our foundation to include support for real-time event forwarding, subscriptions, batch processing, bulk job replay, and new language SDKs.
+We've started by growing our world class team and our roadmap is full with new functionality that will enable you to build better products, faster. We're planning on building on our foundation to include support for real-time event forwarding, subscriptions, batch processing, bulk job replay, and new language SDKs.
 
 Our mission is to enable all developers to build complex systems faster and easier than ever.
 

--- a/content/blog/announcing-metrics-export.mdx
+++ b/content/blog/announcing-metrics-export.mdx
@@ -48,5 +48,3 @@ Get started with the [Prometheus integration](/docs/platform/monitor/prometheus-
 The observability of Inngest Functions is constantly evolving. Here is a glimpse of what we are working on:
 - **Alerting**: we are working on an alerting feature, allowing you to create alerts in the Inngest dashboard.
 - **More metrics**: We are also exploring the possibility of including [our AI traces](/blog/ai-orchestration-with-agentkit-step-ai) in these integrations.
-
-All Inngest features are built with the community in mind. If you have any feature requests, please vote or submit them on our [roadmap page](https://roadmap.inngest.com/roadmap).

--- a/content/blog/announcing-replay-the-death-of-the-dead-letter-queue.mdx
+++ b/content/blog/announcing-replay-the-death-of-the-dead-letter-queue.mdx
@@ -73,7 +73,7 @@ Combined together, we can easily query for all jobs between two timestamps and f
 
 We call this **Replay**. In other words, it's peace of mind that comes with every single Inngest plan, including the free tier. You can use Replay today in every Inngest account or learn how to use this feature in [our guide](https://www.inngest.com/docs/platform/replay).
 
-Once you try it, we would love to hear what you think. [Share your feedback or](https://roadmap.inngest.com/) [reach out on Discord!](/discord)
+Once you try it, we would love to hear what you think. Share your feedback or [reach out on Discord!](/discord)
 
 ## What's next
 

--- a/content/blog/announcing-step-fetch.mdx
+++ b/content/blog/announcing-step-fetch.mdx
@@ -111,4 +111,4 @@ Inngest's `fetch()` and `step.fetch()` APIs are available in our TypeScript SDK.
 
 Get started by reading the [Fetch documentation](/docs/features/inngest-functions/steps-workflows/fetch) and by checking out the [examples](/docs/examples/fetch).
 
-`step.fetch()` is a unique feature that tackles complex use cases while improving the developer experience. Take a [look and participate in our roadmap](https://roadmap.inngest.com/roadmap?ref=footer) as we continue to push the limits of Inngest's APIs!
+`step.fetch()` is a unique feature that tackles complex use cases while improving the developer experience. Take a [look at our changelog](https://www.inngest.com/changelog?ref=blog) as we continue to push the limits of Inngest's APIs!

--- a/content/blog/branch-environments.mdx
+++ b/content/blog/branch-environments.mdx
@@ -57,7 +57,7 @@ The modern stack of developer tools should align with developer workflows, not a
 
 [Check out our documentation](/docs/platform/environments?ref=blog-branch-environments) to learn how to set this up for any of our supported platforms, from Netlify to AWS Lambda to a custom Kubernetes setup. Everyone can benefit from the advantages of this workflow!
 
-Give it a try and drop us a [line on Discord](https://www.inngest.com/discord) if you have any questions or share some feedback or feature requests on [our public roadmap here](http://roadmap.inngest.com/).
+Give it a try and drop us a [line on Discord](https://www.inngest.com/discord).
 
 ## Updates: What's changed since this blog was published
 

--- a/content/blog/building-the-inngest-queue-pt-i-fairness-multi-tenancy.mdx
+++ b/content/blog/building-the-inngest-queue-pt-i-fairness-multi-tenancy.mdx
@@ -38,7 +38,7 @@ In this series of blog posts, we'll explain how the queueing system works and th
 
 ## How reliability layers use queues
 
-To set context, let's walk through how Inngest uses a queue, with an example function configuration using our [TS SDK](/docs/reference/typescript) ([Go](https://pkg.go.dev/github.com/inngest/inngestgo) and [Python](/docs/reference/python) SDKs are also available, with [more coming soon](https://roadmap.inngest.com/roadmap)):
+To set context, let's walk through how Inngest uses a queue, with an example function configuration using our [TS SDK](/docs/reference/typescript) ([Go](https://pkg.go.dev/github.com/inngest/inngestgo) and [Python](/docs/reference/python) SDKs are also available, with more coming soon):
 
 ```tsx
 inngest.createFunction(

--- a/content/blog/cross-language-support-with-new-sdks.mdx
+++ b/content/blog/cross-language-support-with-new-sdks.mdx
@@ -26,8 +26,6 @@ We have just official released our [Python](/docs/reference/python) and [Go](htt
 
 The Inngest SDKs provide a language- and cloud-agnostic way to create fault-tolerant, long-running functions with built-in flow control.
 
-👉 *Is your favorite language not included here? We want to hear from you! [Vote for your language of choice](https://roadmap.inngest.com/roadmap).*
-
 Because of how the Inngest architecture works, state is decoupled from your application using our SDKs. The state of your functions are stored within Inngest and the SDKs handle the communication with our APIs. This includes how state functions are triggered, results of steps are sent back to Inngest, and how state from previous steps is injected into your function (memoization). Because of this, the SDK logic does not need to be burdened by managing state — it’s just a chain of HTTP request and responses.
 
 This design makes the SDKs light weight and the communication layer is thin, only requiring HTTP. This makes it easier, and faster, to create new language SDKs. If you want to learn more about how state works in Inngest how it is enabled in the SDKs, read our [open source SDK spec](https://github.com/inngest/inngest/blob/main/docs/SDK_SPEC.md).

--- a/content/blog/edge-event-api-beta.mdx
+++ b/content/blog/edge-event-api-beta.mdx
@@ -43,7 +43,7 @@ These are the essential requirements in addition to the features already built i
 
 ## How to join the beta
 
-You can be first in line to try the new Event API by upvoting the project [directly on our roadmap](https://roadmap.inngest.com/roadmap?id=cddffcf8-47ba-44ac-a6c3-dd318f9eb132) with your Inngest account email. Please share any context on your application that you’d like to start using it for. Additionally, if you just want to be notified when the feature comes out of beta for wide usage, [add your email here](/newsletter?tag=beta-event-api).
+You can be first in line to try the new Event API by upvoting the project with your Inngest account email. Please share any context on your application that you’d like to start using it for. Additionally, if you just want to be notified when the feature comes out of beta for wide usage, [add your email here](/newsletter?tag=beta-event-api).
 
 We're planning to roll this out first for sending events via [our SDKs](/blog/cross-language-support-with-new-sdks) or [HTTP](/docs/events#send-events-via-http-event-api). Due to the requirements for [transforms](/docs/platform/webhooks#defining-a-transform-function), webhooks will not be part of this beta. **Update (2025):** Since this post, we've shipped significant webhook enhancements including support for form-urlencoded and multipart/form-data content types (Oct 2025) and a Webhook Management API for programmatic control (Nov 2025). [Learn more](/docs/platform/webhooks)
 

--- a/content/blog/enhanced-observability-traces-and-metrics.mdx
+++ b/content/blog/enhanced-observability-traces-and-metrics.mdx
@@ -121,7 +121,7 @@ AI assistants can now:
 
 By combining the new trace experience with a monitoring dashboard, we're equipping you with powerful tools to manage, monitor, and troubleshoot your durable functions with effortless control. The ability to see both detailed execution traces and a holistic view of system health means you can move seamlessly between resolving function-level issues and addressing broader system-wide concerns.
 
-These updates reflect our commitment to improving observability and giving developers the tools they need to build resilient, durable workflows. As we continue to expand Inngest's capabilities, we'd love to hear your [feedback](https://roadmap.inngest.com/roadmap) to make sure we're meeting the needs of your team.
+These updates reflect our commitment to improving observability and giving developers the tools they need to build resilient, durable workflows. As we continue to expand Inngest's capabilities, we'd love to hear your feedback to make sure we're meeting the needs of your team.
 
 **Start using these new features today** and experience a new level of visibility and control over your applications. Whether you're troubleshooting a specific function or monitoring your entire system, these enhancements are designed to make your job easier and more efficient.
 

--- a/content/blog/inngest-1-0-announcing-self-hosting-support.mdx
+++ b/content/blog/inngest-1-0-announcing-self-hosting-support.mdx
@@ -103,7 +103,7 @@ As mentioned above, there are some upcoming features that will be added or impro
 * Event key and signing key management \- [Event keys](https://www.inngest.com/docs/events/creating-an-event-key) and [signing keys](https://www.inngest.com/docs/platform/signing-keys) are used to authenticate client applications that use Inngest SDKs or send events via HTTP. Future releases will add management via the bundled dashboard UI and APIs.
 * Multi-node Inngest server support \- At initial release, the `inngest start` command runs all services in a single process. In a future release, the command will support starting one or more services (API, Executor, etc.) instead of all services in a single process.
 
-What do you want to see? Submit your ideas via our [public roadmap](https://roadmap.inngest.com/roadmap).
+What do you want to see? Submit your ideas via our [support platform](https://support.inngest.com/).
 
 ## Updated licensing
 

--- a/content/blog/launch-week-recap.mdx
+++ b/content/blog/launch-week-recap.mdx
@@ -11,7 +11,7 @@ disableCTA: true
 
 Today marks the end of our first Launch Week. We shipped numerous features that significantly improve Inngest DX such as Replay, bulk cancellation, cross-language support, per-step error handling in our SDKs, and two new SDK betas (Python and Go).
 
-These were much-requested features from our Community. We hear your feedback and ideas, and they inform our [roadmap](https://roadmap.inngest.com/). Thank you 💜
+These were much-requested features from our Community. We hear your feedback and ideas, and they inform our roadmap. Thank you 💜
 
 But that's not all. This week, we also launched a partnership with Clerk to make auth workflows easier, and Svix to simplify Inngest integrations for webhook providers.
 
@@ -134,7 +134,7 @@ You can now use language-native features like try/catch to gracefully handler er
 
 We are introducing a closed beta for our new Edge Event API Beta to reduce latency for users worldwide by implementing regional replication, caching, and payload validation, targeting response times below 100ms. Early testing reveals substantial improvements, with response times reduced by 46-85% in various regions.
 
-To try the new Event API upvote the project [directly on our roadmap](https://roadmap.inngest.com/roadmap?id=cddffcf8-47ba-44ac-a6c3-dd318f9eb132) with your Inngest account email and share any context on your application that you’d like to start using it for. Additionally, if you just want to be notified when the feature comes out of beta for wide usage, [add your email here](/newsletter?tag=beta-event-api).
+To try the new Event API upvote the project with your Inngest account email and share any context on your application that you’d like to start using it for. Additionally, if you just want to be notified when the feature comes out of beta for wide usage, [add your email here](/newsletter?tag=beta-event-api).
 
 ➡️ Read ["Edge Event API Beta: Lower latency from everywhere"](/blog/edge-event-api-beta) blog post.
 
@@ -144,7 +144,5 @@ To try the new Event API upvote the project [directly on our roadmap](https://ro
 ## What's next?
 
 The Launch Week is over but we are not stopping here! We already have next announcements and releases lined up, starting next week.
-
-If you're curious what we are working on, please check (and comment on!) our [public roadmap](https://roadmap.inngest.com/).
 
  We wouldn’t be where we are now without you, your questions, feedback, and feature requests. Join [our Discord](/discord) and help shape the future of Inngest 💜

--- a/content/blog/reimagining-information-architecture.mdx
+++ b/content/blog/reimagining-information-architecture.mdx
@@ -81,5 +81,3 @@ The Monitor grouping offers tools for debugging, troubleshooting, and observing 
 
 
 We have many exciting features in the works, and we'll continue to share updates and insights into our design process. Stay tuned for more from the Inngest team as we enhance the developer experience.
-
-And, of course, we would love to hear any and every piece of feedback you have! Share it with us on [Discord](https://www.inngest.com/discord?ref=blog) or [our roadmap](https://roadmap.inngest.com/roadmap).

--- a/content/blog/svix-integration.mdx
+++ b/content/blog/svix-integration.mdx
@@ -59,4 +59,4 @@ If you're a Svix customer, today you can set up the Inngest transformation templ
 
 If you're a user of one of the many product's whose webhooks are [powered by Svix](https://www.svix.com/), you can request they add the Inngest transformation template today.
 
-We're excited to see how more folks leverage Svix and Inngest together in the future to build amazing developer platforms! Please drop us [any feedback](https://roadmap.inngest.com/) that you have along the way :)
+We're excited to see how more folks leverage Svix and Inngest together in the future to build amazing developer platforms!

--- a/pages/docs/features/events-triggers/neon.mdx
+++ b/pages/docs/features/events-triggers/neon.mdx
@@ -97,4 +97,4 @@ Inngest will setup and connect to your Neon Database automatically. It will crea
 />
 
 ## Local development *(coming soon)*
-For information about our plans check our [public roadmap.](https://roadmap.inngest.com/roadmap)
+We post updates on new features as soon as they ship - check our [changelog.](https://www.inngest.com/changelog?ref=docs-neon)

--- a/pages/docs/reference/typescript/v3/functions/step-invoke.mdx
+++ b/pages/docs/reference/typescript/v3/functions/step-invoke.mdx
@@ -184,7 +184,6 @@ The invoked function will be executed as a regular Inngest function: it will hav
 
 If a `step.invoke()` fails for any of the reasons below, it will throw a `NonRetriableError`. This is to combat compounding retries, such that chains of invoked functions can be executed many more times than expected. For example, if A invokes B which invokes C, which invokes D, on failure D would be run 27 times (`retryCount^n`).
 
-This may change on the future - [let us know](https://roadmap.inngest.com/roadmap?ref=docs) if you'd like to change this.
 
 ## Error handling
 

--- a/pages/docs/reference/typescript/v4/functions/step-invoke.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-invoke.mdx
@@ -195,7 +195,6 @@ The invoked function will be executed as a regular Inngest function: it will hav
 
 If a `step.invoke()` fails for any of the reasons below, it will throw a `NonRetriableError`. This is to combat compounding retries, such that chains of invoked functions can be executed many more times than expected. For example, if A invokes B which invokes C, which invokes D, on failure D would be run 27 times (`retryCount^n`).
 
-This may change on the future - [let us know](https://roadmap.inngest.com/roadmap?ref=docs) if you'd like to change this.
 
 ## Error handling
 

--- a/pages/docs/release-phases.mdx
+++ b/pages/docs/release-phases.mdx
@@ -42,13 +42,6 @@ Developer preview features or products cheat sheet:
 | Limitations | May come with limitations specific to the feature, such as plan-based or usage-based restrictions |
 | Pricing | Limited free availability during preview phase |
 
-Features or products currently in developer preview:
-
-- [Realtime](/docs/features/realtime)
-- [Connect](/docs/setup/connect)
-- [AgentKit](https://agentkit.inngest.com/)
-
-
 
 ### Private/Public Beta
 
@@ -101,15 +94,15 @@ The deprecation of features or products follows the following agenda over multip
 
 ## FAQ
 
-### How feedback are collected during the developer preview phase?
+### How is feedback collected during the developer preview phase?
 
 During the Developer Preview and Public beta phases, we collect feedback from users and customers over our Discord channel.
 
-Feedback from GA and private beta phases are collected over our private support Slack channel, our Discord channel and our [support portal](https://app.inngest.com/support).
+Feedback from GA and private beta phases is collected over our private support Slack channel, our Discord channel and our [support portal](https://app.inngest.com/support).
 
 
 ### How can I stay updated on the release of new features and products?
 
 You can follow us on [Twitter](https://x.com/inngest) or [Discord](https://discord.gg/inngest) to get notified when new features and products are released.
 
-You can also subscribe to our [newsletter](https://inngest.com/newsletter) to get notified when new features and products are released.
+You can also check out our [changelog](https://www.inngest.com/changelog?ref=docs-release-phases) for a running history of updates, or subscribe to our [newsletter](https://inngest.com/newsletter) to get release announcements straight to your inbox.

--- a/pages/docs/setup/connect.mdx
+++ b/pages/docs/setup/connect.mdx
@@ -47,7 +47,7 @@ If using TypeScript, your runtime must support built-in WebSocket support (Node 
 
 ## Getting started
 
-Using `connect` with your app is simple. Using each SDK's "connect" method only requires a list of functions that are available to be executed. (Note: Python support is in beta; [upvote on our roadmap](https://roadmap.inngest.com/roadmap?id=2bac8d74-288f-47c7-8afc-3fd1a0e94654))
+Using `connect` with your app is simple. Using each SDK's "connect" method only requires a list of functions that are available to be executed. (Note: Python support is in beta)
 
 Here is a one-file example of a fully-functioning app that connects to Inngest.
 

--- a/shared/Footer/footerLinks.ts
+++ b/shared/Footer/footerLinks.ts
@@ -67,10 +67,6 @@ const footerLinks = [
         url: "/blog?ref=footer",
       },
       {
-        label: "Roadmap",
-        url: "https://roadmap.inngest.com/roadmap?ref=footer",
-      },
-      {
         label: "Changelog",
         url: "/changelog?ref=footer",
       },


### PR DESCRIPTION
We're no longer using productlane for roadmap and user feedback, so updating the links.