### PR TITLE
chore: Remove outdated LIKE limitation callout in insights docs

### DIFF
--- a/pages/docs/platform/monitor/insights.mdx
+++ b/pages/docs/platform/monitor/insights.mdx
@@ -126,7 +126,7 @@ The `runs` table contains data about your function executions. This allows you t
 </Info>
 
 <Warning>
-  Due to a limitation with `function_id` and `app_id`, you will not be able to query on partial strings (e.g., using `LIKE`) and sorting may be out of order.
+  Due to a limitation with `function_id` and `app_id`, sorting may be out of order.
 </Warning>
 
 ### Steps & Step Attempts Tables
@@ -158,7 +158,7 @@ The `steps` and `step_attempts` tables contain data about your functions' step e
 </Info>
 
 <Warning>
-  Due to a limitation with `function_id` and `app_id`, you will not be able to query on partial strings (e.g., using `LIKE`) and sorting may be out of order.
+  Due to a limitation with `function_id` and `app_id`, sorting may be out of order.
 </Warning>
 
 ### Extended Trace Spans Table
@@ -192,7 +192,7 @@ The `extended_trace_spans` table contains [Extended Trace](/docs/platform/monito
 </Info>
 
 <Warning>
-  Due to a limitation with `function_id` and `app_id`, you will not be able to query on partial strings (e.g., using `LIKE`) and sorting may be out of order.
+  Due to a limitation with `function_id` and `app_id`, sorting may be out of order.
 </Warning>
 
 ### Metadata Table


### PR DESCRIPTION
The function_id/app_id LIKE query limitation no longer applies. The sorting/ordering caveat since that still holds.