### PR TITLE
Add docs about homebrew installation

### DIFF
--- a/pages/docs/cli.mdx
+++ b/pages/docs/cli.mdx
@@ -1,4 +1,4 @@
-import { Callout, CodeGroup } from "src/shared/Docs/mdx";
+import { CodeGroup } from "src/shared/Docs/mdx";
 
 
 export const metaTitle = "Inngest CLI"
@@ -14,6 +14,9 @@ npx inngest-cli@latest
 ```
 ```bash {{ title: "brew" }}
 brew install inngest/tap/inngest
+
+# If Homebrew warns about untrusted taps, run this and then install again
+brew trust --cask inngest/tap/inngest
 ```
 ```bash {{ title: "curl" }}
 curl -sfL https://cli.inngest.com/install.sh | sh

--- a/pages/docs/faq.mdx
+++ b/pages/docs/faq.mdx
@@ -1,4 +1,6 @@
 
+import { CodeGroup } from "src/shared/Docs/mdx";
+
 export const metaTitle = "Inngest FAQ | Frequently Asked Questions"
 export const description = "Answers to common Inngest questions: cron configuration, stopping functions, branch environment keys, timeouts, authentication, data redaction, and more."
 
@@ -19,6 +21,7 @@ export const description = "Answers to common Inngest questions: cron configurat
 - [Why am I getting an `Illegal invocation` error?](#why-am-i-getting-an-illegal-invocation-error)
 - [Why am I getting an `Invalid signature` error on my runs?](#why-am-i-getting-an-invalid-signature-error-on-my-runs)
 - [Why is the dev server polling endpoints that don't exist?](#why-is-the-dev-server-polling-endpoints-that-don-t-exist)
+- [Why doesn't the Dev Server do anything when I start it?](#why-doesn-t-the-dev-server-do-anything-when-i-start-it)
 
 ## How do I run crons only in production?
 
@@ -142,11 +145,24 @@ Learn more about this in the [dev server](/docs/dev-server#auto-discovery) docs.
 
 ## Why doesn't the Dev Server do anything when I start it?
 
-If the Dev Server command (`inngest dev`) doesn't do anything, it might be because you've installed via `npx` and disabled npm install scripts. Instead, you can use our bash installer which installs the binary from our GitHub repository:
+If the Dev Server command (`inngest dev`) doesn't do anything, it might be because you've installed via `npx` and disabled npm install scripts. Instead, install the binary directly with our bash installer or Homebrew:
 
+<CodeGroup>
 ```shell  {{ title: "Bash installer" }}
 # Install the CLI - follow the steps to complete install:
 curl -sSfL https://cli.inngest.com/install.sh | sh
+
 # Run the dev server
 inngest dev -u http://localhost:4321/api/inngest
 ```
+```shell {{ title: "brew" }}
+# Install the CLI:
+brew install inngest/tap/inngest
+
+# If Homebrew warns about untrusted taps, run this and then install again
+brew trust --cask inngest/tap/inngest
+
+# Run the dev server
+inngest dev -u http://localhost:4321/api/inngest
+```
+</CodeGroup>

--- a/pages/docs/getting-started/python-quick-start.mdx
+++ b/pages/docs/getting-started/python-quick-start.mdx
@@ -102,6 +102,17 @@ Start the Dev Server:
 ```shell  {{ title: "Bash installer" }}
 # Install the CLI - follow the steps to complete install:
 curl -sSfL https://cli.inngest.com/install.sh | sh
+
+# Run the dev server
+inngest dev -u http://localhost:8000/api/inngest
+```
+```shell {{ title: "brew" }}
+# Install the CLI:
+brew install inngest/tap/inngest
+
+# If Homebrew warns about untrusted taps, run this and then install again
+brew trust --cask inngest/tap/inngest
+
 # Run the dev server
 inngest dev -u http://localhost:8000/api/inngest
 ```

--- a/pages/docs/local-development.mdx
+++ b/pages/docs/local-development.mdx
@@ -28,6 +28,17 @@ You can start the dev server with a single command. The dev server will attempt 
 ```shell  {{ title: "Bash installer" }}
 # Install the CLI - follow the steps to complete install:
 curl -sSfL https://cli.inngest.com/install.sh | sh
+
+# Run the dev server
+inngest dev -u http://localhost:3000/api/inngest
+```
+```shell {{ title: "brew" }}
+# Install the CLI:
+brew install inngest/tap/inngest
+
+# If Homebrew warns about untrusted taps, run this and then install again
+brew trust --cask inngest/tap/inngest
+
 # Run the dev server
 inngest dev -u http://localhost:3000/api/inngest
 ```


### PR DESCRIPTION
Added to pages where it made sense to call out homebrew, especially in
non JS setups.

Homebrew is currently adding tap trusting, so I added a warning about
it after. It can be confusing if it's the first line because it'll error
on older versions of homebrew.. Once more users are on updated homebrew
versions we can change the order of the commands.

For some reason we already had a homebrew section in the CLI even though
it wasn't ready, so I just added the trust line there.
