### PR TITLE
Remove placeholder tile from Agent Observability tab

### DIFF
--- a/components/v1/sections/Home/ScaleInstantly.tsx
+++ b/components/v1/sections/Home/ScaleInstantly.tsx
@@ -181,13 +181,6 @@ const OBSERVABILITY_CONTENT: TabContent = {
       body: "Group multiple agent loops or turns as a single conversation, thread, or however you choose.",
       ...icon(4),
     },
-    // TODO(jb): the source listed “Scoring” twice — replace this sixth tile
-    // with the intended capability.
-    {
-      title: "[Needs copy]",
-      body: "[Placeholder] Sixth Agent Observability capability goes here.",
-      ...icon(5),
-    },
   ],
 };
 


### PR DESCRIPTION
Removes the leftover `[Needs copy]` placeholder capability tile from the homepage "Durability belongs in code" → **Agent Observability** tab.

The tab now shows the five real capabilities: Scoring, Live Experiments, 100% not 1%, Datasets, Sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)