### PR TITLE
Add /ai-conf vanity redirect for OOH signage campaign (ai-conf-0926)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -360,6 +360,13 @@ async function redirects() {
         "/?utm_medium=ooh&utm_source=car-wrap-sf&utm_campaign=aiewf-2026",
       permanent: false,
     },
+    // OOH campaign - AI conference signage (Sept 2026)
+    {
+      source: "/ai-conf",
+      destination:
+        "/?utm_medium=ooh&utm_source=signage&utm_campaign=ai-conf-0926",
+      permanent: false,
+    },
   ];
 }
 


### PR DESCRIPTION
Adds a 302 redirect for a new vanity URL, following the same pattern as the /sf redirect (#1619).

/ai-conf → /?utm_medium=ooh&utm_source=signage&utm_campaign=ai-conf-0926
Temporary redirect (permanent: false), for a time-boxed OOH signage campaign (Sept 2026)

No other changes.