### PR TITLE
Add Agent Evals demo video (CTA on platform page + docs link)

### DIFF
--- a/components/v1/VideoModal.tsx
+++ b/components/v1/VideoModal.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Modal from "@/components/v1/Modal";
+
+/**
+ * Reusable on-page YouTube lightbox. Built on the shared `Modal` shell
+ * (Headless UI Dialog — focus trap, ESC/click-outside, scroll lock).
+ *
+ * Perf/UX rationale (vs. linking out to YouTube):
+ *   - Keeps visitors on the page instead of bouncing them to
+ *     youtube.com (better for conversion + engagement metrics).
+ *   - The iframe is only rendered while `open` is true, and the Dialog
+ *     unmounts its panel content on close — so nothing YouTube-related
+ *     loads until the CTA is actually clicked, and playback stops the
+ *     moment the modal closes. Zero impact on this page's initial
+ *     load, LCP, or JS bundle.
+ *   - Uses `youtube-nocookie.com`, which skips YouTube's
+ *     tracking-cookie playback mode — lighter and more privacy-friendly
+ *     than a standard embed.
+ */
+export default function VideoModal({
+  open,
+  onClose,
+  videoId,
+  title,
+}: {
+  open: boolean;
+  onClose: () => void;
+  /** YouTube video ID (the part after `youtu.be/` or `?v=`). */
+  videoId: string;
+  /** Accessible name for the dialog + iframe title. */
+  title: string;
+}) {
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      label={title}
+      maxWidthClassName="max-w-[960px]"
+    >
+      <div className="overflow-hidden rounded-[10px] border border-v1-frost/10 bg-v1-jetBlack shadow-2xl">
+        <div className="relative aspect-video w-full">
+          {open && (
+            <iframe
+              className="absolute inset-0 h-full w-full"
+              src={`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`}
+              title={title}
+              allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
+              allowFullScreen
+            />
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/components/v1/sections/AgentEvals/ScoreOutcomes.tsx
+++ b/components/v1/sections/AgentEvals/ScoreOutcomes.tsx
@@ -6,11 +6,20 @@
  * Unbreakable layout.
  */
 
+import { useState } from "react";
 import { motion } from "motion/react";
 import { reveals } from "@/utils/v1/reveals";
 import { cn } from "@/utils/v1/cn";
 import Section from "@/components/v1/sections/shared/Section";
 import { V1_SECTION_TITLE } from "@/components/v1/sections/shared/sectionTitle";
+import Button from "@/components/v1/Button";
+import VideoModal from "@/components/v1/VideoModal";
+
+// "See it in action" demo video — opens in an on-page modal rather than
+// linking out to YouTube, so we don't lose visitors to youtube.com. The
+// iframe below is only mounted once the modal is opened (see VideoModal),
+// so this has zero impact on this page's initial load/perf.
+const DEMO_VIDEO_ID = "ZPysQAlXUrc";
 
 interface Pillar {
   number: string;
@@ -37,6 +46,8 @@ const PILLARS: Pillar[] = [
 ];
 
 export default function ScoreOutcomes() {
+  const [videoOpen, setVideoOpen] = useState(false);
+
   return (
     <Section
       aria-labelledby="agent-evals-score-heading"
@@ -44,7 +55,10 @@ export default function ScoreOutcomes() {
       containerClassName="relative flex flex-col gap-v1-stack-lg lg:flex-row lg:items-start lg:gap-x-16"
     >
       <div className="relative lg:sticky lg:top-[22vh] lg:min-w-0 lg:flex-1 lg:self-start">
-        <h2 id="agent-evals-score-heading" className={cn(V1_SECTION_TITLE, "relative z-10")}>
+        <h2
+          id="agent-evals-score-heading"
+          className={cn(V1_SECTION_TITLE, "relative z-10")}
+        >
           {["Score outcomes,", "not output"].map((line, i) => (
             <motion.span key={i} {...reveals.item(i)} className="block">
               {line}
@@ -53,11 +67,16 @@ export default function ScoreOutcomes() {
         </h2>
         <motion.p
           {...reveals.body}
-          className="mt-6 max-w-[440px] text-v1-body-lg-loose text-v1-frost"
+          className="text-v1-body-lg-loose mt-6 max-w-[440px] text-v1-frost"
         >
-          Score agents based on user and product signals, not just based on
-          what one LLM says about another.
+          Score agents based on user and product signals, not just based on what
+          one LLM says about another.
         </motion.p>
+        <motion.div {...reveals.item(2)} className="mt-8">
+          <Button variant="primary" onClick={() => setVideoOpen(true)}>
+            See it in action
+          </Button>
+        </motion.div>
       </div>
 
       <ol className="flex flex-col gap-[60px] lg:max-w-[550px] lg:gap-0">
@@ -65,6 +84,13 @@ export default function ScoreOutcomes() {
           <PillarRow key={pillar.number} pillar={pillar} index={i} />
         ))}
       </ol>
+
+      <VideoModal
+        open={videoOpen}
+        onClose={() => setVideoOpen(false)}
+        videoId={DEMO_VIDEO_ID}
+        title="Agent Evals — see it in action"
+      />
     </Section>
   );
 }

--- a/pages/docs/learn/agent-evals.mdx
+++ b/pages/docs/learn/agent-evals.mdx
@@ -1,4 +1,6 @@
 import { Callout } from "src/shared/Docs/mdx";
+import { ResourceGrid, Resource } from "src/shared/Docs/Resources";
+import { VideoCameraIcon } from "@heroicons/react/24/outline";
 
 export const metaTitle = "Agent Evals | Evaluate AI Workflows in Production"
 export const description = "Use scoring, deferred scoring, sessions, traces, experiments, and Insights to evaluate production AI workflows on Inngest."
@@ -277,6 +279,20 @@ Agent Evals connects several docs and dashboard surfaces:
 | **Interpreting results** | |
 | Boolean scores look like numbers in aggregates. | Boolean scores aggregate numerically. Treat `true` as `1` and `false` as `0`. |
 | A model call succeeded but the score is bad. | Inspect the trace and session. Production evals measure the outcome, not only whether the model request completed. |
+
+## Resources
+
+<ResourceGrid cols={1}>
+
+<Resource resource={{
+  href: "https://youtu.be/ZPysQAlXUrc",
+  name: 'Video: "Score outcomes, not output"',
+  icon: VideoCameraIcon,
+  description: "See Agent Evals in action: scoring functions with step.score(), tracking outcomes from product signals, and evaluating full agent trajectories.",
+  pattern: 1,
+}}/>
+
+</ResourceGrid>
 
 ## Related docs
 


### PR DESCRIPTION
Adds a CTA button below the intro copy in the "Score outcomes, not output" section on /platform/agent-evals that opens up video player with "Agent Evals" demo (Youtube vid).

The iframe is only mounted once the modal is opened and unmounts on close, so this should have no impact on initial page load/perf.