### PR TITLE
docs(logging): note the context logger de-duplicates logs across step replays

### DIFF
--- a/pages/docs/guides/logging.mdx
+++ b/pages/docs/guides/logging.mdx
@@ -25,6 +25,8 @@ async ({ event, step }) => {
 
 We provide a thin wrapper over existing logging tools, and export it to Inngest functions in order to mitigate these problems, so you, as the user, don't need to deal with them and things should work as you expect.
 
+This de-duplication only applies to the `logger` passed to your function as a handler argument (see [Usage](#usage) below). The SDK silences it while it replays memoized steps, so a log statement outside a `step` runs only on the real, non-replayed execution. A logger you import or instantiate yourself and call directly has no such awareness — called outside a `step`, it runs on every replay and duplicates. Use the handler's `logger`, or wrap the log in `step.run` when you need it to run exactly once.
+
 ## Usage
 
 A `logger` object is available within all Inngest functions as a handler argument. You can use it with the logger of your choice, or if absent, `logger` will default to use `console`.


### PR DESCRIPTION
The guide already says a log outside a `step` "can be run three times" and that the built-in wrapper mitigates it — but not that this depends on using the handler-provided `logger`. A logger you import or instantiate yourself and call directly outside a `step` still duplicates on every replay. This PR adds one sentence making that explicit, with the fix (use the handler `logger`, or wrap the log in `step.run`).

Docs only, no code change.

Backing (SDK source): `ProxyLogger` gates every method on an `enabled` flag (default false), enabled only in `onMemoizationEnd` — so it's silenced while memoized steps replay. See `packages/inngest/src/middleware/logger.ts` and `packages/inngest/src/components/Inngest.ts`.