### PR TITLE
docs(v4): remove event.user from the v4 TypeScript reference

### DIFF
--- a/pages/docs/reference/typescript/v4/events/send.mdx
+++ b/pages/docs/reference/typescript/v4/events/send.mdx
@@ -18,10 +18,6 @@ await inngest.send({
     accountId: "645e9f6794e10937e9bdc201",
     billingPlan: "pro",
   },
-  user: {
-    external_id: "645ea000129f1c40109ca7ad",
-    email: "taylor@example.com",
-  }
 })
 ```
 
@@ -48,14 +44,6 @@ To send events from within the context of a function, use [`step.sendEvent()`](/
           </Property>
           <Property name="data" type="object" required>
             Any data to associate with the event. Will be serialized as JSON.
-          </Property>
-          <Property name="user" type="object">
-            Any relevant user identifying data or attributes associated with the event. **This data is encrypted at rest.**
-            <Properties nested>
-              <Property name="external_id" type="string">
-                An external identifier for the user. Most commonly, their user id in your system.
-              </Property>
-            </Properties>
           </Property>
           <Property name="id" type="string">
             A unique ID used to idempotently trigger function runs.  If duplicate event IDs are seen,
@@ -103,23 +91,12 @@ To send events from within the context of a function, use [`step.sendEvent()`](/
     },
   ]);
 
-  // Send user data that will be encrypted at rest
-  await inngest.send({
-    name: "app/account.created",
-    data: { billingPlan: "pro" },
-    user: {
-      external_id: "6463da8211cdbbcb191dd7da",
-      email: "test@example.com"
-    }
-  });
-
   // Specify the idempotency id, version, and timestamp
   await inngest.send({
     // Use an id specific to the event type & payload
     id: "cart-checkout-completed-ed12c8bde",
     name: "storefront/cart.checkout.completed",
     data: { cartId: "ed12c8bde" },
-    user: { external_id: "6463da8211cdbbcb191dd7da" },
     ts: 1684274328198,
     v: "2024-05-15.1"
   });
@@ -149,16 +126,6 @@ const { ids } = await inngest.send([
  * ]
  */
 ```
-
-## User data encryption 🔐
-
-All data sent in the `user` object is fully encrypted at rest.
-
-<Callout variant="warning">
-  <span className="text-yellow-300">⚠️</span> When [replaying a function](/docs/platform/replay), `event.user` will be empty. This will be fixed in the future, but for now assume that you cannot replay functions that rely on `event.user` data.
-</Callout>
-
-In the future, this object will be used to support programmatic deletion via API endpoint to support certain right-to-be-forgotten flows in your system. This will use the `user.external_id` property for lookup.
 
 ## Usage limits
 

--- a/pages/docs/reference/typescript/v4/functions/create.mdx
+++ b/pages/docs/reference/typescript/v4/functions/create.mdx
@@ -86,7 +86,7 @@ The `createFunction` method accepts a series of arguments to define your functio
     Expressions are defined using the Common Expression Language (CEL) with the original event accessible using dot-notation. Read [our guide to writing expressions](/docs/guides/writing-expressions) for more info. Examples:
 
     * Only run once for each customer id: `'event.data.customer_id'`
-    * Only run once for each account and email address: `'event.data.account_id + "-" + event.user.email'`
+    * Only run once for each account and email address: `'event.data.account_id + "-" + event.data.email'`
   </Property>
 
   <Property name="rateLimit" type="object">
@@ -106,7 +106,7 @@ The `createFunction` method accepts a series of arguments to define your functio
         Expressions are defined using the Common Expression Language (CEL) with the original event accessible using dot-notation. Read [our guide to writing expressions](/docs/guides/writing-expressions) for more info. Examples:
 
         * Rate limit per customer id: `'event.data.customer_id'`
-        * Rate limit per account and email address: `'event.data.account_id + "-" + event.user.email'`
+        * Rate limit per account and email address: `'event.data.account_id + "-" + event.data.email'`
       </Property>
     </Properties>
   </Property>
@@ -124,7 +124,7 @@ The `createFunction` method accepts a series of arguments to define your functio
         Expressions are defined using the Common Expression Language (CEL) with the original event accessible using dot-notation. Read [our guide to writing expressions](/docs/guides/writing-expressions) for more info. Examples:
 
         * Debounce per customer id: `'event.data.customer_id'`
-        * Debounce per account and email address: `'event.data.account_id + "-" + event.user.email'`
+        * Debounce per account and email address: `'event.data.account_id + "-" + event.data.email'`
       </Property>
     </Properties>
   </Property>
@@ -163,7 +163,7 @@ The `createFunction` method accepts a series of arguments to define your functio
         Expressions are defined using the Common Expression Language (CEL) with the original event accessible using dot-notation. Read [our guide to writing expressions](/docs/guides/writing-expressions) for more info. Examples:
 
         * Batch events per customer id: `'event.data.customer_id'`
-        * Batch events per account and email address: `'event.data.account_id + "-" + event.user.email'`
+        * Batch events per account and email address: `'event.data.account_id + "-" + event.data.email'`
       </Property>
       <Property name="if" type="string">
         A boolean expression to conditionally batch events that evaluate to true on this expression. The expression is evaluated for each triggering event.

--- a/pages/docs/reference/typescript/v4/functions/debounce.mdx
+++ b/pages/docs/reference/typescript/v4/functions/debounce.mdx
@@ -46,7 +46,7 @@ export default inngest.createFunction(
         Expressions are defined using the Common Expression Language (CEL) with the original event accessible using dot-notation. Read [our guide to writing expressions](/docs/guides/writing-expressions) for more info. Examples:
 
         * Rate limit per customer id: `'event.data.customer_id'`
-        * Rate limit per account and email address: `'event.data.account_id + "-" + event.user.email'`
+        * Rate limit per account and email address: `'event.data.account_id + "-" + event.data.email'`
       </Property>
       <Property name="timeout" type="string">
         The maximum time that a debounce can be extended before running.
@@ -62,4 +62,3 @@ export default inngest.createFunction(
 <Callout variant="warning">
   Debounce cannot be combined with [batching](/docs/guides/batching).
 </Callout>
-

--- a/pages/docs/reference/typescript/v4/functions/rate-limit.mdx
+++ b/pages/docs/reference/typescript/v4/functions/rate-limit.mdx
@@ -48,7 +48,7 @@ export default inngest.createFunction(
         Expressions are defined using the Common Expression Language (CEL) with the original event accessible using dot-notation. Read [our guide to writing expressions](/docs/guides/writing-expressions) for more info. Examples:
 
         * Rate limit per customer id: `'event.data.customer_id'`
-        * Rate limit per account and email address: `'event.data.account_id + "-" + event.user.email'`
+        * Rate limit per account and email address: `'event.data.account_id + "-" + event.data.email'`
       </Property>
     </Properties>
   </Property>
@@ -109,12 +109,9 @@ When there is an issue in your system, you may want to send your user an email n
     incident_id: "01HB9PWHZ4CZJYRAGEY60XEHCZ",
     issue: "HTTP uptime check failed at 2023-09-26T21:23:51.515631317Z",
     user_id: "user_aW5uZ2VzdF9pc19mdWNraW5nX2F3ZXNvbWU=",
+    email: "user@example.com",
     service_name: "api",
     service_id: "01HB9Q2EFBYG2B7X8VCD6JVRFH"
-  },
-  user: {
-    external_id: "user_aW5uZ2VzdF9pc19mdWNraW5nX2F3ZXNvbWU=",
-    email: "user@example.com"
   }
 }
 */
@@ -133,7 +130,7 @@ export default inngest.createFunction(
     await step.run("send-alert-email", async () => {
       return await resend.emails.send({
         from: "notifications@myco.com",
-        to: event.user.email,
+        to: event.data.email,
         subject: `ALERT: ${event.data.issue}`,
         text: `Dear user, ...`,
       });

--- a/pages/docs/reference/typescript/v4/functions/singleton.mdx
+++ b/pages/docs/reference/typescript/v4/functions/singleton.mdx
@@ -39,7 +39,7 @@ export default inngest.createFunction(
         Expressions are defined using the Common Expression Language (CEL) with the original event accessible using dot-notation. Read [our guide to writing expressions](/docs/guides/writing-expressions) for more info. Examples:
 
         * Ensure exclusive execution of a function per customer ID: `'event.data.customer_id'`
-        * Ensure exclusive execution of a function per account and email address: `'event.data.account_id + "-" + event.user.email'`
+        * Ensure exclusive execution of a function per account and email address: `'event.data.account_id + "-" + event.data.email'`
       </Property>
       <Property name="mode" type="string" required>
         The mode to use for the singleton function:
@@ -92,4 +92,3 @@ export default inngest.createFunction(
 While similar to [Debounce](/docs/guides/debounce), Singleton Functions are designed to ensure that only a single run of a function is happening at a time, whereas Debounce ensures that only a single event is processed within a given time window.
 
 Refer to the [Singleton Functions guide](/docs/guides/singleton) for more information about how this feature works.
-


### PR DESCRIPTION
## Summary

The v4 migration guide says `event.user` was removed in v4:

> ### Remove `event.user`
> The deprecated `event.user` field has been removed. If you previously sent user information on the top-level `user` field or read it from `event.user` inside a function, move the data your function needs into `event.data` instead.

Several v4 reference pages still document and use it. Following them produces a TypeScript error, which is what was reported in inngest/inngest-js#1610:

```ts
await inngest.send({
  name: "eventName",
  data,
  user: { external_id: "sub", email: "email", name: "name" },
});
// Object literal may only specify known properties,
// and 'user' does not exist in type ...
```

On that issue a maintainer confirmed the removal was intentional and noted the migration guide had missed it. #1738 fixed the migration guide; the reference pages were left behind, so the v4 docs now contradict each other.

## Changes

**`v4/events/send.mdx`** — the page documented `user` as a first-class payload property:

- Remove the `user` property from the `eventPayload` reference table
- Remove `user` from the three code samples that set it
- Remove the "User data encryption 🔐" section, which documents only the `user` object and its replay caveat

**`v4/functions/{create,debounce,rate-limit,singleton}.mdx`** — the CEL key-expression examples for `idempotency`, `rateLimit`, `debounce`, `batchEvents` and `singleton` all read `event.user.email`:

- `'event.data.account_id + "-" + event.user.email'` → `'event.data.account_id + "-" + event.data.email'`
- In the `rate-limit` example payload, move `email` into `data` and read `event.data.email` instead of `event.user.email`

The v3 reference pages are deliberately untouched — `user` is still valid there.

## Verification

- No `event.user` or `external_id` references remain on any v4 page (the migration guide keeps its intentional mentions)
- MDX component tags stay balanced on `send.mdx` (`Properties` 3/3, `Property` 8/8, `Row` 1/1, `Col` 2/2, `Callout` 1/1)
- `Callout` is still used on `send.mdx`, so its import stays valid
- Diffs are minimal: `send.mdx` is purely subtractive (33 lines removed); the other four are one-line substitutions plus the payload move

Closes inngest/inngest-js#1610
