### PR TITLE
docs: add missing v4 segment to three reference links

### DIFF
--- a/app/(v0)/durable-endpoints/DurableEndpointsLP.tsx
+++ b/app/(v0)/durable-endpoints/DurableEndpointsLP.tsx
@@ -206,7 +206,7 @@ export function DurableEndpointsLP({
                 title: "Durable Execution reference",
                 description:
                   "Explore the Durable Endpoints TypeScript SDK reference with the complete list of options and use case examples.",
-                url: `/docs/reference/typescript/durable-endpoints?ref=${ref}`,
+                url: `/docs/reference/typescript/v4/durable-endpoints?ref=${ref}`,
               },
             ]}
           />

--- a/pages/docs/features/inngest-functions/cancellation/cancel-on-events.mdx
+++ b/pages/docs/features/inngest-functions/cancellation/cancel-on-events.mdx
@@ -89,7 +89,7 @@ Here is an example of these two events which will be matched on the `data.remind
 * You can configure multiple events to cancel a function, up to five.
 * You can write a more complex matching statement using the `if` field.
 
-Learn more in the full [reference](/docs/reference/typescript/functions/cancel-on).
+Learn more in the full [reference](/docs/reference/typescript/v4/functions/cancel-on).
 
 </LanguageSection>
 

--- a/pages/docs/learn/durable-endpoints.mdx
+++ b/pages/docs/learn/durable-endpoints.mdx
@@ -163,7 +163,7 @@ Bun.serve({
 
 If `process` fails, the endpoint will retry from that step. `enrich-data` won't re-run.
 
-**Read the [Durable Endpoint TypeScript SDK Reference](/docs/reference/typescript/durable-endpoints) for more detailed usage information.**
+**Read the [Durable Endpoint TypeScript SDK Reference](/docs/reference/typescript/v4/durable-endpoints) for more detailed usage information.**
 
 ### Using Steps
 
@@ -335,7 +335,7 @@ The following demos are also available to check out and run locally with the Inn
 
 ## Further Reference
 
-- [Durable Endpoint - TypeScript SDK Reference](/docs/reference/typescript/durable-endpoints)
+- [Durable Endpoint - TypeScript SDK Reference](/docs/reference/typescript/v4/durable-endpoints)
 - [Steps Overview](/docs/learn/inngest-steps)
 
 </LanguageSelector>

--- a/pages/docs/platform/monitor/traces.mdx
+++ b/pages/docs/platform/monitor/traces.mdx
@@ -268,7 +268,7 @@ Right panel (when userland span is selected):
 */}
 
 <Note>
-  When set up with `@inngest/otel`, Extended Traces automatically capture spans from popular libraries including HTTP clients, database drivers, and more. See the [instrumentation notes](/docs/reference/typescript/extended-traces#instrumentation).
+  When set up with `@inngest/otel`, Extended Traces automatically capture spans from popular libraries including HTTP clients, database drivers, and more. See the [instrumentation notes](/docs/reference/typescript/v4/extended-traces#instrumentation).
 </Note>
 
 ### Get Started
@@ -277,7 +277,7 @@ Extended Traces are available in TypeScript as an opt-in feature. Get started in
 
 <div className="flex items-end justify-start">
 <Button
-  href={"/docs/reference/typescript/extended-traces"}
+  href={"/docs/reference/typescript/v4/extended-traces"}
   size="sm"
   variant="primaryOutline"
 >Get started with Extended Traces</Button>


### PR DESCRIPTION
## Summary

Several pages link to TypeScript reference pages without the version segment. Those paths resolve to nothing:

| Link | Referenced from |
|---|---|
| `/docs/reference/typescript/durable-endpoints` | `pages/docs/learn/durable-endpoints.mdx` (×2), `app/(v0)/durable-endpoints/DurableEndpointsLP.tsx` |
| `/docs/reference/typescript/extended-traces` | `pages/docs/platform/monitor/traces.mdx` (×2) |
| `/docs/reference/typescript/functions/cancel-on` | `pages/docs/features/inngest-functions/cancellation/cancel-on-events.mdx` |

For each one I checked all three ways a path can resolve:

1. **No page file** — nothing at `pages/docs/reference/typescript/{durable-endpoints,extended-traces,functions/cancel-on}.mdx`
2. **No redirect** — `next.config.mjs` enumerates unversioned reference paths individually (`/docs/reference/typescript/functions/errors`, `/docs/reference/serve`, …) but these three are absent, and there is no wildcard rule for `/docs/reference/typescript/:path*`
3. **No middleware rewrite** — `middleware.ts` only does markdown content negotiation and canonical headers; it never rewrites version segments

All three targets exist under `/v4/`, and other pages already link to them with the version included, e.g.:

- `pages/docs/reference/typescript/v4/client/create.mdx` → `/docs/reference/typescript/v4/durable-endpoints`
- `pages/docs/learn/agent-evals.mdx` → `/docs/reference/typescript/v4/extended-traces`
- `pages/docs/reference/typescript/v4/functions/create.mdx` → `/docs/reference/typescript/v4/functions/cancel-on`

So these are just missing version segments.

## Changes

Add `/v4` to the six affected links: four markdown links (one carrying an `#instrumentation` anchor), one `href` prop on a card in `traces.mdx`, and the "Durable Execution reference" resource card on the Durable Endpoints landing page — that last one is a live CTA that currently 404s.

## Not changed

Two blog posts carry the same dead paths:

- `content/blog/introducing-extended-traces.mdx` → `/docs/reference/typescript/extended-traces`
- `content/blog/accidentally-quadratic-evaluating-trillions-of-event-matches-in-real-time.mdx` → `/docs/reference/typescript/functions/cancel-on`

They were valid when published, and I did not want to rewrite archived posts without knowing your policy on that. Happy to include them if you'd like.

## Verification

Wrote a checker that resolves every `](/docs/...)` link in `pages/docs/**/*.mdx` against page files, `next.config.mjs` redirect entries and dynamic route patterns, ignoring links inside `{/* ... */}` MDX comments:

- Before: these 3 routes unresolved
- After: **0 unresolved routes** across all 247 docs pages
