### PR TITLE
docs: point quick-start dev server links at a heading that exists

### DIFF
--- a/pages/docs/getting-started/astro-quick-start.mdx
+++ b/pages/docs/getting-started/astro-quick-start.mdx
@@ -86,7 +86,7 @@ bun add inngest
 
 ## 2. Run the Inngest Dev Server
 
-Next, start the [Inngest Dev Server](/docs/local-development#inngest-dev-server), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs. This tutorial assumes that your Astro server will be running on port `4321`; change this to match your port if you use another.
+Next, start the [Inngest Dev Server](/docs/local-development#getting-started), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs. This tutorial assumes that your Astro server will be running on port `4321`; change this to match your port if you use another.
 
 <CodeGroup>
 ```shell  {{ title: "Bash installer" }}

--- a/pages/docs/getting-started/express-quick-start.mdx
+++ b/pages/docs/getting-started/express-quick-start.mdx
@@ -66,7 +66,7 @@ bun add inngest
 
 ## 2. Run the Inngest Dev Server
 
-Next, start the [Inngest Dev Server](/docs/local-development#inngest-dev-server), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs. This tutorial assumes that your Express server will be running on port `3000`; change this to match your port if you use another.
+Next, start the [Inngest Dev Server](/docs/local-development#getting-started), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs. This tutorial assumes that your Express server will be running on port `3000`; change this to match your port if you use another.
 
 <CodeGroup>
 ```shell  {{ title: "Bash installer" }}

--- a/pages/docs/getting-started/h3-quick-start.mdx
+++ b/pages/docs/getting-started/h3-quick-start.mdx
@@ -87,7 +87,7 @@ bun add inngest
 
 ## 2. Run the Inngest Dev Server
 
-Next, start the [Inngest Dev Server](/docs/local-development#inngest-dev-server), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs. This tutorial assumes that your H3 server will be running on port `3000`; change this to match your port if you use another.
+Next, start the [Inngest Dev Server](/docs/local-development#getting-started), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs. This tutorial assumes that your H3 server will be running on port `3000`; change this to match your port if you use another.
 
 <CodeGroup>
 ```shell  {{ title: "Bash installer" }}

--- a/pages/docs/getting-started/nestjs-quick-start.mdx
+++ b/pages/docs/getting-started/nestjs-quick-start.mdx
@@ -66,7 +66,7 @@ bun add inngest
 
 ## 2. Run the Inngest Dev Server
 
-Next, start the [Inngest Dev Server](/docs/local-development#inngest-dev-server), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs. This tutorial assumes that your NestJS server will be running on port `3000`; change this to match your port if you use another.
+Next, start the [Inngest Dev Server](/docs/local-development#getting-started), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs. This tutorial assumes that your NestJS server will be running on port `3000`; change this to match your port if you use another.
 
 <CodeGroup>
 ```shell  {{ title: "Bash installer" }}

--- a/pages/docs/getting-started/nodejs-quick-start.mdx
+++ b/pages/docs/getting-started/nodejs-quick-start.mdx
@@ -69,7 +69,7 @@ bun add inngest
 
 ## 2. Run the Inngest Dev Server
 
-Next, start the [Inngest Dev Server](/docs/local-development#inngest-dev-server), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs. This tutorial assumes that your Node.js server will be running on port `3000`; change this to match your port if you use another.
+Next, start the [Inngest Dev Server](/docs/local-development#getting-started), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs. This tutorial assumes that your Node.js server will be running on port `3000`; change this to match your port if you use another.
 
 <CodeGroup>
 ```shell  {{ title: "Bash installer" }}

--- a/pages/docs/getting-started/tanstack-start-quick-start.mdx
+++ b/pages/docs/getting-started/tanstack-start-quick-start.mdx
@@ -59,7 +59,7 @@ bun add inngest
 
 ## 2. Run the Inngest Dev Server
 
-Next, start the [Inngest Dev Server](/docs/local-development#inngest-dev-server?ref=tanstack-start-quick-start), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs:
+Next, start the [Inngest Dev Server](/docs/local-development?ref=tanstack-start-quick-start#getting-started), which is a fast, in-memory version of Inngest where you can quickly send and view events and function runs:
 
 <CodeGroup>
 ```shell  {{ title: "Bash installer" }}


### PR DESCRIPTION
## Summary

Six quick-start guides link to `/docs/local-development#inngest-dev-server`. That page has no heading that produces an `inngest-dev-server` id, so the anchor resolves to nothing and readers land at the top of the page instead of the section they were sent to.

`pages/docs/local-development.mdx` headings are:

```
# Local development
## Getting started
## AI-assisted local development
## Connecting apps to the Dev Server
### How functions are loaded by the Dev Server
## Testing functions
### Invoke via UI
### Sending events to the Dev Server
```

(The other `#` lines in that file are shell comments inside code fences, so they get no id.)

Slugs come from `mdx/rehype.mjs`, which applies `@sindresorhus/slugify` to h1–h4 text. None of the above yields `inngest-dev-server`.

## Changes

In all six guides the link text is **"start the Inngest Dev Server"**, and the section that covers installing the CLI and running `inngest dev` is `## Getting started`. Repointed to `#getting-started`:

- `astro-quick-start.mdx`
- `express-quick-start.mdx`
- `h3-quick-start.mdx`
- `nestjs-quick-start.mdx`
- `nodejs-quick-start.mdx`
- `tanstack-start-quick-start.mdx`

The TanStack Start guide additionally had its query string **after** the fragment:

```diff
- /docs/local-development#inngest-dev-server?ref=tanstack-start-quick-start
+ /docs/local-development?ref=tanstack-start-quick-start#getting-started
```

As written, `?ref=…` was part of the fragment, not a query parameter, so the `ref` attribution was silently lost. Reordered.

Happy to use a different target if you'd rather add an `inngest-dev-server` heading to `local-development.mdx` instead — that would work too, and I can switch this PR to that approach.

## Verification

Wrote a checker that computes each docs page's real anchor set — h1–h4 slugified with the same `slugifyWithCounter` the site uses, plus `<Property name>` ids and explicit `id=` attributes — then resolves every fragment link in `pages/docs/**/*.mdx` against it, ignoring code fences and `{/* … */}` comments.

It reports 22 other fragment links that don't resolve, mostly anchors into code-heavy headings where I'm less confident my slug reproduction matches the renderer exactly. I deliberately left those out of this PR rather than guess. If the approach looks useful to you I'm glad to work through them in a follow-up, or share the script.
