### PR TITLE
Update Pro pricing: 1M executions included, up to 20M add-on

### DIFF
--- a/components/v1/sections/Pricing/ComparisonTable.tsx
+++ b/components/v1/sections/Pricing/ComparisonTable.tsx
@@ -286,7 +286,7 @@ function Cell({ value }: { value: FeatureCell | undefined }) {
         {value.value}
       </span>
       {value.description && (
-        <span className="text-v1-body-xs text-v1-carbon-200 lg:text-v1-body-sm">
+        <span className="text-[11px] font-light leading-snug text-v1-carbon-200">
           {value.description}
         </span>
       )}

--- a/components/v1/sections/Pricing/Hero.tsx
+++ b/components/v1/sections/Pricing/Hero.tsx
@@ -395,6 +395,11 @@ function PlanCard({
                 <span className="font-bold">{feature.value} </span>
               )}
               {feature.text}
+              {feature.note && (
+                <span className="mt-0.5 block text-[11px] font-light leading-snug text-v1-frost/70 group-hover:text-white/70 group-data-[active]:text-white/70">
+                  {feature.note}
+                </span>
+              )}
             </li>
           ))}
         </ul>
@@ -408,6 +413,11 @@ function PlanCard({
                     <span className="font-bold">{feature.value} </span>
                   )}
                   {feature.text}
+                  {feature.note && (
+                    <span className="mt-0.5 block text-[11px] font-light leading-snug text-v1-frost/70 group-hover:text-white/70 group-data-[active]:text-white/70">
+                      {feature.note}
+                    </span>
+                  )}
                 </li>
               ))}
             </ul>

--- a/components/v1/sections/Pricing/plans.ts
+++ b/components/v1/sections/Pricing/plans.ts
@@ -39,8 +39,9 @@ export interface Plan {
   priceCaption: string;
   cta: { href: string; text: string };
   /** Feature bullets below the CTA. `value`, when set, renders bold
-   *  before the label — e.g. **50k** executions. */
-  features: { value?: string; text: string }[];
+   *  before the label — e.g. **50k** executions. `note`, when set,
+   *  renders below in a smaller, lighter weight. */
+  features: { value?: string; text: string; note?: string }[];
   /** Tags / badges (e.g. "POPULAR"). */
   badge?: string;
 }
@@ -118,7 +119,11 @@ export const PLANS: Plan[] = [
       text: "Get started for Free",
     },
     features: [
-      { value: "1M+", text: "executions" },
+      {
+        value: "1M",
+        text: "executions included",
+        note: "Up to 20M add-on",
+      },
       { value: "100+", text: "concurrent executions" },
       { value: "5 GB", text: "span data ingested" },
       { value: "50K", text: "scores" },
@@ -224,8 +229,8 @@ export const FEATURES: Feature[] = [
     plans: {
       [PLAN_NAMES.hobby]: "50k /mo included",
       [PLAN_NAMES.pro]: {
-        value: "1m /mo included",
-        description: "then $50 per 1m",
+        value: "1M executions included",
+        description: "Up to 20M add-on",
       },
       [PLAN_NAMES.enterprise]: "Custom",
     },


### PR DESCRIPTION
## Summary
- Update Pro plan executions copy from “1M+ executions” to **1M executions included** with **Up to 20M add-on** on the hero plan card
- Mirror the same copy in the comparison table Executions row (replacing “then $50 per 1m”)
- Render the add-on note in smaller, lighter type on both the card and table secondary lines

## Test plan
- [ ] Open `/pricing` and confirm Pro (orange) card shows “1M executions included” + smaller “Up to 20M add-on”
- [ ] Confirm comparison table Executions → Pro matches the same wording/styling
- [ ] Hover/activate Pro card and confirm add-on note stays legible on the salmon surface
- [ ] Spot-check other table rows with secondary descriptions still look correct


Made with [Cursor](https://cursor.com)