### PR TITLE
Update Pro pricing: pay as you go up to 20M

### DIFF
--- a/components/v1/sections/Pricing/ComparisonTable.tsx
+++ b/components/v1/sections/Pricing/ComparisonTable.tsx
@@ -286,7 +286,7 @@ function Cell({ value }: { value: FeatureCell | undefined }) {
         {value.value}
       </span>
       {value.description && (
-        <span className="text-[11px] font-light leading-snug text-v1-carbon-200">
+        <span className="text-v1-body-xs italic text-v1-carbon-200">
           {value.description}
         </span>
       )}

--- a/components/v1/sections/Pricing/Hero.tsx
+++ b/components/v1/sections/Pricing/Hero.tsx
@@ -396,7 +396,7 @@ function PlanCard({
               )}
               {feature.text}
               {feature.note && (
-                <span className="mt-0.5 block text-[11px] font-light leading-snug text-v1-frost/70 group-hover:text-white/70 group-data-[active]:text-white/70">
+                <span className="mt-0.5 block text-v1-body-xs text-v1-frost/80 group-hover:text-white/80 group-data-[active]:text-white/80">
                   {feature.note}
                 </span>
               )}
@@ -414,7 +414,7 @@ function PlanCard({
                   )}
                   {feature.text}
                   {feature.note && (
-                    <span className="mt-0.5 block text-[11px] font-light leading-snug text-v1-frost/70 group-hover:text-white/70 group-data-[active]:text-white/70">
+                    <span className="mt-0.5 block text-v1-frost/80 group-hover:text-white/80 group-data-[active]:text-white/80">
                       {feature.note}
                     </span>
                   )}

--- a/components/v1/sections/Pricing/plans.ts
+++ b/components/v1/sections/Pricing/plans.ts
@@ -122,7 +122,7 @@ export const PLANS: Plan[] = [
       {
         value: "1M",
         text: "executions included",
-        note: "Up to 20M add-on",
+        note: "Pay as you go up to 20M",
       },
       { value: "100+", text: "concurrent executions" },
       { value: "5 GB", text: "span data ingested" },
@@ -230,7 +230,7 @@ export const FEATURES: Feature[] = [
       [PLAN_NAMES.hobby]: "50k /mo included",
       [PLAN_NAMES.pro]: {
         value: "1M executions included",
-        description: "Up to 20M add-on",
+        description: "Pay as you go up to 20M",
       },
       [PLAN_NAMES.enterprise]: "Custom",
     },


### PR DESCRIPTION
## Summary
- Change Pro executions secondary copy from “Up to 20M add-on” to **Pay as you go up to 20M** (hero card + comparison table)
- Soften secondary-line styling vs the previous ultra-light 11px treatment
- Keep italics in the comparison table only; plain smaller type on the orange Pro card

## Test plan
- [ ] Open `/pricing` and confirm Pro card shows “1M executions included” + non-italic “Pay as you go up to 20M”
- [ ] Confirm comparison table Executions → Pro matches, with italic secondary line
- [ ] Hover/activate Pro card and confirm secondary line stays legible on salmon


Made with [Cursor](https://cursor.com)