### PR TITLE
Add Cloudflare Node compat copy

### DIFF
--- a/pages/docs/deploy/cloudflare.mdx
+++ b/pages/docs/deploy/cloudflare.mdx
@@ -1,5 +1,7 @@
+import { Callout } from "src/shared/Docs/mdx";
+
 export const metaTitle = "Deploy Inngest to Cloudflare Pages"
-export const description = "Host Inngest functions on Cloudflare Pages. Set up the serve handler, configure environment variables, and deploy your durable workflows to the edge."
+export const description = "Host Inngest functions on Cloudflare Pages. Set up the serve handler, configure environment variables, and deploy durable workflows."
 
 # Cloudflare Pages
 
@@ -9,11 +11,20 @@ Inngest allows you to deploy your event-driven functions to [Cloudflare Pages](h
 ## Deploying to Cloudflare Pages
 
 1. [Write your functions](/docs/functions)
-2. [Serve your functions](/docs/learn/serving-inngest-functions#framework-cloudflare)
+2. [Serve your functions](/docs/learn/serving-inngest-functions#framework-cloudflare-pages-functions)
 3. [Set environment variables](https://developers.cloudflare.com/pages/get-started/#environment-variables) for your deployment
-  - `NODE_VERSION: 16`
+  - `NODE_VERSION: 22`
   - `INNGEST_SIGNING_KEY: ***` - from [the Inngest dashboard](https://app.inngest.com/env/production/manage/signing-key)
   - `INNGEST_EVENT_KEY: ***` - from [the Inngest dashboard](https://app.inngest.com/env/production/manage/keys)
+
+<Callout>
+  Cloudflare Pages Functions run on the Workers runtime. Enable Node.js compatibility so Inngest can use `AsyncLocalStorage` during function execution:
+
+  ```toml
+  compatibility_flags = ["nodejs_compat"]
+  compatibility_date = "2024-09-23"
+  ```
+</Callout>
 
 ##  Syncing your app
 

--- a/pages/docs/learn/serving-inngest-functions.mdx
+++ b/pages/docs/learn/serving-inngest-functions.mdx
@@ -175,6 +175,10 @@ export const onRequest = serve({
 ```
 </CodeGroup>
 
+<Callout>
+  Cloudflare Pages Functions run on the Workers runtime. Enable Node.js compatibility so Inngest can use `AsyncLocalStorage` during function execution.
+</Callout>
+
 ### Framework: Cloudflare Workers
 
 You can export `"inngest/cloudflare"`'s `serve()` as your Cloudflare Worker:
@@ -195,6 +199,10 @@ export default {
 };
 ```
 </CodeGroup>
+
+<Callout>
+  Enable Node.js compatibility so Inngest can use `AsyncLocalStorage` during function execution. Add `nodejs_compat` to your compatibility flags and use a compatibility date of `2024-09-23` or later.
+</Callout>
 
 <Tip>
   To automatically pass environment variables defined with Wrangler to Inngest function handlers, use the [Cloudflare Workers bindings middleware](/docs/examples/middleware/cloudflare-workers-environment-variables).


### PR DESCRIPTION
Tell Cloudflare users they need Node compat since we rely on `AsyncLocalStorage`