### PR TITLE
Make Flow Control and Agent Observability capability tiles clickable

### DIFF
--- a/components/v1/sections/AgentEvals/Features.tsx
+++ b/components/v1/sections/AgentEvals/Features.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "motion/react";
+import Link from "next/link";
 import { reveals } from "@/utils/v1/reveals";
 import GradientFrame from "@/components/v1/sections/shared/GradientFrame";
 import Section from "@/components/v1/sections/shared/Section";
@@ -22,6 +23,7 @@ interface Feature {
   icon: string;
   iconWidth: number;
   iconHeight: number;
+  href?: string;
 }
 
 const FEATURES: Feature[] = [
@@ -31,6 +33,7 @@ const FEATURES: Feature[] = [
     icon: "/assets/v1/scale-instantly/ai-agents.svg",
     iconWidth: 27.77,
     iconHeight: 32,
+    href: "/docs/patterns/ai-evals/score-agents-on-real-outcomes?ref=agent-evals-features",
   },
   {
     title: "Live Experiments",
@@ -38,6 +41,7 @@ const FEATURES: Feature[] = [
     icon: "/assets/v1/scale-instantly/api-endpoints.svg",
     iconWidth: 30.02,
     iconHeight: 25.71,
+    href: "/docs/patterns/ai-evals/run-experiments-in-production?ref=agent-evals-features",
   },
   {
     title: "100% not 1%",
@@ -45,6 +49,7 @@ const FEATURES: Feature[] = [
     icon: "/assets/v1/scale-instantly/workflows.svg",
     iconWidth: 32,
     iconHeight: 32,
+    href: "/docs/platform/monitor/traces?ref=agent-evals-features",
   },
   {
     title: "Datasets",
@@ -52,6 +57,7 @@ const FEATURES: Feature[] = [
     icon: "/assets/v1/scale-instantly/serverless.svg",
     iconWidth: 32,
     iconHeight: 20.52,
+    href: "/docs/platform/monitor/insights?ref=agent-evals-features",
   },
   {
     title: "Sessions",
@@ -59,6 +65,7 @@ const FEATURES: Feature[] = [
     icon: "/assets/v1/scale-instantly/events.svg",
     iconWidth: 21.65,
     iconHeight: 32,
+    href: "/docs/features/events-triggers/sessions?ref=agent-evals-features",
   },
 ];
 
@@ -102,32 +109,51 @@ export default function Features() {
         </div>
 
         <ul className="grid grid-cols-1 gap-[22px] lg:grid-cols-3 lg:gap-[58px]">
-          {FEATURES.map((f, i) => (
-            <motion.li
-              key={f.title}
-              {...reveals.item(i)}
-              className="flex flex-col gap-2"
-            >
-              <div className="flex items-center gap-[10px]">
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center">
-                  <img
-                    src={f.icon}
-                    alt=""
-                    aria-hidden="true"
-                    width={f.iconWidth}
-                    height={f.iconHeight}
-                    className="block"
-                  />
-                </span>
-                <h3 className="text-v1-heading-xs text-v1-frost lg:text-v1-heading-card">
-                  {f.title}
-                </h3>
-              </div>
-              <p className="text-v1-heading-xs-loose text-pretty text-[#B3B3B3]">
-                {f.body}
-              </p>
-            </motion.li>
-          ))}
+          {FEATURES.map((f, i) => {
+            const inner = (
+              <>
+                <div className="flex items-center gap-[10px]">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center">
+                    <img
+                      src={f.icon}
+                      alt=""
+                      aria-hidden="true"
+                      width={f.iconWidth}
+                      height={f.iconHeight}
+                      className="block"
+                    />
+                  </span>
+                  <h3 className="text-v1-heading-xs text-v1-frost lg:text-v1-heading-card">
+                    {f.title}
+                  </h3>
+                </div>
+                <p className="text-v1-heading-xs-loose text-pretty text-[#B3B3B3]">
+                  {f.body}
+                </p>
+              </>
+            );
+            return (
+              <motion.li
+                key={f.title}
+                {...reveals.item(i)}
+                className="flex flex-col gap-2"
+              >
+                {f.href ? (
+                  <Link
+                    href={f.href}
+                    prefetch={false}
+                    className="-m-3 flex flex-col gap-2 rounded-md p-3 hover:bg-gradient-to-br hover:from-white/[0.06] hover:to-white/[0.02] motion-safe:transition-colors motion-safe:duration-200"
+                  >
+                    {inner}
+                  </Link>
+                ) : (
+                  <div className="flex cursor-default flex-col gap-2">
+                    {inner}
+                  </div>
+                )}
+              </motion.li>
+            );
+          })}
         </ul>
       </GradientFrame>
     </Section>

--- a/components/v1/sections/AgentEvals/UseCases.tsx
+++ b/components/v1/sections/AgentEvals/UseCases.tsx
@@ -22,6 +22,10 @@ const STUDIES: CaseStudyItem[] = [
         external pipeline, no trace ID threading.
       </>
     ),
+    cta: {
+      label: "Read the pattern",
+      href: "/docs/patterns/ai-evals/score-agents-on-real-outcomes?ref=agent-evals-usecases",
+    },
   },
   {
     id: "ab-test",
@@ -32,16 +36,28 @@ const STUDIES: CaseStudyItem[] = [
         cost, and latency across real users.
       </>
     ),
+    cta: {
+      label: "Read the pattern",
+      href: "/docs/patterns/ai-evals/run-experiments-in-production?ref=agent-evals-usecases",
+    },
   },
   {
     id: "llm-judge",
     title: "LLM-as-a-judge",
     body: <>Add this pattern to any experiment.</>,
+    cta: {
+      label: "Read the docs",
+      href: "/docs/examples/ai-eval-scorer-quickstart?ref=agent-evals-usecases",
+    },
   },
   {
     id: "cost",
     title: "Cost management",
     body: <>Learn how to instrument and measure costs across agents.</>,
+    cta: {
+      label: "Read the docs",
+      href: "/docs/examples/ai-metadata-quickstart?ref=agent-evals-usecases",
+    },
   },
   {
     id: "model-fallback",
@@ -52,6 +68,10 @@ const STUDIES: CaseStudyItem[] = [
         outage.
       </>
     ),
+    cta: {
+      label: "Read the docs",
+      href: "/docs/features/inngest-functions/error-retries/rollbacks?ref=agent-evals-usecases",
+    },
   },
 ];
 

--- a/components/v1/sections/Home/ScaleInstantly.tsx
+++ b/components/v1/sections/Home/ScaleInstantly.tsx
@@ -53,7 +53,7 @@ const RETRIES_CONTENT: TabContent = {
       icon: "/assets/v1/scale-instantly/ai-agents.svg",
       iconWidth: 27.77,
       iconHeight: 32,
-      href: "/ai",
+      href: "/ai?ref=homepage-durable-execution",
     },
     {
       title: "API Endpoints",
@@ -61,7 +61,7 @@ const RETRIES_CONTENT: TabContent = {
       icon: "/assets/v1/scale-instantly/api-endpoints.svg",
       iconWidth: 30.02,
       iconHeight: 25.71,
-      href: "/docs/learn/durable-endpoints",
+      href: "/docs/learn/durable-endpoints?ref=homepage-durable-execution",
     },
     {
       title: "Workflows",
@@ -69,7 +69,7 @@ const RETRIES_CONTENT: TabContent = {
       icon: "/assets/v1/scale-instantly/workflows.svg",
       iconWidth: 32,
       iconHeight: 32,
-      href: "/ai",
+      href: "/ai?ref=homepage-durable-execution",
     },
     {
       title: "Schedules",
@@ -77,7 +77,7 @@ const RETRIES_CONTENT: TabContent = {
       icon: "/assets/v1/scale-instantly/schedules.svg",
       iconWidth: 32,
       iconHeight: 12.85,
-      href: "/uses/scheduled-jobs",
+      href: "/uses/scheduled-jobs?ref=homepage-durable-execution",
     },
     {
       title: "Serverless",
@@ -85,7 +85,7 @@ const RETRIES_CONTENT: TabContent = {
       icon: "/assets/v1/scale-instantly/serverless.svg",
       iconWidth: 32,
       iconHeight: 20.52,
-      href: "/docs/reference/typescript/v4/extended-traces#serverless",
+      href: "/docs/reference/typescript/v4/extended-traces?ref=homepage-durable-execution#serverless",
     },
     {
       title: "Events",
@@ -93,7 +93,7 @@ const RETRIES_CONTENT: TabContent = {
       icon: "/assets/v1/scale-instantly/events.svg",
       iconWidth: 21.65,
       iconHeight: 32,
-      href: "/uses/webhooks",
+      href: "/uses/webhooks?ref=homepage-durable-execution",
     },
   ],
 };
@@ -118,31 +118,37 @@ const FLOW_CONTROL_CONTENT: TabContent = {
     {
       title: "Concurrency Control",
       body: "Every tenant gets their fair share, no matter how much work one of them throws at your app.",
+      href: "/docs/guides/concurrency?ref=homepage-flow-control",
       ...icon(0),
     },
     {
       title: "Throttling & Rate Limiting",
       body: "Absorb traffic spikes without dropping work—excess runs queue and drain at your rate.",
+      href: "/docs/guides/throttling?ref=homepage-flow-control",
       ...icon(1),
     },
     {
       title: "Debouncing",
       body: "Don’t burn compute on redundant work. Collapse bursts of identical events into one execution.",
+      href: "/docs/guides/debounce?ref=homepage-flow-control",
       ...icon(2),
     },
     {
       title: "Dynamic Prioritization",
       body: "Decide which work should take priority without starving the rest.",
+      href: "/docs/guides/priority?ref=homepage-flow-control",
       ...icon(3),
     },
     {
       title: "Batch Processing",
       body: "Reduce invocation costs on high-volume workloads by ensuring whatever comes first triggers the run.",
+      href: "/docs/guides/batching?ref=homepage-flow-control",
       ...icon(4),
     },
     {
       title: "Declarative Cancellation",
       body: "Cancel in-flight runs automatically if a matching event occurs.",
+      href: "/docs/features/inngest-functions/cancellation/cancel-on-events?ref=homepage-flow-control",
       ...icon(5),
     },
   ],
@@ -159,26 +165,31 @@ const OBSERVABILITY_CONTENT: TabContent = {
     {
       title: "Scoring",
       body: "One shot was never enough. We let you use real production outcomes to eval variants.",
+      href: "/docs/patterns/ai-evals/score-agents-on-real-outcomes?ref=homepage-agent-observability",
       ...icon(0),
     },
     {
       title: "Live Experiments",
       body: "Test what works against live production traffic, or in a sandbox.",
+      href: "/docs/patterns/ai-evals/run-experiments-in-production?ref=homepage-agent-observability",
       ...icon(1),
     },
     {
       title: "100% not 1%",
       body: "Track outcomes across every run, without needing to sample.",
+      href: "/docs/platform/monitor/traces?ref=homepage-agent-observability",
       ...icon(2),
     },
     {
       title: "Datasets",
       body: "Generate datasets of good and bad runs for evals and offline replay.",
+      href: "/docs/platform/monitor/insights?ref=homepage-agent-observability",
       ...icon(3),
     },
     {
       title: "Sessions",
       body: "Group multiple agent loops or turns as a single conversation, thread, or however you choose.",
+      href: "/docs/features/events-triggers/sessions?ref=homepage-agent-observability",
       ...icon(4),
     },
   ],


### PR DESCRIPTION
Adds links to the capability tiles under "Flow Control" and "Agent Observability" on the homepage so they're clickable (matching the existing "Durable Execution" tiles' hover/click behavior).

Flow Control:

Concurrency Control → /docs/guides/concurrency
Throttling & Rate Limiting → /docs/guides/throttling
Debouncing → /docs/guides/debounce
Dynamic Prioritization → /docs/guides/priority
Batch Processing → /docs/guides/batching
Declarative Cancellation → /docs/features/inngest-functions/cancellation/cancel-on-events

Agent Observability:

Scoring → /docs/patterns/ai-evals/score-agents-on-real-outcomes
Live Experiments → /docs/patterns/ai-evals/run-experiments-in-production
100% not 1% → /docs/platform/monitor/traces
Datasets → /docs/platform/monitor/insights
Sessions → /docs/features/events-triggers/sessions

No component logic changes needed — CapabilityTile already renders a link with the grey hover treatment when href is set.