### PR TITLE
Make announcement banner desktop-only, promote Agent Evals Lightning Lab

### DIFF
--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -5,6 +5,8 @@ type Props = {
   href: string;
   children: React.ReactNode;
   className?: string;
+  target?: string;
+  rel?: string;
 };
 
 /**
@@ -17,11 +19,14 @@ type Props = {
   `}</style>
  */
 
-const Banner: React.FC<Props> = ({ href, children, className }) => (
+const Banner: React.FC<Props> = ({ href, children, className, target, rel }) => (
   <a
     href={href}
+    target={target}
+    rel={rel}
     // use the .page-banner class to hide it on select pages via CSS
-    className={`page-banner group flex w-full items-center justify-center gap-2.5 border-b border-[rgb(var(--color-primary-subtle))]
+    // hidden on mobile/tablet, flex on desktop (md+) — matches the nav's own mobile/desktop breakpoint
+    className={`page-banner group hidden md:flex w-full items-center justify-center gap-2.5 border-b border-[rgb(var(--color-primary-subtle))]
                 px-6 py-2 text-base
                 text-basis transition-all ${className}`}
     style={{
@@ -38,11 +43,15 @@ const Banner: React.FC<Props> = ({ href, children, className }) => (
 
 export default function AnnouncementBanner() {
   return (
-    <Banner href="/blog/ai-in-production-report-2026?ref=site-banner">
-      What are the most confident teams using to build AI? →{" "}
+    <Banner
+      href="https://luma.com/inngest-r614?utm_source=web-banner"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       <strong className="underline underline-offset-2">
-        2026 Benchmark Report
-      </strong>
+        Join us on August 12th for an Agent Evals Lightning Lab
+      </strong>{" "}
+      →
     </Banner>
   );
 }

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -62,9 +62,9 @@ export default function AnnouncementBanner() {
       target="_blank"
       rel="noopener noreferrer"
     >
-      <strong className="font-semibold underline underline-offset-2">
+      <span className="font-normal underline underline-offset-2">
         Join us on August 12th for an Agent Evals Lightning Lab
-      </strong>{" "}
+      </span>{" "}
       →
     </Banner>
   );

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { RiRocket2Fill } from "@remixicon/react";
 
 type Props = {
   href: string;
@@ -19,25 +18,40 @@ type Props = {
   `}</style>
  */
 
+// Matches the v1 feature card salmon: bg-v1-accent-salmon-gradient = rgb(247, 98, 70).
+// Set as a literal (not a Tailwind `bg-v1-*` utility) so it renders correctly on
+// every caller of this shared component, including legacy/pages-router routes
+// that don't load styles/v1.css (where `--color-v1-*` custom properties are undefined).
+const BANNER_BG = "rgb(247, 98, 70)";
+
+// Inline SVG feTurbulence noise — zero network request, seamlessly tileable at any scale.
+const NOISE_BG =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.72' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='0.18'/%3E%3C/svg%3E\")";
+
 const Banner: React.FC<Props> = ({ href, children, className, target, rel }) => (
   <a
     href={href}
     target={target}
     rel={rel}
     // use the .page-banner class to hide it on select pages via CSS
-    // hidden on mobile/tablet, flex on desktop (md+) — matches the nav's own mobile/desktop breakpoint
-    className={`page-banner group hidden md:flex w-full items-center justify-center gap-2.5 border-b border-[rgb(var(--color-primary-subtle))]
-                px-6 py-2 text-base
-                text-basis transition-all ${className}`}
-    style={{
-      backgroundImage: `
-        linear-gradient(270deg, rgba(2, 117, 177, 0.80) 0%, rgba(21, 158, 136, 0.80) 0.02%, rgba(102, 189, 139, 0.80) 17.5%, rgba(45, 159, 101, 0.80) 100%)`,
-    }}
+    // hidden on mobile/tablet, flex on desktop (lg+) — matches the v1 redesign's
+    // own banner breakpoint from the prior global-promo-banner work
+    className={`page-banner group relative hidden lg:flex w-full items-center justify-center gap-1.5
+                overflow-hidden px-6 py-1.5 font-v1Heading text-sm
+                text-white transition-opacity hover:opacity-90 ${className}`}
+    style={{ backgroundColor: BANNER_BG }}
   >
-    <span className="rotate-45">
-      <RiRocket2Fill className="h-4 w-4 group-hover:animate-[wiggle_200ms_ease-in-out_infinite]" />
-    </span>
-    <span>{children}</span>
+    {/* Inline SVG noise overlay — soft-light grain with zero added bytes or requests */}
+    <span
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0"
+      style={{
+        backgroundImage: NOISE_BG,
+        backgroundSize: "200px 200px",
+        mixBlendMode: "soft-light",
+      }}
+    />
+    <span className="relative">{children}</span>
   </a>
 );
 
@@ -48,7 +62,7 @@ export default function AnnouncementBanner() {
       target="_blank"
       rel="noopener noreferrer"
     >
-      <strong className="underline underline-offset-2">
+      <strong className="font-semibold underline underline-offset-2">
         Join us on August 12th for an Agent Evals Lightning Lab
       </strong>{" "}
       →

--- a/components/v1/Header.tsx
+++ b/components/v1/Header.tsx
@@ -13,6 +13,7 @@ import Link from "@/components/v1/Link";
 import Button from "@/components/v1/Button";
 import Logo from "@/components/v1/Logo";
 import MobileMenu from "@/components/v1/MobileMenu";
+import AnnouncementBanner from "src/components/AnnouncementBanner";
 import NavMenuPanel from "@/components/v1/NavMenuPanel";
 import {
   NAV_PRIMARY,
@@ -235,6 +236,8 @@ export default function Header() {
       style={wipeFillStyle}
       data-ink-nav={inkNav ? "" : undefined}
     >
+      {/* Promo banner — hidden on /blog (LCP risk) and when header is compacted */}
+      {!compact && !pathname?.startsWith("/blog") && <AnnouncementBanner />}
       {/* Full-bleed container: the bar spans the full page width with
           only the gutters insetting it, so the left group (logo + nav)
           anchors to the left edge and the right group (Open Source /


### PR DESCRIPTION
Description:
Hides the global announcement banner on mobile/tablet — it now only renders at the md breakpoint and up, matching the same breakpoint the nav already uses to switch between its mobile hamburger and desktop links.
Banner to promote the August 12th Agent Evals Lightning Lab, linking out to https://luma.com/inngest-r614?utm_source=web-banner (opens in a new tab).
