### PR TITLE
Add sidebar CTA below blog TOC (for top 25 visited blog)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ See `snippets/CLAUDE.md` for full snippet documentation including validation com
 - `focus` (boolean) - Feature as highlighted post on main blog feed. Only use if a post must be highlighted for a longer time.
 - `hide` (boolean) - Accessible at URL but hidden from feeds and RSS. Only use for pre-release blog posts.
 - `featured` (boolean, optional) - When false, hidden from main feed but available on category pages.
+- `sidebarCta` (object, optional) - `{ text, buttonLabel, href }`. Renders a small text + button CTA below the table of contents in the sticky right rail (standard layout posts only; hidden below `lg`). Omit to render nothing.
 
 ### Changelog Entry Format
 

--- a/app/(v1)/blog/[slug]/BlogSidebarCta.tsx
+++ b/app/(v1)/blog/[slug]/BlogSidebarCta.tsx
@@ -1,0 +1,53 @@
+import ButtonLink from "@/components/v1/ButtonLink";
+import { cn } from "@/utils/v1/cn";
+
+export type BlogSidebarCtaProps = {
+  text: string;
+  buttonLabel: string;
+  href: string;
+  className?: string;
+};
+
+// Slim conversion CTA that sits directly beneath BlogToc in the blog
+// post's sticky right rail (see ArticleSection in page.tsx). It's a
+// plain server component — no "use client", no observers/listeners —
+// so it rides along inside BlogToc's existing `sticky` wrapper for
+// zero extra JS: ButtonLink/Button are already part of the page's
+// client bundle via BuildBetterAgentsCta below the article, so this
+// adds no new chunk, just a few bytes of server-rendered markup.
+//
+// Opt-in per post via the `sidebarCta` frontmatter field (see Scope
+// in page.tsx) — most posts render nothing here.
+export default function BlogSidebarCta({
+  text,
+  buttonLabel,
+  href,
+  className,
+}: BlogSidebarCtaProps) {
+  return (
+    <div
+      className={cn(
+        "mt-6 flex flex-col gap-4 rounded-[8px] border border-v1-strong/[0.35] px-6 py-6",
+        className
+      )}
+      style={{
+        backgroundImage:
+          "linear-gradient(-53.62deg, rgba(33,33,33,0) 2.25%, #020202 46.83%)",
+      }}
+    >
+      <p className="text-v1-body-sm text-v1-frost/80">{text}</p>
+      <ButtonLink
+        href={href}
+        variant="secondary"
+        size="sm"
+        // `sm` is the smallest step on the shared Button scale; these
+        // overrides shrink it further for this narrow sidebar slot.
+        // `cn` runs tailwind-merge, so these cleanly win over the
+        // `sm` size classes instead of just concatenating.
+        className="h-7 min-w-0 self-start px-4 text-[11px]"
+      >
+        {buttonLabel}
+      </ButtonLink>
+    </div>
+  );
+}

--- a/app/(v1)/blog/[slug]/page.tsx
+++ b/app/(v1)/blog/[slug]/page.tsx
@@ -19,6 +19,7 @@ import RegisterCue from "@/components/v1/sections/Events/RegisterCue";
 import StippleCtaSection from "@/components/v1/sections/shared/StippleCtaSection";
 import ArticleBody from "./ArticleBody";
 import BlogToc, { type BlogTocItem } from "./BlogToc";
+import BlogSidebarCta from "./BlogSidebarCta";
 import Prose from "@/components/v1/Prose";
 import { Unreleased } from "shared/Docs/Unreleased";
 import { getFullURL } from "src/utils/social";
@@ -55,6 +56,13 @@ type Scope = {
   reading?: { text: string };
   primaryCTA?: "docs" | "sales" | "signUp";
   floatingCTA?: boolean;
+  // Opt-in text + button CTA rendered below the TOC in the sticky
+  // right rail (standard layout only). Omit to render nothing.
+  sidebarCta?: {
+    text: string;
+    buttonLabel: string;
+    href: string;
+  };
   // Syndicated posts point canonical at the original source.
   canonical_url?: string;
   // When set, the post is gated behind ?unreleased=<label>.
@@ -436,9 +444,18 @@ function ArticleSection({
             <ArticleBody source={content} scope={scope} />
           </Prose>
         </div>
-        {/* TOC — right rail, sticky, hidden on mobile */}
+        {/* TOC (+ optional CTA below it) — right rail, sticky, hidden
+            on mobile. Both share one sticky wrapper so the CTA scrolls
+            with the TOC instead of needing its own sticky context. */}
         <div className="hidden lg:sticky lg:top-[100px] lg:block">
           <BlogToc items={tocItems} />
+          {scope.sidebarCta ? (
+            <BlogSidebarCta
+              text={scope.sidebarCta.text}
+              buttonLabel={scope.sidebarCta.buttonLabel}
+              href={scope.sidebarCta.href}
+            />
+          ) : null}
         </div>
       </div>
     </section>

--- a/content/blog/adding-a-second-middleware-broke-our-typescript-types.mdx
+++ b/content/blog/adding-a-second-middleware-broke-our-typescript-types.mdx
@@ -6,6 +6,10 @@ date: 2026-07-13
 author: Linell Bonnette
 category: engineering
 showSubtitle: true
+sidebarCta:
+  text: "Type-safe from day one. Set up Inngest in your Next.js app."
+  buttonLabel: "Next.js Quick Start Guide"
+  href: "/docs/getting-started/nextjs-quick-start?ref=blog-adding-a-second-middleware-broke-our-typescript-types-sidebar"
 ---
 
 While reading through `inngest-js`'s open issues, I came across one that was pretty surprising — **Multiple middlewares corrupt TS typings.**

--- a/content/blog/after-the-agent-signs-in.mdx
+++ b/content/blog/after-the-agent-signs-in.mdx
@@ -9,6 +9,10 @@ date: 2026-04-21
 category: engineering
 author: Sterling Chin
 primaryCTA: "report2026"
+sidebarCta:
+  text: "Agents that resume. Pause for input, then pick up where you left off."
+  buttonLabel: "Read the docs"
+  href: "/docs/learn/durable-agents?ref=blog-after-the-agent-signs-in-sidebar"
 ---
 
 *Companion to: [Inngest + Stripe Projects: Ship Durable Apps Without Leaving the Terminal](https://www.inngest.com/blog/inngest-stripe-projects-ship-durable-apps-without-leaving-the-terminal)*

--- a/content/blog/agent-loop-architecture.mdx
+++ b/content/blog/agent-loop-architecture.mdx
@@ -5,6 +5,10 @@ image: /assets/blog/agent-loop-architecture/featured-image.png
 date: 2026-06-18
 author: Dan Farrelly
 category: engineering
+sidebarCta:
+  text: "Build the agent loop. Durable agents that pause and resume, free to start."
+  buttonLabel: "Start free"
+  href: "/sign-up?ref=blog-agent-loop-architecture-sidebar"
 ---
 
 Everyone's asking "WTF is a loop?" Here's the question nobody's asking: what runs the loop?

--- a/content/blog/ai-agents-inngest-durable-steps.mdx
+++ b/content/blog/ai-agents-inngest-durable-steps.mdx
@@ -8,6 +8,10 @@ category: engineering
 author: Dan Farrelly
 showSubtitle: true
 primaryCTA: "report2026"
+sidebarCta:
+  text: "Durable steps for agents. Each step retries on its own, no restarts."
+  buttonLabel: "Explore steps"
+  href: "/docs/features/inngest-functions/steps-workflows?ref=blog-ai-agents-inngest-durable-steps-sidebar"
 ---
 
 Most AI agent tutorials stop at the happy path — call the LLM, run a tool, loop. But the moment you ship an agent to production, you hit the real problems: tool calls fail, LLM providers rate-limit you, long-running tasks time out, and you can't see what the hell happened when something goes wrong.

--- a/content/blog/ai-in-production-report-2026.mdx
+++ b/content/blog/ai-in-production-report-2026.mdx
@@ -10,6 +10,10 @@ image: /assets/blog/ai-in-production-report-2026-card/featured-image/featured-im
 date: "2026-05-05"
 category: company-news
 author: Lauren Craigie
+sidebarCta:
+  text: "Production is different. Build AI workflows that can't fail."
+  buttonLabel: "Start free"
+  href: "/sign-up?ref=blog-ai-in-production-report-2026-sidebar"
 ---
 
 <ReportExecSummary

--- a/content/blog/announcing-defer.mdx
+++ b/content/blog/announcing-defer.mdx
@@ -9,6 +9,10 @@ author:
   - Lauren Craigie
   - Linell Bonnette
 category: product-updates
+sidebarCta:
+  text: "Defer is a difference maker. Take back control over your workflows."
+  buttonLabel: "Start free"
+  href: "/sign-up?ref=blog-announcing-defer-sidebar"
 ---
 
 Orchestration tools are great at running one thing after another. They're worse at the follow-up — scoring an AI response with the prompt and latency the parent just produced, or waiting days for a conversion before recording whether a recommendation paid off. Today, that means a separate handler, a hand-rolled payload contract, and often a second platform sitting between them.

--- a/content/blog/announcing-the-constraint-api.mdx
+++ b/content/blog/announcing-the-constraint-api.mdx
@@ -7,6 +7,10 @@ subtitle: "How we extracted constraint enforcement into a dedicated service to u
 date: 2026-02-23
 author: Bruno Scheufler
 category: engineering
+sidebarCta:
+  text: "Preserve it in production. Add Inngest to your project in minutes."
+  buttonLabel: "Start free"
+  href: "/sign-up?ref=blog-announcing-the-constraint-api-sidebar"
 ---
 
 **Inngest's [flow control](/docs/guides/flow-control) features (for example [concurrency](/docs/guides/concurrency), [throttling](/docs/guides/throttling), and [rate limiting](/docs/guides/rate-limiting)) are some of the most powerful tools we offer. They let developers tailor function scheduling and execution to their business needs without building multi-tenant rate limiting infrastructure themselves. Today, I'm excited to share how we rebuilt the system behind these features from the ground up: the Constraint API.**

--- a/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
+++ b/content/blog/background-agents-are-here-your-orchestration-isnt-ready.md
@@ -12,6 +12,10 @@ image: /assets/blog/background-agents-are-here/featured-image-gold.png
 date: 2026-05-08
 author: Dan Farrelly
 primaryCTA: "report2026"
+sidebarCta:
+  text: "Keep it in your codebase. Everything you need to make it durable and observable."
+  buttonLabel: "Start free"
+  href: "/sign-up?ref=blog-background-agents-are-here-your-orchestration-isnt-ready-sidebar"
 ---
 
 Every six months, the "right" way to build an AI agent changes.

--- a/content/blog/build-self-learning-agent.mdx
+++ b/content/blog/build-self-learning-agent.mdx
@@ -8,6 +8,10 @@ date: 2026-04-16
 category: engineering
 author: "Mitchell Alderson (guest post)"
 primaryCTA: "report2026"
+sidebarCta:
+  text: "Build a smarter agent. Start with durable agents in your codebase."
+  buttonLabel: "Read the docs"
+  href: "/docs/learn/durable-agents?ref=blog-build-self-learning-agent-sidebar"
 ---
 
 I built an AI agent that improves its own prompts. Within hours of running the evaluation pipeline, the LLM discovered it could game the scoring system.

--- a/content/blog/building-the-inngest-queue-pt-i-fairness-multi-tenancy.mdx
+++ b/content/blog/building-the-inngest-queue-pt-i-fairness-multi-tenancy.mdx
@@ -7,6 +7,10 @@ image: /assets/blog/inngest-queue-pt-i/featured-image-v2.png
 date: 2024-01-22
 author: Tony Holdstock-Brown
 category: engineering
+sidebarCta:
+  text: "Fairness at scale. Per-tenant concurrency without the babysitting."
+  buttonLabel: "Flow Control Docs"
+  href: "/docs/guides/flow-control?ref=blog-building-the-inngest-queue-pt-i-fairness-multi-tenancy-sidebar"
 ---
 
 In software development, queueing systems are important for reliability, and they're hard to build.  There's lots of debate around *how* to build a queueing system — with [Postgres](https://news.ycombinator.com/item?id=35526846) and [SKIP LOCKED](https://news.ycombinator.com/item?id=37636841) *always* cropping up.

--- a/content/blog/context-engineering-in-practice.mdx
+++ b/content/blog/context-engineering-in-practice.mdx
@@ -8,6 +8,10 @@ date: 2025-11-07
 author: Charly Poly
 disableCTA: false
 primaryCTA: "report2026"
+sidebarCta:
+  text: "Engineer agent context. Build durable agents that hold state."
+  buttonLabel: "Read the docs"
+  href: "/docs/learn/durable-agents?ref=blog-context-engineering-in-practice-sidebar"
 ---
 
 A lot has been written about Context Engineering theory and its principles, with few examples. At Inngest, we are fortunate to experience context engineering in practice through our exchanges with our [community](http://inngest.com/discord) and [customers](http://inngest.com/customers), which include leading AI products such as [Outtake](/customers/outtake), [Replit](/blog/inngest-replit-vibe-code-ai-agents), and 11x.

--- a/content/blog/durable-execution-key-to-harnessing-ai-agents.mdx
+++ b/content/blog/durable-execution-key-to-harnessing-ai-agents.mdx
@@ -7,6 +7,10 @@ date: 2026-02-19
 author: Charly Poly
 category: engineering
 primaryCTA: "report2026"
+sidebarCta:
+  text: "Durable agents in prod. See how cubic cut false positives by 51%."
+  buttonLabel: "Read the story"
+  href: "/customers/cubic?ref=blog-durable-execution-key-to-harnessing-ai-agents-sidebar"
 ---
 
 ### Key Takeaways

--- a/content/blog/hanging-promises-for-control-flow.mdx
+++ b/content/blog/hanging-promises-for-control-flow.mdx
@@ -7,6 +7,10 @@ date: 2026-04-07
 author: Aaron Harper
 category: engineering
 primaryCTA: "report2026"
+sidebarCta:
+  text: "Handle sudden spikes. Flow control in one line of code."
+  buttonLabel: "Explore steps"
+  href: "/docs/features/inngest-functions/steps-workflows?ref=blog-hanging-promises-for-control-flow-sidebar"
 ---
 
 You can't cancel a JavaScript promise. There's no `.cancel()` method, no `AbortController` integration, no built-in way to say "never mind, stop." The TC39 committee [considered adding cancellation](https://github.com/tc39/proposal-cancelable-promises) in 2016, but the proposal was withdrawn after heated debate. Part of the problem is that cancelling arbitrary code mid-execution can leave resources in a dirty state (open handles, half-written data), so true cancellation requires cooperative cleanup, which undermines the simplicity people want from a `.cancel()` method.

--- a/content/blog/interactive-clis-with-bubbletea.md
+++ b/content/blog/interactive-clis-with-bubbletea.md
@@ -4,6 +4,10 @@ heading: "Rapidly building interactive CLIs in Go with Bubbletea"
 subtitle: Our product is just different enough to make our CLI require really good interactivity.  We bundle an interactive event browser in our CLI.  Here's how it's built.
 image: "/assets/blog/interactive-clis-with-bubbletea.jpg?v=2022-04-28"
 date: 2022-04-15
+sidebarCta:
+  text: "Build and test locally. Spin up the Inngest dev server in minutes."
+  buttonLabel: "Local Development Docs"
+  href: "/docs/local-development?ref=blog-interactive-clis-with-bubbletea-sidebar"
 ---
 
 In this post we’ll walk through our use of Bubbletea, an elm-inspired TUI interface for Golang. We’ll discuss why we chose it, some example code, and some thoughts. Let’s start with context — what we’re building and why.

--- a/content/blog/introducing-agent-evals.mdx
+++ b/content/blog/introducing-agent-evals.mdx
@@ -6,6 +6,10 @@ showSubtitle: true
 date: 2026-06-30
 author: Lauren Craigie
 category: product-updates
+sidebarCta:
+  text: "Score anything. Continuously improve agents with one line of code."
+  buttonLabel: "Start free"
+  href: "/sign-up?ref=blog-introducing-agent-evals-sidebar"
 ---
 
 An agent returns a perfect answer. The user doesn't convert, the ticket reopens, the customer churns. The output scored well on every metric you have, and none of it mattered to your bottom line.

--- a/content/blog/migrating-off-nextjs-tanstack-start.mdx
+++ b/content/blog/migrating-off-nextjs-tanstack-start.mdx
@@ -7,6 +7,10 @@ date: 2026-01-30
 category: engineering
 author: Jacob Heric
 showSubtitle: true
+sidebarCta:
+  text: "Add Inngest to your app. Get running with the Next.js quick start."
+  buttonLabel: "Next.js Quick Start Guide"
+  href: "/docs/getting-started/nextjs-quick-start?ref=blog-migrating-off-nextjs-tanstack-start-sidebar"
 ---
 
 At Inngest, DX is everything. Uniquely good, ergonomic APIs are why customers choose us, and stay with us. So it might not be surprising that every engineering decision follows the same checklist: **make it simple, make it obvious, make it delightful.** As such, it's nearly impossible to separate how we want devs to feel when using Inngest, from how we want our own team to feel when *building* Inngest.

--- a/content/blog/multi-tenant-ai-platform-flow-control.mdx
+++ b/content/blog/multi-tenant-ai-platform-flow-control.mdx
@@ -7,6 +7,10 @@ image: /assets/blog/multi-tenant-ai-platform-flow-control/featured-image.png
 date: 2026-05-27
 author: Lauren Craigie
 category: engineering
+sidebarCta:
+  text: "Fair, multi-tenant scale. Add concurrency and throttling in one line."
+  buttonLabel: "Flow Control Guide"
+  href: "/docs/guides/flow-control?ref=blog-multi-tenant-ai-platform-flow-control-sidebar"
 ---
 
 If you have an AI platform that serves many customers, or maybe more specifically—if every customer request hits the same OpenAI bill—this blog is for you. Regardless of your business model, your pipeline probably looks the same: **Long-running, non-deterministic, multi-step pipelines, where every step depends on 1-7 external providers that could fail for any number of reasons.** Which means, your product _is_ your pipeline.

--- a/content/blog/node-worker-threads-production.mdx
+++ b/content/blog/node-worker-threads-production.mdx
@@ -6,6 +6,10 @@ date: 2026-06-22
 author: Aaron Harper
 category: "engineering"
 image: /assets/blog/node-worker-threads-production/cover.png
+sidebarCta:
+  text: "Background jobs in NodeJS. Production-ready without managing infra."
+  buttonLabel: "Node.js Quick Start"
+  href: "/docs/getting-started/nodejs-quick-start?ref=blog-node-worker-threads-production-sidebar"
 ---
 
 In a [previous post](/blog/node-worker-threads?ref=blog-node-worker-threads-production), we wrote about why we moved [Inngest Connect](/docs/setup/connect?ref=blog-node-worker-threads-production) internals into a Node.js worker thread.

--- a/content/blog/node-worker-threads.mdx
+++ b/content/blog/node-worker-threads.mdx
@@ -7,6 +7,10 @@ date: 2026-03-18
 author: Aaron Harper
 category: "engineering"
 image: /assets/blog/node-worker-threads/cover.png
+sidebarCta:
+  text: "Skip the worker threads. Run durable background jobs in Node with Inngest."
+  buttonLabel: "Node.js Quick Start"
+  href: "/docs/getting-started/nodejs-quick-start?ref=blog-node-worker-threads-sidebar"
 ---
 
 Node.js runs on a single thread. That's usually fine. The event loop handles I/O concurrency without you thinking about locks, races, or deadlocks. But "single-threaded" has a cost that only shows up under pressure: if your JavaScript monopolizes the CPU, nothing else runs. No timers fire. No network callbacks execute. No I/O completes.

--- a/content/blog/principles-of-durable-execution.mdx
+++ b/content/blog/principles-of-durable-execution.mdx
@@ -14,6 +14,10 @@ teaser:
   - "Developers face many challenges when working with these systems. They need to handle failures, ensure reliability, and maintain observability in distributed environments. Additionally, they often find themselves grappling with concurrency issues while working with suboptimal tooling."
   - "Durable Execution has emerged as a powerful approach to address these challenges, enabling reliable, long-running software processes."
   - "Learn the principles of Durable Execution and how to apply it in your system today."
+sidebarCta:
+  text: "How durable execution works. Code that runs to completion, every time."
+  buttonLabel: "Read the docs"
+  href: "/docs/learn/how-functions-are-executed?ref=blog-principles-of-durable-execution-sidebar"
 ---
 import Blockquote from "src/shared/Blog/Blockquote";
 

--- a/content/blog/three-patterns-you-need-for-agentic-systems.md
+++ b/content/blog/three-patterns-you-need-for-agentic-systems.md
@@ -6,6 +6,10 @@ image: /assets/blog/three-patterns-you-need-for-agentic-systems/blog-banner.png
 date: 2026-03-11
 author: Dan Farrelly
 primaryCTA: "report2026"
+sidebarCta:
+  text: "Patterns for agentic systems. Proven building blocks in the docs."
+  buttonLabel: "See patterns"
+  href: "/docs/patterns?ref=blog-three-patterns-you-need-for-agentic-systems-sidebar"
 ---
 
 **Every agentic system that actually ships ends up needing three delegation patterns: one that blocks, one that fires and forgets, and one that runs later. The question isn't whether you need sub-agents — it's how you wire them up.**

--- a/content/blog/too-many-javascript-schema-libraries-support-only-one.mdx
+++ b/content/blog/too-many-javascript-schema-libraries-support-only-one.mdx
@@ -7,6 +7,10 @@ image: /assets/blog/too-many-javascript-schema-libraries-support-only-one/cover.
 date: 2026-06-10
 author: Aaron Harper
 category: engineering
+sidebarCta:
+  text: "Build type-safe workflows. See how Inngest fits your TypeScript stack."
+  buttonLabel: "View the docs"
+  href: "/docs?ref=blog-too-many-javascript-schema-libraries-support-only-one-sidebar"
 ---
 
 TypeScript developers have no shortage of schema libraries: Zod, Valibot, ArkType, Yup, Effect Schema, Superstruct, io-ts, Runtypes, TypeBox, Joi, and more.

--- a/content/blog/what-to-expect-when-youre-expecting-to-scale-asynchronous-workflows.mdx
+++ b/content/blog/what-to-expect-when-youre-expecting-to-scale-asynchronous-workflows.mdx
@@ -7,6 +7,10 @@ date: "2026-04-08"
 category: "engineering"
 author: "Lauren Craigie"
 showSubtitle: true
+sidebarCta:
+  text: "You need more than a queue. Build workflows that control flow by default."
+  buttonLabel: "Start free"
+  href: "/sign-up?ref=blog-what-to-expect-when-youre-expecting-to-scale-asynchronous-workflows-sidebar"
 ---
 
 Everyone needs retries, but not everyone needs priority queuing. Last week I was looking at product event data to find patterns in our most successful users. What features do they use? Where do less active users stall out? I do this because it helps me prioritize content: tighter docs, more examples, better guidelines.

--- a/content/blog/your-agent-just-learned-to-spend-money.mdx
+++ b/content/blog/your-agent-just-learned-to-spend-money.mdx
@@ -7,6 +7,10 @@ date: 2026-07-21
 category: engineering
 tags: ["AI & Agents", "Durable Execution", "Engineering"]
 author: Mitchell Alderson
+sidebarCta:
+  text: "Agents taking real actions? See how Otto runs high-stakes AI workflows."
+  buttonLabel: "Read the story"
+  href: "/customers/otto?ref=blog-your-agent-just-learned-to-spend-money-sidebar"
 ---
 Your AI Shopping Agent™️ works. It helps a customer pick the right product, charges their card, places the order, hands-free. Then one afternoon the payment gateway times out mid-charge, and your agent does the reasonable thing: it retries. Now the customer's been charged twice, and your support inbox is the first to find out. 
 

--- a/content/blog/your-agent-needs-a-harness-not-a-framework.mdx
+++ b/content/blog/your-agent-needs-a-harness-not-a-framework.mdx
@@ -7,6 +7,10 @@ date: 2026-03-03
 author: Dan Farrelly
 category: engineering
 primaryCTA: "report2026"
+sidebarCta:
+  text: "Give your agent a harness. Start building durable agents for free."
+  buttonLabel: "Start free"
+  href: "/sign-up?ref=blog-your-agent-needs-a-harness-not-a-framework-sidebar"
 ---
 
 In every engineering discipline, a harness is the same thing: the layer that connects, protects, and orchestrates components — without doing the work itself. A wiring harness routes signals between an engine, sensors, and dashboard. A test harness provides the scaffolding that makes code repeatable and observable. A safety harness catches you when you fall.


### PR DESCRIPTION
## What

Adds an opt-in text + button CTA that renders directly below the table
of contents in the sticky right rail on standard blog post layouts.
Enabled per post via a new `sidebarCta` frontmatter field:

sidebarCta:
  text: "Blurb copy."
  buttonLabel: "Button label"
  href: "/relative/path?ref=..."

Applied to the 25 posts in the CTA mapping doc, each with its own
copy/target from that doc.

## Performance

No client JS added. `BlogSidebarCta` is a plain server component (no
`"use client"`, no observers/listeners) — it reuses `ButtonLink`/
`Button`, which every blog post already loads for the CTA at the
bottom of the article, so this ships zero new JS bundle bytes. It's
rendered inside the TOC's existing sticky wrapper, which is already
hidden below the `lg` breakpoint, so nothing changes on mobile. No new
images, fonts, or network requests. Doesn't touch the hero/above-the-
fold content, so no LCP impact.

## Files

- `app/(v1)/blog/[slug]/BlogSidebarCta.tsx` — new component
- `app/(v1)/blog/[slug]/page.tsx` — wires it in below `BlogToc`,
  gated on `scope.sidebarCta`
- `AGENTS.md` — documents the new frontmatter field
- 25 `content/blog/*.mdx`/`.md` files — `sidebarCta` frontmatter per
  the CTA mapping doc

## Notes

- One copy correction: `introducing-agent-evals` had a typo in the
  source doc ("Continuously iimprove agents...") — fixed to "improve".
- Target URLs from the doc were converted to relative internal links
  with `?ref=blog-<slug>-sidebar` tags, per repo convention.