### PR TITLE
Document sessions on deferred functions

### DIFF
--- a/pages/docs/features/inngest-functions/deferred-functions.mdx
+++ b/pages/docs/features/inngest-functions/deferred-functions.mdx
@@ -117,6 +117,28 @@ async ({ event, parents }) => {
 }
 ```
 
+## Sessions
+
+A deferred run automatically joins the [sessions](/docs/features/events-triggers/sessions?ref=docs-deferred-functions) of the run that deferred it, so the two appear together in the dashboard without you passing anything.
+
+Pass `meta.sessions` to set a session on the deferred run explicitly:
+
+```ts
+defer("send-confirmation", {
+  function: sendEmail,
+  data: { to: event.data.email, body: "Thanks for your order!" },
+  meta: {
+    sessions: {
+      conversation_id: event.data.conversationId,
+    },
+  },
+});
+```
+
+Sessions set here take precedence over inherited ones. See the [sessions doc](/docs/features/events-triggers/sessions?ref=docs-deferred-functions) for more on how to use sessions.
+
+---
+
 ## Attributing scores to an experiment
 
 When the deferred function is an [LLM scorer](/docs/features/inngest-functions/steps-workflows/deferred-scoring), you can attribute its result to the [experiment variant](/docs/features/inngest-functions/steps-workflows/step-experiments) that produced the output being scored. Pass the `experimentRef` returned by `group.experiment()` as the `experiment` option:
@@ -137,7 +159,7 @@ The variant is surfaced to the deferred handler on `parents[0].experiment` as `{
 
 Because `defer(...)` is fire-and-forget, a bad call should never derail the surrounding handler.
 
-- **Call-site errors**, such as a synchronous schema failure or passing a function that wasn't created with `createDefer`, are logged via the internal logger and the call is silently skipped. The parent run continues normally and the deferred function does not fire.
+- **Call-site errors**, such as a synchronous schema failure, an invalid `meta.sessions` value, or passing a function that wasn't created with `createDefer`, are logged via the internal logger and the call is silently skipped. The parent run continues normally and the deferred function does not fire.
 - **Receiver-side errors** fail the deferred run itself, never the parent. A schema mismatch on the received `event.data` fails the run without retries, because retrying can't change the data. A handler that throws for any other reason fails with normal retry semantics.
 
 ---

--- a/pages/docs/reference/typescript/v4/client/create.mdx
+++ b/pages/docs/reference/typescript/v4/client/create.mdx
@@ -76,6 +76,11 @@ const inngest = new Inngest({
 
     Set this to `false` to opt out of the SDK's built-in AI metadata extraction. This does not affect [Extended Traces](/docs/reference/typescript/v4/extended-traces).
   </Property>
+  <Property name="sessionPropagation" type="boolean">
+    Whether events created during a run — via `inngest.send()`, `step.sendEvent()`, `step.invoke()`, and `defer()` — inherit the run's [sessions](/docs/features/events-triggers/sessions?ref=docs-reference-client-create), so the resulting child runs stay grouped with their parent. Defaults to `true`.
+
+    Set this to `false` to opt out. Sessions you set explicitly in `meta.sessions` are still sent. See [disabling propagation](/docs/features/events-triggers/sessions?ref=docs-reference-client-create#disabling-propagation).
+  </Property>
   <Property name="endpointAdapter" type="InngestEndpointAdapter.Like">
     An endpoint adapter that enables [Durable Endpoints](/docs/reference/typescript/v4/durable-endpoints).  When provided, `inngest.endpoint()` and `inngest.endpointProxy()` become available.
   </Property>

--- a/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
+++ b/pages/docs/reference/typescript/v4/functions/deferred-functions.mdx
@@ -128,6 +128,14 @@ await step.run("notify", async () => {
       <Property name="data" type="object" required>
         Payload to send to the deferred function. Typed from `function.schema` when present.
       </Property>
+      <Property name="meta" type="object">
+        Event metadata shared with the deferred run.
+        <Properties nested>
+          <Property name="sessions" type="Record<string, string | number | null> | null">
+            [Sessions](/docs/features/events-triggers/sessions?ref=docs-reference-deferred-functions) to add to or override on the deferred run. Manually set sessions take precedence over sessions inherited from the calling run. A `null` value clears an inherited session for that key; setting `sessions` itself to `null` clears every inherited session. Numbers are normalized to strings.
+          </Property>
+        </Properties>
+      </Property>
     </Properties>
   </Property>
 </Properties>
@@ -164,11 +172,35 @@ Call-site validation must be synchronous because `defer(...)` itself is sync. If
 
 ---
 
+## Sessions
+
+A deferred run inherits the [sessions](/docs/features/events-triggers/sessions?ref=docs-reference-deferred-functions) of the run that called `defer(...)`, so the two are grouped together in the dashboard. Pass `meta.sessions` to add or override sessions on the deferred run:
+
+```ts
+defer("score", {
+  function: feedbackScorer,
+  data: { ticketId },
+  meta: {
+    sessions: {
+      conversation_id: "conv_1234", // add or override
+      internal_trace_id: null,      // clear an inherited session
+    },
+  },
+});
+```
+
+- Manually set sessions win over inherited ones, per key.
+- `meta.sessions: null` clears every inherited session.
+- Session IDs must be strings or finite numbers; numbers are normalized to strings. An invalid value is a call-site error — the whole `defer(...)` call is logged and skipped.
+- Inheritance is controlled by the client-level [`sessionPropagation`](/docs/reference/typescript/v4/client/create#configuration) option. Sessions passed explicitly in `meta.sessions` are sent regardless of that setting.
+
+---
+
 ## Error handling
 
 `defer(...)` is fire-and-forget, so a bad call should not derail the surrounding handler.
 
-- **Call-site errors** (for example, a synchronous schema failure) are logged via the internal logger and the call is silently skipped. The parent run continues normally and the deferred function does not fire.
+- **Call-site errors** (for example, a synchronous schema failure, or an invalid `meta.sessions` value) are logged via the internal logger and the call is silently skipped. The parent run continues normally and the deferred function does not fire.
 - **Receiver-side errors** (the deferred run reading invalid `event.data`, or the handler throwing) fail the deferred run itself with normal retry semantics.
 
 ---

--- a/pages/docs/reference/typescript/v4/functions/step-invoke.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-invoke.mdx
@@ -62,6 +62,14 @@ const mainFunction = inngest.createFunction(
           <Property name="user" type="object">
             Optional user context for the invocation.
           </Property>
+          <Property name="meta" type="object">
+            Optional event metadata for the invocation.
+            <Properties nested={true}>
+              <Property name="sessions" type="Record<string, string | number | null> | null">
+                [Sessions](/docs/features/events-triggers/sessions?ref=docs-reference-step-invoke) to add to or override on the invoked run, which otherwise inherits the calling run's sessions. A `null` value clears an inherited session for that key; setting `sessions` itself to `null` clears every inherited session. Numbers are normalized to strings.
+              </Property>
+            </Properties>
+          </Property>
           <Property name="timeout" type="string | number | Date | Temporal.Duration | Temporal.Instant | Temporal.ZonedDateTime">
             {/* Purposefully not mentioning the default timeout of 1 year, as we expect to lower this very soon. */}
             How long to wait for the invoked function to complete. Either:

--- a/pages/docs/reference/typescript/v4/functions/step-send-event.mdx
+++ b/pages/docs/reference/typescript/v4/functions/step-send-event.mdx
@@ -46,6 +46,8 @@ To send events from outside of the context of a function, use [`inngest.send()`]
         An event payload object or an array of event payload objects.
 
         [See the documentation for `inngest.send()`](/docs/reference/typescript/v4/events/send#inngest-send-event-payload-event-payload-promise) for the event payload format.
+
+        Events sent from within a run inherit the run's [sessions](/docs/features/events-triggers/sessions?ref=docs-reference-step-send-event). Use `meta.sessions` on the payload to add or override them.
       </Property>
     </Properties>
   </Col>


### PR DESCRIPTION
- Document sessions outside of the main sessions page.

I recommend reviewing with these links to the preview:

- [Deferred functions](https://website-git-scott-defer-sessions-docs-inngest.vercel.app/docs/features/inngest-functions/deferred-functions#sessions) — new Sessions section, plus an [error handling](https://website-git-scott-defer-sessions-docs-inngest.vercel.app/docs/features/inngest-functions/deferred-functions#error-handling) note that an invalid session value drops the whole `defer()` call
- [Deferred functions reference](https://website-git-scott-defer-sessions-docs-inngest.vercel.app/docs/reference/typescript/v4/functions/deferred-functions#sessions) — new Sessions section and the `meta.sessions` property on `defer(id, options)`
- [Client reference](https://website-git-scott-defer-sessions-docs-inngest.vercel.app/docs/reference/typescript/v4/client/create#configuration) — new `sessionPropagation` option
- [`step.invoke()`](https://website-git-scott-defer-sessions-docs-inngest.vercel.app/docs/reference/typescript/v4/functions/step-invoke#meta) — new `meta.sessions` property
- [`step.sendEvent()`](https://website-git-scott-defer-sessions-docs-inngest.vercel.app/docs/reference/typescript/v4/functions/step-send-event#step-send-event-id-event-payload-event-payload-promise-ids-string) — note that events sent from a run inherit its sessions

Notes:
- Do not merge until sessions propagation is released with opt-out
- EXE-2035