### PR TITLE
docs(otel): add aiMiddleware quick start

### DIFF
--- a/content/changelog/2026-08-11-ai-middleware.mdx
+++ b/content/changelog/2026-08-11-ai-middleware.mdx
@@ -1,0 +1,25 @@
+export const title = "aiMiddleware: scoring, metadata, and Extended Traces in one bundle";
+export const date = "2026-08-11";
+export const unreleased = "ai-middleware";
+
+`aiMiddleware()` enables the TypeScript SDK's experimental AI features in one place: scoring (`step.score()`), step metadata (`step.metadata()`), and Extended Traces (`ctx.tracer`). Each previously needed its own middleware from `inngest/experimental`; one call now covers all three.
+
+```ts
+import { Inngest } from "inngest";
+import { aiMiddleware } from "inngest/experimental";
+
+export const inngest = new Inngest({
+  id: "my-app",
+  middleware: [...aiMiddleware()],
+});
+```
+
+Extended Traces attach to your registered OpenTelemetry provider by default; pass `traces: { behaviour: "off" }` to leave your provider untouched. Add your own middleware alongside the spread: `middleware: [...aiMiddleware(), myMiddleware]`.
+
+If you already use `scoreMiddleware()`, `metadataMiddleware()`, or `extendedTracesMiddleware()`, replace them with the bundle rather than adding it alongside them. In particular, running `extendedTracesMiddleware()` and `aiMiddleware()` together attaches two span processors to your provider, so every span is exported twice. Options you passed to `extendedTracesMiddleware()` move to the bundle's `traces` option: `extendedTracesMiddleware({ behaviour: "off" })` becomes `aiMiddleware({ traces: { behaviour: "off" } })`. The deprecated `"auto"` and `"createProvider"` behaviours are not part of the bundle; use [`@inngest/otel`](https://www.npmjs.com/package/@inngest/otel) to set up a provider instead.
+
+Available now in beta: `npm install inngest@latest`.
+
+- [OpenTelemetry setup and quick start](/docs/examples/open-telemetry?ref=changelog-ai-middleware)
+- [Extended Traces reference](/docs/reference/typescript/v4/extended-traces?ref=changelog-ai-middleware)
+- [Score a function run](/docs/features/inngest-functions/steps-workflows/scoring?ref=changelog-ai-middleware)

--- a/pages/docs/examples/open-telemetry.mdx
+++ b/pages/docs/examples/open-telemetry.mdx
@@ -1,4 +1,4 @@
-import { VersionBadge, Callout } from "src/shared/Docs/mdx";
+import { VersionBadge, Callout, Unreleased } from "src/shared/Docs/mdx";
 
 export const metaTitle = "OpenTelemetry Integration with Inngest"
 export const description = "Set up OpenTelemetry with Inngest for AI metadata extraction and Extended Traces. Use @inngest/otel or bring your own OpenTelemetry provider."
@@ -12,7 +12,37 @@ Inngest uses OpenTelemetry for two separate features:
 - **AI metadata extraction:** Extract AI metadata from OpenTelemetry spans with OpenTelemetry GenAI attributes and attach it to the step where the model call happened. This is enabled by default with `aiMetadata: true`.
 - **Extended Traces:** Export spans from inside your function run into [Inngest Traces](/docs/platform/monitor/traces#extended-traces), so database queries, HTTP calls, AI requests, and custom spans appear in the run timeline.
 
-This guide first shows how to set up OpenTelemetry in your process. After that, it shows how to use that setup for AI metadata extraction and Extended Traces.
+<Unreleased label="ai-middleware" fallback={<p>This guide first shows how to set up OpenTelemetry in your process. After that, it shows how to use that setup for AI metadata extraction and Extended Traces.</p>}>
+
+## Quick start
+
+If your application does not already configure OpenTelemetry, install [`@inngest/otel`](https://www.npmjs.com/package/@inngest/otel) and preload it so it registers a provider and common instrumentation before any application code loads:
+
+```shell
+npm install @inngest/otel
+```
+
+```shell
+node --import @inngest/otel/node ./app.js
+```
+
+Then add `aiMiddleware()` to your Inngest client. It enables Extended Traces on the provider you just registered, along with scoring ([`step.score()`](/docs/features/inngest-functions/steps-workflows/scoring?ref=docs-open-telemetry)) and step metadata ([`step.metadata()`](/docs/features/inngest-functions/steps-workflows/step-metadata-how-to?ref=docs-open-telemetry)):
+
+```ts inngest/client.ts
+import { Inngest } from "inngest";
+import { aiMiddleware } from "inngest/experimental";
+
+export const inngest = new Inngest({
+  id: "my-app",
+  middleware: aiMiddleware(),
+});
+```
+
+No other configuration is needed. AI metadata extraction is on by default, and spans from model calls, HTTP requests, and database queries now appear in your run traces. `aiMiddleware()` returns a tuple of middleware, so spread it to combine the bundle with your own: `middleware: [...aiMiddleware(), myMiddleware]`.
+
+If a framework CLI starts your dev server, pass the preload through `NODE_OPTIONS` instead (see [Framework dev servers](#framework-dev-servers)). The rest of this guide covers bringing your own OpenTelemetry provider and configuring each feature on its own.
+
+</Unreleased>
 
 ## Set up OpenTelemetry
 
@@ -197,6 +227,12 @@ See the [`aiMetadata` client option](/docs/reference/typescript/v4/client/create
 
 Extended Traces export application OpenTelemetry spans from inside an Inngest function run to [Inngest Traces](/docs/platform/monitor/traces#extended-traces). Use this when you want HTTP calls, database queries, AI requests, and custom spans to appear in the run timeline.
 
+<Unreleased label="ai-middleware">
+
+`aiMiddleware()` from the [quick start](#quick-start) already enables Extended Traces. Use `extendedTracesMiddleware()` directly when you want Extended Traces without the rest of the bundle.
+
+</Unreleased>
+
 If you create the provider yourself, add `new InngestSpanProcessor(inngest)` to that provider and configure the Inngest middleware with `behaviour: "off"`.
 
 The provider setup imports your Inngest client, so keep that module focused on creating the client. Do not use it as a barrel file that imports your app entrypoint, functions, route handlers, database clients, or AI SDK clients. Those modules should import the Inngest client, not the other way around.
@@ -237,6 +273,12 @@ If you create the OpenTelemetry provider yourself and add `InngestSpanProcessor`
 If you want the middleware to attach to an already-registered provider, set `behaviour` to `"extendProvider"`.
 
 Avoid `behaviour: "createProvider"` for new setups. Provider creation from the middleware is deprecated.
+
+<Unreleased label="ai-middleware">
+
+With `aiMiddleware()`, set the mode through its `traces` option: `aiMiddleware({ traces: { behaviour: "off" } })`.
+
+</Unreleased>
 
 </Callout>
 

--- a/pages/docs/examples/open-telemetry.mdx
+++ b/pages/docs/examples/open-telemetry.mdx
@@ -34,11 +34,11 @@ import { aiMiddleware } from "inngest/experimental";
 
 export const inngest = new Inngest({
   id: "my-app",
-  middleware: aiMiddleware(),
+  middleware: [...aiMiddleware()],
 });
 ```
 
-No other configuration is needed. AI metadata extraction is on by default, and spans from model calls, HTTP requests, and database queries now appear in your run traces. `aiMiddleware()` returns a tuple of middleware, so spread it to combine the bundle with your own: `middleware: [...aiMiddleware(), myMiddleware]`.
+No other configuration is needed. AI metadata extraction is on by default, and spans from model calls, HTTP requests, and database queries now appear in your run traces. Add your own middleware alongside the spread: `middleware: [...aiMiddleware(), myMiddleware]`.
 
 If a framework CLI starts your dev server, pass the preload through `NODE_OPTIONS` instead (see [Framework dev servers](#framework-dev-servers)). The rest of this guide covers bringing your own OpenTelemetry provider and configuring each feature on its own.
 

--- a/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
+++ b/pages/docs/features/inngest-functions/steps-workflows/scoring.mdx
@@ -1,4 +1,4 @@
-import { Callout, CodeGroup } from "src/shared/Docs/mdx";
+import { Callout, CodeGroup, Unreleased } from "src/shared/Docs/mdx";
 
 
 export const metaTitle = "Score Inngest Function Runs | AI Evaluation Docs"
@@ -45,6 +45,12 @@ export default inngest.createFunction(
   }
 );
 ```
+
+<Unreleased label="ai-middleware">
+
+`aiMiddleware()` (also from `inngest/experimental`) enables scoring too, bundled with step metadata and [Extended Traces](/docs/examples/open-telemetry?ref=docs-scoring#quick-start): `middleware: [...aiMiddleware()]`.
+
+</Unreleased>
 
 `step.score()` attaches the score to the current run. Its first argument is a durable step ID that memoizes the write, so a retry or replay can't record it twice. Use it when you know the outcome before the function finishes.
 

--- a/pages/docs/learn/agent-evals.mdx
+++ b/pages/docs/learn/agent-evals.mdx
@@ -1,4 +1,4 @@
-import { Callout } from "src/shared/Docs/mdx";
+import { Callout, Unreleased } from "src/shared/Docs/mdx";
 import { ResourceGrid, Resource } from "src/shared/Docs/Resources";
 import { VideoCameraIcon } from "@heroicons/react/24/outline";
 
@@ -60,6 +60,12 @@ export default inngest.createFunction(
 ```
 
 [`step.score()`](/docs/reference/typescript/v4/functions/scoring?ref=docs-agent-evals#step-score-id-options) is durable and memoized. If the function retries or replays, Inngest does not record the same score twice.
+
+<Unreleased label="ai-middleware">
+
+To enable scoring together with step metadata and Extended Traces, use `aiMiddleware()` from `inngest/experimental` instead: `middleware: [...aiMiddleware()]`. See the [OpenTelemetry quick start](/docs/examples/open-telemetry?ref=docs-agent-evals#quick-start).
+
+</Unreleased>
 
 ## How Agent Evals works
 

--- a/pages/docs/reference/typescript/v4/extended-traces.mdx
+++ b/pages/docs/reference/typescript/v4/extended-traces.mdx
@@ -1,4 +1,4 @@
-import { Info, Callout, Note, CardGroup, Card } from "src/shared/Docs/mdx";
+import { Info, Callout, Note, CardGroup, Card, Unreleased } from "src/shared/Docs/mdx";
 import { RiBarChart2Fill } from "@remixicon/react";
 
 
@@ -16,6 +16,14 @@ If you want Inngest to set up OpenTelemetry for you, use [`@inngest/otel`](https
 ## Basic Usage
 
 Use this path when your application does not already configure OpenTelemetry. Install and use `@inngest/otel` to set up a Node.js OpenTelemetry provider and common instrumentations before your application code starts, and `extendedTracesMiddleware()` attaches to that provider.
+
+<Unreleased label="ai-middleware">
+
+<Note>
+  `aiMiddleware()` bundles this middleware with scoring and step metadata; see the [quick start](/docs/examples/open-telemetry?ref=docs-extended-traces#quick-start). If you already use `extendedTracesMiddleware()`, replace it with the bundle rather than registering both — two instances attach two span processors and export every span twice.
+</Note>
+
+</Unreleased>
 
 Preload it before your application:
 
@@ -124,6 +132,12 @@ The options are:
 - `"createProvider"` (deprecated): Only attempt to create a provider. Use `@inngest/otel` instead.
 - `"off"`: Do nothing
 
+<Unreleased label="ai-middleware">
+
+When configured via `aiMiddleware({ traces: { ... } })`, only `"extendProvider"` (its default) and `"off"` are available; there is no `instrumentations` option.
+
+</Unreleased>
+
 If you only use `extendedTracesMiddleware()` to extend an existing provider, you do not need to call it before other application code. The provider and instrumentation setup remains owned by your existing OpenTelemetry configuration.
 
 ### Manually extend
@@ -195,3 +209,9 @@ const sdk = new NodeSDK({
 
 sdk.start();
 ```
+
+<Unreleased label="ai-middleware">
+
+With the bundle, the equivalent is `aiMiddleware({ traces: { behaviour: "off" } })`.
+
+</Unreleased>

--- a/pages/docs/reference/typescript/v4/functions/metadata.mdx
+++ b/pages/docs/reference/typescript/v4/functions/metadata.mdx
@@ -1,4 +1,4 @@
-import { CodeGroup, VersionBadge, Info, Warning } from "src/shared/Docs/mdx";
+import { CodeGroup, VersionBadge, Info, Warning, Unreleased } from "src/shared/Docs/mdx";
 
 
 export const metaTitle = "step.metadata() | Attach Metadata to Runs (SDK v4)"
@@ -27,6 +27,12 @@ const inngest = new Inngest({
 ```
 
 This makes `step.metadata()` available inside function handlers and `inngest.metadata` available on the client instance.
+
+<Unreleased label="ai-middleware">
+
+Alternatively, `aiMiddleware()` enables step metadata alongside scoring and [Extended Traces](/docs/examples/open-telemetry?ref=docs-metadata#quick-start): `middleware: [...aiMiddleware()]`.
+
+</Unreleased>
 
 ## `step.metadata(memoId)`
 

--- a/pages/docs/reference/typescript/v4/functions/scoring.mdx
+++ b/pages/docs/reference/typescript/v4/functions/scoring.mdx
@@ -1,4 +1,4 @@
-import { Callout, Properties, Property, Row, Col } from "src/shared/Docs/mdx";
+import { Callout, Properties, Property, Row, Col, Unreleased } from "src/shared/Docs/mdx";
 
 export const metaTitle = "inngest.score() | Score AI Outputs (TypeScript SDK v4)"
 export const description = "Attach numeric or boolean quality scores to AI function runs, steps, and experiment variants to track LLM-as-a-judge evals and performance across model versions."
@@ -98,6 +98,12 @@ await inngest.score.experiment({
 ## `step.score(id, options)`
 
 Score the current run from within a step context, as a durable, memoized step. `runId` is automatically set to the current run. Requires `scoreMiddleware()` (from `inngest/experimental`) on the client.
+
+<Unreleased label="ai-middleware">
+
+`aiMiddleware()` satisfies this too: `middleware: [...aiMiddleware()]`.
+
+</Unreleased>
 
 <Properties>
   <Property name="id" type="string" required>


### PR DESCRIPTION
Add a quick start for `aiMiddleware()` to the OpenTelemetry guide, gated behind `?unreleased=ai-middleware` until the SDK feature ships, plus notes mapping its `traces` option to the Extended Traces behaviour modes.

SDK: inngest/inngest-js#1695 (aiMiddleware), inngest/inngest-js#1696 (example app).