### PR TITLE
Swap Lightning Lab register CTA for watch-recording link

### DIFF
--- a/components/v1/pages/LightningLabShipYourFirstEval.tsx
+++ b/components/v1/pages/LightningLabShipYourFirstEval.tsx
@@ -19,6 +19,9 @@ const EVENT = {
 
 const REGISTER_URL = "https://luma.com/inngest-r614?utm_source=eventspage";
 
+const RECORDING_URL =
+  "https://events.zoom.us/e/recording?videoId=uKbFJoUhRQKS9V71ysKkLw&eventId=Z8vtvPiATTq_LQxwlO8_ZA&organizationId=Jm1kZRVvQC6tCNBq9FaDag";
+
 const COVERAGE = [
   "Determining a first scoring metric",
   "Attaching a scorer to a function you've already deployed",
@@ -250,9 +253,16 @@ export default function LightningLabShipYourFirstEval() {
               </div>
 
               {isPastEvent(EVENT) ? (
-                <Chip variant="solid" size="md" className="self-start font-normal">
-                  Past event
-                </Chip>
+                <div className="flex flex-col items-start gap-4">
+                  <Chip variant="solid" size="md" className="self-start font-normal">
+                    Past event
+                  </Chip>
+                  <Button asChild variant="accent" className="self-start">
+                    <a href={RECORDING_URL} target="_blank" rel="noopener noreferrer">
+                      Watch the recording →
+                    </a>
+                  </Button>
+                </div>
               ) : (
                 <Button asChild variant="accent" className="self-start">
                   <a href={REGISTER_URL} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary
- The Lightning Lab webinar (Aug 12) has already happened
- Its detail page now shows the "Past event" chip alongside a "Watch the recording →" button linking to the Zoom recording, instead of a bare chip with no CTA
- The "Register here" Luma link is only used for events that haven't happened yet, unchanged for future events

## Notes for reviewer
- Recording link: `https://events.zoom.us/e/recording?videoId=uKbFJoUhRQKS9V71ysKkLw&eventId=Z8vtvPiATTq_LQxwlO8_ZA&organizationId=Jm1kZRVvQC6tCNBq9FaDag`
- The "Past event" chip on `/events` cards was already automatic (driven by `isPastEvent`/`startsAt`) — no data changes needed there

## Test plan
- [x] Verified `/events/lightning-lab-ship-your-first-eval` shows "Past event" chip + "Watch the recording" button linking to the Zoom URL
- [x] Verified `/events` still shows the card with a "Past event" chip and "View event details" CTA
- [x] Typecheck passes; checked browser console for errors — none found