### PR TITLE
Add Agent Evals Lightning Lab webinar CTA to eval-focused posts

### DIFF
--- a/app/(v1)/blog/[slug]/BlogSidebarCta.tsx
+++ b/app/(v1)/blog/[slug]/BlogSidebarCta.tsx
@@ -24,6 +24,12 @@ export default function BlogSidebarCta({
   href,
   className,
 }: BlogSidebarCtaProps) {
+  // Off-site targets (e.g. a Zoom recording) open in a new tab, per
+  // the same convention as LightningLabShipYourFirstEval's external
+  // register link — internal /docs, /sign-up, /customers, etc. links
+  // navigate in-tab as usual.
+  const isExternal = /^https?:\/\//i.test(href);
+
   return (
     <div
       className={cn(
@@ -45,6 +51,9 @@ export default function BlogSidebarCta({
         // `cn` runs tailwind-merge, so these cleanly win over the
         // `sm` size classes instead of just concatenating.
         className="h-7 min-w-0 self-start px-4 text-[11px]"
+        {...(isExternal
+          ? { target: "_blank", rel: "noopener noreferrer" }
+          : {})}
       >
         {buttonLabel}
       </ButtonLink>

--- a/content/blog/introducing-agent-evals.mdx
+++ b/content/blog/introducing-agent-evals.mdx
@@ -7,9 +7,9 @@ date: 2026-06-30
 author: Lauren Craigie
 category: product-updates
 sidebarCta:
-  text: "Score anything. Continuously improve agents with one line of code."
-  buttonLabel: "Start free"
-  href: "/sign-up?ref=blog-introducing-agent-evals-sidebar"
+  text: "You're already running agents in prod. Learn how to ship your first eval."
+  buttonLabel: "Watch the recording"
+  href: "https://events.zoom.us/e/recording?videoId=uKbFJoUhRQKS9V71ysKkLw&eventId=Z8vtvPiATTq_LQxwlO8_ZA&organizationId=Jm1kZRVvQC6tCNBq9FaDag"
 ---
 
 An agent returns a perfect answer. The user doesn't convert, the ticket reopens, the customer churns. The output scored well on every metric you have, and none of it mattered to your bottom line.

--- a/content/blog/introducing-group-experiment.mdx
+++ b/content/blog/introducing-group-experiment.mdx
@@ -6,6 +6,10 @@ showSubtitle: true
 date: 2026-06-23
 author: Lauren Craigie
 category: product-updates
+sidebarCta:
+  text: "You're already running agents in prod. Learn how to ship your first eval."
+  buttonLabel: "Watch the recording"
+  href: "https://events.zoom.us/e/recording?videoId=uKbFJoUhRQKS9V71ysKkLw&eventId=Z8vtvPiATTq_LQxwlO8_ZA&organizationId=Jm1kZRVvQC6tCNBq9FaDag"
 ---
 
 The data you need to actually judge a workflow experiment has never been reachable from where you run experiments today.

--- a/content/blog/introducing-scoring.mdx
+++ b/content/blog/introducing-scoring.mdx
@@ -6,6 +6,10 @@ showSubtitle: true
 date: 2026-06-30
 author: Lauren Craigie
 category: product-updates
+sidebarCta:
+  text: "You're already running agents in prod. Learn how to ship your first eval."
+  buttonLabel: "Watch the recording"
+  href: "https://events.zoom.us/e/recording?videoId=uKbFJoUhRQKS9V71ysKkLw&eventId=Z8vtvPiATTq_LQxwlO8_ZA&organizationId=Jm1kZRVvQC6tCNBq9FaDag"
 ---
 
 Durable execution ensures every step of your workflow or agent completes successfully. But how do you know whether the outcome was the one you actually wanted?

--- a/content/blog/online-vs-offline-ai-evals-when-to-use-each.mdx
+++ b/content/blog/online-vs-offline-ai-evals-when-to-use-each.mdx
@@ -13,6 +13,10 @@ image: /assets/blog/online-vs-offline-ai-evals-when-to-use-each/featured-image.p
 date: 2026-07-14
 category: engineering
 author: Mitchell Alderson
+sidebarCta:
+  text: "You're already running agents in prod. Learn how to ship your first eval."
+  buttonLabel: "Watch the recording"
+  href: "https://events.zoom.us/e/recording?videoId=uKbFJoUhRQKS9V71ysKkLw&eventId=Z8vtvPiATTq_LQxwlO8_ZA&organizationId=Jm1kZRVvQC6tCNBq9FaDag"
 ---
 
 AI agents excel at breaking things. They're non-deterministic: the same input can produce different outputs, some with bad consequences.


### PR DESCRIPTION
## What

Adds the on-demand Agent Evals Lightning Lab recording as the sidebar
CTA on 4 eval-focused posts, using the `sidebarCta` frontmatter field
from #<PR-number-of-blog-sidebar-cta>:

- /blog/introducing-agent-evals (swapped from /sign-up)
- /blog/introducing-scoring (new)
- /blog/introducing-group-experiment (new)
- /blog/online-vs-offline-ai-evals-when-to-use-each (new)

Copy/target per the Agent Evals Webinar CTA mapping doc. Button label
("Watch the recording") wasn't specified in the doc — chosen to match
the on-demand/Zoom-recording nature of the link.

## Change to BlogSidebarCta

The target is an external Zoom recording URL, so the component now
opens external links (`http(s)://`) in a new tab with
`rel="noopener noreferrer"`, matching the convention already used for
the external register link in `LightningLabShipYourFirstEval.tsx`.
Internal links (`/docs`, `/sign-up`, etc.) are unaffected.