### PR TITLE
Refresh durable execution page for SEO and clearer lifecycle messaging.

### DIFF
--- a/app/(v1)/platform/durable-execution/page.tsx
+++ b/app/(v1)/platform/durable-execution/page.tsx
@@ -8,9 +8,9 @@ import deDotsData from "@/public/assets/v1/durable-execution-hero/dots.json";
 const DE_DOTS_JSON = JSON.stringify(deDotsData);
 
 export const metadata: Metadata = generateMetadata({
-  title: "Durable Execution Explained: Automatic Retries & Checkpoints",
+  title: "Durable Execution Platform for Reliable Workflows",
   description:
-    "What is durable execution? Fault-tolerant code that finishes despite failures—via automatic retries and step checkpoints. Compare Inngest to Temporal and start building durable functions.",
+    "Durable execution keeps functions running through failures, retries, and restarts. Add step.run, step.sleep, and waitForEvent to any code. No extra workers required.",
 });
 
 export default function Page() {

--- a/app/(v1)/platform/durable-execution/page.tsx
+++ b/app/(v1)/platform/durable-execution/page.tsx
@@ -8,9 +8,9 @@ import deDotsData from "@/public/assets/v1/durable-execution-hero/dots.json";
 const DE_DOTS_JSON = JSON.stringify(deDotsData);
 
 export const metadata: Metadata = generateMetadata({
-  title: "Durable Execution - Reliable Workflows",
+  title: "Durable Execution Explained: Automatic Retries & Checkpoints",
   description:
-    "Make any function durable with step.run, step.sleep, and waitForEvent. Inngest retries, resumes, and traces your workflows - no extra workers required.",
+    "What is durable execution? Fault-tolerant code that finishes despite failures—via automatic retries and step checkpoints. Compare Inngest to Temporal and start building durable functions.",
 });
 
 export default function Page() {

--- a/components/v1/pages/DurableExecution.tsx
+++ b/components/v1/pages/DurableExecution.tsx
@@ -1,8 +1,9 @@
 import PageShell from "@/components/v1/PageShell";
 import CaseStudies from "@/components/v1/sections/DurableExecution/CaseStudies";
 import FinalCTA from "@/components/v1/sections/DurableExecution/FinalCTA";
-import ProblemsGrid from "@/components/v1/sections/QueuesFlowControl/ProblemsGrid";
 import Hero from "@/components/v1/sections/DurableExecution/Hero";
+import Problems from "@/components/v1/sections/DurableExecution/Problems";
+import TemporalComparison from "@/components/v1/sections/DurableExecution/TemporalComparison";
 import Primitives from "@/components/v1/sections/DurableExecution/Primitives";
 import ControlFlow from "@/components/v1/sections/DurableExecution/ControlFlow";
 import Observability from "@/components/v1/sections/DurableExecution/Observability";
@@ -14,17 +15,8 @@ export default function DurableExecution() {
   return (
     <PageShell>
       <Hero />
-      <ProblemsGrid
-        labelledById="de-problems-headline"
-        eyebrow="The problem"
-        headline={
-          <>
-            <span className="block">Your pipelines will fail.</span>
-            <span className="block">Then what?</span>
-          </>
-        }
-        intro="The best queues are good at one thing: making sure a job gets picked up. For workflows with API calls or human-in-the-loop pauses, you need to make sure your code can run, sleep, wait, and retry as needed."
-      />
+      <Problems />
+      <TemporalComparison />
       <Primitives />
       <ControlFlow />
       <Observability />

--- a/components/v1/sections/DurableExecution/AnyCode.tsx
+++ b/components/v1/sections/DurableExecution/AnyCode.tsx
@@ -24,6 +24,7 @@ export default function AnyCode() {
     >
       <SectionHeader
         className="lg:pr-8"
+        eyebrow="Optionality"
         title="Any code, any runtime."
         body="Workflows, agents, endpoints. API calls, webhooks, cron. Edge, serverless, traditional. Same primitives, same guarantees, no matter what or where you run. Wrap functions in steps to make any code durable by default."
         bodyClassName="max-w-[640px]"

--- a/components/v1/sections/DurableExecution/ControlFlow.tsx
+++ b/components/v1/sections/DurableExecution/ControlFlow.tsx
@@ -67,6 +67,7 @@ function Copy() {
       <div className="flex flex-col gap-10">
         <SectionHeader
           id="de-control-flow-heading"
+          eyebrow="Flow control"
           title="Control flow through every event."
           body="Left to a queue, work piles up, noisy tenants starve others, and APIs get hammered. Flow control is how you stay in control as volume grows."
         />

--- a/components/v1/sections/DurableExecution/Hero.tsx
+++ b/components/v1/sections/DurableExecution/Hero.tsx
@@ -6,9 +6,7 @@ import DurableExecutionDotsCanvas from "@/components/v1/sections/DurableExecutio
 export default function Hero() {
   return (
     <SplitHero
-      breadcrumbs={[
-        { label: "Durable Execution" },
-      ]}
+      breadcrumbs={[{ label: "Durable Execution" }]}
       palette="blue"
       headlineId="de-hero-headline"
       srHeadline="Code that works, without extra workers."
@@ -21,10 +19,10 @@ export default function Hero() {
         </>
       }
       bodyLines={[
-        "Your code has to complete no matter what. LLM",
-        "outages, API timeouts, server restarts, traffic spikes.",
-        "Inngest lets you make every function durable without",
-        "leaving your codebase."
+        "What is durable execution? Fault-tolerant code that",
+        "finishes even when APIs fail or servers restart.",
+        "Inngest checkpoints every step and retries",
+        "automatically—so workflows resume where they left off.",
       ]}
       docsHref="/docs/learn/how-functions-are-executed?ref=durable-execution"
       signupHref="/sign-up?ref=durable-execution"

--- a/components/v1/sections/DurableExecution/LifecycleGlyphs.tsx
+++ b/components/v1/sections/DurableExecution/LifecycleGlyphs.tsx
@@ -1,0 +1,327 @@
+/**
+ * Lightweight abstract SVG glyphs for the Durable Execution problem
+ * strip. Static stroke geometry + one SMIL-animated spark each — no
+ * images, no JS timers. Sparks pause under prefers-reduced-motion.
+ */
+
+import type { ReactNode } from "react";
+
+const LINE = "rgb(255 255 255 / 0.32)";
+const LINE_DIM = "rgb(255 255 255 / 0.16)";
+const SALMON = "rgb(251 85 54)";
+const BLUE = "rgb(96 140 255)";
+const GREEN = "rgb(11 221 72)";
+
+const STROKE = 1.5;
+const STROKE_DIM = 1.25;
+
+function Spark({
+  color,
+  path,
+  dur,
+  begin = "0s",
+}: {
+  color: string;
+  path: string;
+  dur: string;
+  begin?: string;
+}) {
+  return (
+    <g className="de-lifecycle-spark">
+      <animateMotion
+        dur={dur}
+        begin={begin}
+        repeatCount="indefinite"
+        path={path}
+      />
+      <circle r="5.5" fill={color} opacity={0.22} />
+      <circle r="2.5" fill={color} />
+    </g>
+  );
+}
+
+function GlyphShell({
+  children,
+  label,
+}: {
+  children: ReactNode;
+  label: string;
+}) {
+  return (
+    <svg
+      viewBox="0 0 120 100"
+      width={160}
+      height={133}
+      aria-hidden="true"
+      className="de-lifecycle-glyph h-auto w-full max-w-[160px]"
+    >
+      <title>{label}</title>
+      {children}
+    </svg>
+  );
+}
+
+function Node({ cx, cy }: { cx: number; cy: number }) {
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r="3.5"
+      fill="rgb(31 31 31)"
+      stroke={LINE}
+      strokeWidth={STROKE}
+    />
+  );
+}
+
+/**
+ * Automatic retries: progress through steps, fail with room to spare,
+ * loop back to the last checkpoint, then finish.
+ */
+export function RetriesGlyph() {
+  // Nodes at 18 / 50 / 82; failure X sits further out at ~108.
+  const path =
+    "M18,50 H50 H82 H100 Q110,50 110,36 Q110,24 96,24 H50 Q38,24 38,50 H82 H112";
+  return (
+    <GlyphShell label="Automatic retries">
+      <path
+        d="M18,50 H112"
+        fill="none"
+        stroke={LINE_DIM}
+        strokeWidth={STROKE_DIM}
+      />
+      <path
+        d="M100,50 Q110,50 110,36 Q110,24 96,24 H50 Q38,24 38,50"
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE}
+        strokeLinecap="square"
+        strokeDasharray="3 3"
+      />
+      <path
+        d="M18,50 H82"
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE}
+        strokeLinecap="square"
+      />
+      <Node cx={18} cy={50} />
+      <Node cx={50} cy={50} />
+      <Node cx={82} cy={50} />
+      {/* Failure mark — spaced clear of the last checkpoint */}
+      <path
+        d="M104,42 L112,58 M112,42 L104,58"
+        stroke={LINE}
+        strokeWidth={STROKE}
+        strokeLinecap="square"
+        opacity={0.7}
+      />
+      <Spark color={SALMON} path={path} dur="6.5s" />
+    </GlyphShell>
+  );
+}
+
+/** Fan out: one trunk splits into three branches (radial, not L→R only). */
+export function FanOutGlyph() {
+  const path = "M60,18 V48 L28,88";
+  return (
+    <GlyphShell label="Fan out events">
+      <path
+        d="M60,18 V48"
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE}
+        strokeLinecap="square"
+      />
+      <path
+        d="M60,48 L28,88"
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE}
+        strokeLinecap="square"
+      />
+      <path
+        d="M60,48 L60,90"
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE}
+        strokeLinecap="square"
+      />
+      <path
+        d="M60,48 L92,88"
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE}
+        strokeLinecap="square"
+      />
+      <Node cx={60} cy={18} />
+      <Node cx={60} cy={48} />
+      <g className="de-lifecycle-spark" opacity={0.55}>
+        <animateMotion
+          dur="6.5s"
+          begin="0.8s"
+          repeatCount="indefinite"
+          path="M60,18 V48 L60,90"
+        />
+        <circle r="5" fill={BLUE} opacity={0.2} />
+        <circle r="2.25" fill={BLUE} />
+      </g>
+      <g className="de-lifecycle-spark" opacity={0.4}>
+        <animateMotion
+          dur="6.5s"
+          begin="1.6s"
+          repeatCount="indefinite"
+          path="M60,18 V48 L92,88"
+        />
+        <circle r="5" fill={BLUE} opacity={0.2} />
+        <circle r="2.25" fill={BLUE} />
+      </g>
+      <Spark color={BLUE} path={path} dur="6.5s" />
+    </GlyphShell>
+  );
+}
+
+/** Isolated clean lane between thrashing neighbors. */
+export function NoisyNeighborsGlyph() {
+  const path = "M16,50 H104";
+  return (
+    <GlyphShell label="Solve noisy neighbors">
+      <path
+        d="M16,28 H36 L44,22 H60 L68,34 H84 L92,26 H104"
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE_DIM}
+        strokeDasharray="3 4"
+        opacity={0.45}
+      />
+      <path
+        d={path}
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE}
+        strokeLinecap="square"
+      />
+      <path
+        d="M16,72 H28 L40,80 H56 L64,66 H80 L90,76 H104"
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE_DIM}
+        strokeDasharray="3 4"
+        opacity={0.45}
+      />
+      <Spark color={GREEN} path={path} dur="5s" />
+    </GlyphShell>
+  );
+}
+
+/**
+ * Wait: spark arrives at a hold point, dwells there (keyPoints park),
+ * then continues. No orbit that reads as “falling off.”
+ */
+export function WaitGlyph() {
+  const path = "M14,50 H60 H106";
+  return (
+    <GlyphShell label="Wait without polling">
+      <path
+        d={path}
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE}
+        strokeLinecap="square"
+      />
+      {/* Hold marker */}
+      <circle
+        cx="60"
+        cy="50"
+        r="10"
+        fill="none"
+        stroke={LINE_DIM}
+        strokeWidth={STROKE_DIM}
+        strokeDasharray="3 3"
+      />
+      <Node cx={60} cy={50} />
+      <g className="de-lifecycle-spark">
+        <animateMotion
+          dur="7.5s"
+          repeatCount="indefinite"
+          path={path}
+          keyTimes="0;0.22;0.72;1"
+          keyPoints="0;0.5;0.5;1"
+          calcMode="linear"
+        />
+        <circle r="5.5" fill={BLUE} opacity={0.22} />
+        <circle r="2.5" fill={BLUE} />
+      </g>
+    </GlyphShell>
+  );
+}
+
+/**
+ * Deep observability: rewind a finished run to the step that failed
+ * and inspect what happened.
+ */
+export function ObservabilityGlyph() {
+  // Start at the end of the run, travel back to the failed step, orbit it.
+  const path =
+    "M108,50 H88 H58 A12,12 0 1,1 57.99,50 A12,12 0 1,1 58,50";
+  return (
+    <GlyphShell label="Get deep observability">
+      <path
+        d="M12,50 H108"
+        fill="none"
+        stroke={LINE_DIM}
+        strokeWidth={STROKE_DIM}
+      />
+      <path
+        d="M12,50 H58"
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE}
+        strokeLinecap="square"
+      />
+      <Node cx={20} cy={50} />
+      <Node cx={40} cy={50} />
+      {/* Failed step */}
+      <circle
+        cx="58"
+        cy="50"
+        r="3.5"
+        fill="rgb(31 31 31)"
+        stroke={SALMON}
+        strokeWidth={STROKE}
+        opacity={0.9}
+      />
+      <path
+        d="M54,44 L62,56 M62,44 L54,56"
+        stroke={SALMON}
+        strokeWidth={STROKE}
+        strokeLinecap="square"
+        opacity={0.85}
+      />
+      {/* Later steps after the failure (dim) */}
+      <Node cx={88} cy={50} />
+      <Node cx={108} cy={50} />
+      {/* Inspect ring around the failure */}
+      <circle
+        cx="58"
+        cy="50"
+        r="12"
+        fill="none"
+        stroke={LINE}
+        strokeWidth={STROKE_DIM}
+        strokeDasharray="3 3"
+      />
+      <Spark color={SALMON} path={path} dur="7s" />
+    </GlyphShell>
+  );
+}
+
+export const LIFECYCLE_GLYPHS = {
+  retries: RetriesGlyph,
+  "fan-out": FanOutGlyph,
+  "noisy-neighbor": NoisyNeighborsGlyph,
+  wait: WaitGlyph,
+  observability: ObservabilityGlyph,
+} as const;
+
+export type LifecycleGlyphId = keyof typeof LIFECYCLE_GLYPHS;

--- a/components/v1/sections/DurableExecution/LifecycleGlyphs.tsx
+++ b/components/v1/sections/DurableExecution/LifecycleGlyphs.tsx
@@ -50,10 +50,10 @@ function GlyphShell({
   return (
     <svg
       viewBox="0 0 120 100"
-      width={160}
-      height={133}
+      width={192}
+      height={160}
       aria-hidden="true"
-      className="de-lifecycle-glyph h-auto w-full max-w-[160px]"
+      className="de-lifecycle-glyph h-auto w-full max-w-[192px]"
     >
       <title>{label}</title>
       {children}

--- a/components/v1/sections/DurableExecution/Observability.tsx
+++ b/components/v1/sections/DurableExecution/Observability.tsx
@@ -11,9 +11,8 @@ import { reveals } from "@/utils/v1/reveals";
 // "Observability by default." Bordered card with a
 // top row (514px copy column + 784px dashboard) and a 3×2 feature grid
 // below. The CTA sits under the intro copy in the left column; the grid
-// holds the five features (its 6th cell is empty). Feature rows use a
-// salmon square bullet on the first (featured) item and a gray bullet
-// on the rest, with title + supporting copy stacked beneath.
+// holds six features (traces, metrics, search, replay, scoring,
+// experiments). Feature rows use title + supporting copy with a docs link.
 
 interface Feature {
   title: string;
@@ -25,27 +24,32 @@ const FEATURES: Feature[] = [
   {
     title: "Waterfall Traces",
     body: "Functions traced automatically, in parallel",
-    href: "/docs/platform/monitor/traces",
+    href: "/docs/platform/monitor/traces?ref=durable-execution",
   },
   {
     title: "Metrics dashboard",
     body: "System health at the environment level",
-    href: "/docs/platform/monitor/observability-metrics#function-metrics",
+    href: "/docs/platform/monitor/observability-metrics?ref=durable-execution#function-metrics",
   },
   {
     title: "Run search",
     body: "Find the exact run for any user, org,\nor error pattern",
-    href: "/docs/platform/monitor/inspecting-function-runs#searching-function-runs",
+    href: "/docs/platform/monitor/inspecting-function-runs?ref=durable-execution#searching-function-runs",
   },
   {
     title: "Replay",
     body: "Deploy a fix and re-run in bulk—\nno dead-letter queues",
-    href: "/docs/platform/replay",
+    href: "/docs/platform/replay?ref=durable-execution",
   },
   {
-    title: "Insights",
-    body: "Query event and run data with SQL.\nNo ETL needed",
-    href: "/docs/platform/monitor/insights",
+    title: "Scoring",
+    body: "Score runs or groups of runs in code—\nquality signals on every execution",
+    href: "/docs/features/inngest-functions/steps-workflows/scoring?ref=durable-execution",
+  },
+  {
+    title: "Experiments",
+    body: "Split traffic across variants and\ncompare scored outcomes in production",
+    href: "/docs/features/inngest-functions/steps-workflows/step-experiments?ref=durable-execution",
   },
 ];
 
@@ -74,7 +78,7 @@ export default function Observability() {
                 <span className="block">by default.</span>
               </>
             }
-            body="To guarantee completion, Inngest tracks the state of every step. That state is the trace — every timing, input, output, and retry, captured from day one with no extra instrumentation."
+            body="To guarantee completion, Inngest tracks the state of every step. That state is the trace — every timing, input, output, and retry, captured from day one. Score runs, group outcomes, and run experiments without bolting on another tool."
             bodyClassName="max-w-[445px]"
             actions={
               <ButtonLink

--- a/components/v1/sections/DurableExecution/Primitives.tsx
+++ b/components/v1/sections/DurableExecution/Primitives.tsx
@@ -17,37 +17,37 @@ const PRIMITIVES: Primitive[] = [
   {
     id: "step-run",
     api: "step.run",
-    body: "The core unit of durability. Wrap any piece of work and it becomes a named checkpoint — retried automatically on failure, result cached so it never re-runs if a later step fails.",
+    body: "Wrap any work as a named checkpoint. Retried on failure, cached on success.",
     illustration: "/assets/v1/durable-execution/primitives/d1.svg",
   },
   {
     id: "step-sleep",
     api: "step.sleep",
-    body: "Suspend a workflow mid-execution for seconds or months at zero cost. No polling loops, no cron jobs, no workers spinning in the background. Resumes exactly where it stopped.",
+    body: "Pause for seconds or months at zero cost. No polling, no idle workers.",
     illustration: "/assets/v1/durable-execution/primitives/d2.svg",
   },
   {
     id: "step-wait-for-event",
     api: "step.waitForEvent",
-    body: "Suspend until a matching external event arrives — an approval, webhook, or user action — then resume with the event data in hand. The function waits at zero cost, however long it takes.",
+    body: "Suspend until an approval, webhook, or user action arrives, then resume.",
     illustration: "/assets/v1/durable-execution/primitives/d3.svg",
   },
   {
     id: "step-invoke",
     api: "step.invoke",
-    body: "Call another function and wait for its result as a durable step. Compose workflows across functions without losing the durability guarantee. Each child function is independently traced and retried.",
+    body: "Call another function as a durable step. Independently traced and retried.",
     illustration: "/assets/v1/durable-execution/primitives/d4.svg",
   },
   {
     id: "parallel-steps",
     api: "Parallel steps",
-    body: "Send one or more events from within a running function — as a durable step. Fan out to multiple downstream workflows without worrying about partial sends if the function retries.",
+    body: "Fan out events from a running function without risking partial sends.",
     illustration: "/assets/v1/durable-execution/primitives/d5.svg",
   },
   {
     id: "custom-retries",
     api: "Custom retries",
-    body: "“Retry everything 3 times” causes more problems than it solves. Zero retries for payments. Exponential backoff for flaky APIs. Immediate retry for bad LLM JSON. Configured per function, not globally inherited.",
+    body: "Tune retries per function: zero for payments, backoff for flaky APIs.",
     illustration: "/assets/v1/durable-execution/primitives/d6.svg",
   },
 ];

--- a/components/v1/sections/DurableExecution/Problems.tsx
+++ b/components/v1/sections/DurableExecution/Problems.tsx
@@ -71,7 +71,7 @@ function OutcomeCard({
       {...reveals.item(i)}
       className="group relative flex list-none flex-col items-stretch gap-10 sm:gap-[60px] lg:gap-[83px]"
     >
-      <div className="relative flex h-[148px] items-center justify-center motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-out motion-safe:group-hover:scale-105">
+      <div className="relative flex h-[180px] items-center justify-center motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-out motion-safe:group-hover:scale-110">
         <Glyph />
       </div>
 

--- a/components/v1/sections/DurableExecution/Problems.tsx
+++ b/components/v1/sections/DurableExecution/Problems.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { motion } from "motion/react";
+import { cn } from "@/utils/v1/cn";
+import Section from "@/components/v1/sections/shared/Section";
+import SectionHeader from "@/components/v1/sections/shared/SectionHeader";
+import {
+  LIFECYCLE_GLYPHS,
+  type LifecycleGlyphId,
+} from "@/components/v1/sections/DurableExecution/LifecycleGlyphs";
+import { reveals } from "@/utils/v1/reveals";
+
+/**
+ * Five plain-English outcomes along the Inngest lifecycle — write
+ * durable steps, fan out, control flow, wait when needed, observe.
+ * Icons are lightweight inline SVG glyphs (no PNG payloads).
+ */
+
+interface Outcome {
+  id: LifecycleGlyphId;
+  label: string;
+}
+
+const OUTCOMES: Outcome[] = [
+  { id: "retries", label: "Automatic retries" },
+  { id: "fan-out", label: "Fan out events" },
+  { id: "noisy-neighbor", label: "Solve noisy neighbors" },
+  { id: "wait", label: "Wait without polling" },
+  { id: "observability", label: "Get deep observability" },
+];
+
+export default function Problems() {
+  return (
+    <Section
+      aria-labelledby="de-problems-headline"
+      className="relative"
+      containerClassName="flex flex-col gap-v1-stack-lg"
+    >
+      <SectionHeader
+        id="de-problems-headline"
+        eyebrow="The problem"
+        title={
+          <>
+            <span className="block">Your workflows will fail.</span>
+            <span className="block">Then what?</span>
+          </>
+        }
+        body="Hand-rolled queues break under real load. With Inngest you retry from checkpoints, fan out work, control noisy tenants, wait for the real world, and see every step — without another worker fleet to babysit."
+        bodyClassName="max-w-[655px]"
+      />
+
+      <ul className="grid list-none grid-cols-1 gap-y-12 pl-0 sm:grid-cols-2 sm:gap-y-10 lg:grid-cols-5 lg:items-end lg:gap-y-0">
+        {OUTCOMES.map((item, i) => (
+          <OutcomeCard key={item.id} item={item} index={i} />
+        ))}
+      </ul>
+    </Section>
+  );
+}
+
+function OutcomeCard({
+  item,
+  index: i,
+}: {
+  item: Outcome;
+  index: number;
+}) {
+  const Glyph = LIFECYCLE_GLYPHS[item.id];
+  return (
+    <motion.li
+      {...reveals.item(i)}
+      className="group relative flex list-none flex-col items-stretch gap-10 sm:gap-[60px] lg:gap-[83px]"
+    >
+      <div className="relative flex h-[148px] items-center justify-center motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-out motion-safe:group-hover:scale-105">
+        <Glyph />
+      </div>
+
+      <div
+        className={cn(
+          "flex h-[97px] flex-col items-center justify-center gap-2 border border-v1-frost px-3 pb-4 pt-3 text-center uppercase",
+          i > 0 && "lg:-ml-px",
+        )}
+      >
+        <span className="text-v1-label-md text-v1-frost">{item.label}</span>
+      </div>
+    </motion.li>
+  );
+}

--- a/components/v1/sections/DurableExecution/TemporalComparison.tsx
+++ b/components/v1/sections/DurableExecution/TemporalComparison.tsx
@@ -5,6 +5,7 @@ import ButtonLink from "@/components/v1/ButtonLink";
 import Logo from "@/components/v1/Logo";
 import Section from "@/components/v1/sections/shared/Section";
 import SectionHeader from "@/components/v1/sections/shared/SectionHeader";
+import { cn } from "@/utils/v1/cn";
 import { reveals } from "@/utils/v1/reveals";
 
 /**
@@ -173,6 +174,7 @@ export default function TemporalComparison() {
               tone="frost"
               icon={<Logo logomarkOnly width={30} />}
               iconGap={6}
+              highlight
             >
               Inngest
             </HeaderCell>
@@ -186,7 +188,7 @@ export default function TemporalComparison() {
               <CapabilityCell>{row.capability}</CapabilityCell>
               <FeatureCell cell={row.queues} muted />
               <FeatureCell cell={row.temporal} muted />
-              <FeatureCell cell={row.inngest} />
+              <FeatureCell cell={row.inngest} highlight />
             </div>
           ))}
         </motion.div>
@@ -200,25 +202,36 @@ function HeaderCell({
   tone,
   icon,
   iconGap = 8,
+  highlight,
 }: {
   children: React.ReactNode;
   tone: "frost" | "dim";
   icon?: React.ReactNode;
   iconGap?: number;
+  /** Inngest column only - subtle green wash + hairline sides so the
+   * "us" lane reads with more contrast against the reference columns. */
+  highlight?: boolean;
 }) {
   return (
     <div
       role="columnheader"
-      className="flex h-[52px] items-center px-4 lg:px-6"
+      className={cn(
+        "flex h-[52px] items-center px-4 lg:px-6",
+        highlight &&
+          "border-x border-solid border-v1-accent-green/25 bg-v1-accent-green/[0.06]",
+      )}
       style={{ columnGap: iconGap }}
     >
       {icon}
       <span
-        className="font-v1Mono text-[12px] uppercase leading-[14px] whitespace-nowrap lg:text-[16px] lg:leading-[18px]"
+        className={cn(
+          "font-v1Mono text-[12px] uppercase leading-[14px] whitespace-nowrap lg:text-[16px] lg:leading-[18px]",
+          highlight && "font-medium",
+        )}
         style={{
           color:
             tone === "dim"
-              ? "rgb(var(--color-v1-carbon-100) / 0.7)"
+              ? "rgb(var(--color-v1-carbon-100) / 0.55)"
               : "rgb(var(--color-v1-frost))",
         }}
       >
@@ -238,21 +251,37 @@ function CapabilityCell({ children }: { children: React.ReactNode }) {
   );
 }
 
-function FeatureCell({ cell, muted }: { cell: Cell; muted?: boolean }) {
+function FeatureCell({
+  cell,
+  muted,
+  highlight,
+}: {
+  cell: Cell;
+  muted?: boolean;
+  /** Inngest column only - see HeaderCell. */
+  highlight?: boolean;
+}) {
   const { text, cross, check } = cell;
   return (
     <div
       role="cell"
-      className="flex min-h-[52px] items-center gap-1 px-4 py-3 lg:gap-[10px] lg:px-6"
+      className={cn(
+        "flex min-h-[52px] items-center gap-1 px-4 py-3 lg:gap-[10px] lg:px-6",
+        highlight &&
+          "border-x border-solid border-v1-accent-green/25 bg-v1-accent-green/[0.06]",
+      )}
     >
       {check && <CheckIcon />}
       {cross && <CrossIcon />}
       {text && (
         <span
-          className="font-v1Body text-[13px] leading-[18px] lg:text-[15px] lg:leading-[22px]"
+          className={cn(
+            "font-v1Body text-[13px] leading-[18px] lg:text-[15px] lg:leading-[22px]",
+            highlight && "font-medium",
+          )}
           style={{
             color: muted
-              ? "rgb(var(--color-v1-carbon-100) / 0.7)"
+              ? "rgb(var(--color-v1-carbon-100) / 0.55)"
               : "rgb(var(--color-v1-frost))",
           }}
         >

--- a/components/v1/sections/DurableExecution/TemporalComparison.tsx
+++ b/components/v1/sections/DurableExecution/TemporalComparison.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { motion } from "motion/react";
+import ButtonLink from "@/components/v1/ButtonLink";
+import Logo from "@/components/v1/Logo";
+import Section from "@/components/v1/sections/shared/Section";
+import SectionHeader from "@/components/v1/sections/shared/SectionHeader";
+import { reveals } from "@/utils/v1/reveals";
+
+/**
+ * Capability comparison: traditional queues vs Temporal vs Inngest.
+ * Placed directly under the problem section on /platform/durable-execution.
+ * Table chrome mirrors BackgroundJobs/QueueComparison.
+ *
+ * Check balance (fair, not all-or-nothing):
+ *   Traditional queues — a couple (basic retries, quick start, any language)
+ *   Temporal — more (retries, checkpointing, waits, multi-step, languages)
+ *   Inngest — most (above + serverless + scoring + experiments + zero workers)
+ *
+ * Temporal setup copy grounded in Temporal docs / Cloud FAQ: Cloud
+ * removes the cluster but you still run workers; self-host adds K8s +
+ * Cassandra/PostgreSQL + ongoing ops.
+ */
+
+interface Cell {
+  text?: string;
+  cross?: boolean;
+  check?: boolean;
+}
+
+interface ComparisonRow {
+  capability: string;
+  queues: Cell;
+  temporal: Cell;
+  inngest: Cell;
+}
+
+const ROWS: ComparisonRow[] = [
+  {
+    capability: "Automatic retries",
+    queues: { check: true, text: "Job-level / limited" },
+    temporal: { check: true, text: "Per activity" },
+    inngest: { check: true, text: "Per-step, built in" },
+  },
+  {
+    capability: "Step-level checkpointing",
+    queues: { cross: true },
+    temporal: { check: true, text: "Activity results cached" },
+    inngest: { check: true, text: "Every step memoized" },
+  },
+  {
+    capability: "Long sleeps / wait for events",
+    queues: { cross: true, text: "Polling or custom infra" },
+    temporal: { check: true, text: "Signals + timers" },
+    inngest: { check: true, text: "Native sleep + waitForEvent" },
+  },
+  {
+    capability: "Multi-step durable workflows",
+    queues: { cross: true, text: "Hand-rolled" },
+    temporal: { check: true, text: "Core strength" },
+    inngest: { check: true, text: "First-class in code" },
+  },
+  {
+    capability: "Any language / runtime",
+    queues: { check: true, text: "Whatever talks to the queue" },
+    temporal: { check: true, text: "Go, Java, TS, Python — Go strongest" },
+    inngest: { check: true, text: "TS, Python, Go — any HTTP runtime" },
+  },
+  {
+    capability: "Works in serverless / edge",
+    queues: { cross: true, text: "Difficult" },
+    temporal: { cross: true, text: "Persistent workers required" },
+    inngest: { check: true, text: "Native HTTP model" },
+  },
+  {
+    capability: "Native run & group scoring",
+    queues: { cross: true },
+    temporal: { cross: true, text: "DIY / external tools" },
+    inngest: { check: true, text: "step.score — runs or groups" },
+  },
+  {
+    capability: "In-code experiments",
+    queues: { cross: true },
+    temporal: { cross: true, text: "Custom traffic splitting" },
+    inngest: { check: true, text: "group.experiment() built in" },
+  },
+  {
+    capability: "Time to first durable workflow",
+    queues: { check: true, text: "Minutes for a basic job" },
+    temporal: {
+      cross: true,
+      text: "Days — workers + cluster/DB (Cloud still needs a worker fleet)",
+    },
+    inngest: { check: true, text: "Minutes — wrap existing code" },
+  },
+  {
+    capability: "Infrastructure to own",
+    queues: { text: "Queue, workers, DLQ" },
+    temporal: { text: "Workers always; self-host adds server + DB" },
+    inngest: { check: true, text: "Zero — fully managed" },
+  },
+];
+
+const CheckIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M5 12.5 L 10 17 L 19 7"
+      stroke="rgb(var(--color-v1-green-200))"
+      strokeWidth="1.75"
+      fill="none"
+      strokeLinecap="square"
+    />
+  </svg>
+);
+
+const CrossIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M7 7 17 17 M17 7 7 17"
+      stroke="rgb(var(--color-v1-carbon-300))"
+      strokeWidth="1.75"
+      fill="none"
+      strokeLinecap="square"
+    />
+  </svg>
+);
+
+export default function TemporalComparison() {
+  return (
+    <Section aria-labelledby="de-temporal-comparison-heading" className="relative">
+      <SectionHeader
+        id="de-temporal-comparison-heading"
+        eyebrow="Compare"
+        title={
+          <>
+            What is durable execution—
+            <br className="hidden lg:inline" />
+            {" and how does Inngest compare?"}
+          </>
+        }
+        body="Durable execution keeps long-running workflows reliable with automatic retries and checkpoints when steps fail. Temporal gets you there if you can absorb the worker fleet and platform setup; traditional queues don't. Inngest delivers the same durability guarantees from the code you already run — no workers, no cluster, no separate orchestration fleet."
+        bodyClassName="max-w-[760px]"
+        actions={
+          <div className="flex flex-wrap gap-6">
+            <ButtonLink
+              href="/compare-to-temporal?ref=durable-execution"
+              variant="primary"
+            >
+              Compare to Temporal →
+            </ButtonLink>
+            <ButtonLink href="/sign-up?ref=durable-execution-compare" variant="secondary">
+              Start building free
+            </ButtonLink>
+          </div>
+        }
+      />
+
+      <div className="-mx-6 mt-v1-stack overflow-x-auto sm:-mx-9 lg:mx-0 lg:overflow-visible">
+        <motion.div
+          {...reveals.item(3)}
+          role="table"
+          aria-label="Capability comparison between traditional queues, Temporal, and Inngest"
+          className="min-w-[960px] px-6 sm:px-9 lg:min-w-0 lg:px-0"
+        >
+          <div
+            role="row"
+            className="grid grid-cols-4 border-b border-solid border-v1-strong"
+          >
+            <HeaderCell tone="frost">Capability</HeaderCell>
+            <HeaderCell tone="dim">Traditional queues</HeaderCell>
+            <HeaderCell tone="dim">Temporal</HeaderCell>
+            <HeaderCell
+              tone="frost"
+              icon={<Logo logomarkOnly width={30} />}
+              iconGap={6}
+            >
+              Inngest
+            </HeaderCell>
+          </div>
+          {ROWS.map((row) => (
+            <div
+              key={row.capability}
+              role="row"
+              className="grid grid-cols-4 border-b border-solid border-v1-strong/[0.4]"
+            >
+              <CapabilityCell>{row.capability}</CapabilityCell>
+              <FeatureCell cell={row.queues} muted />
+              <FeatureCell cell={row.temporal} muted />
+              <FeatureCell cell={row.inngest} />
+            </div>
+          ))}
+        </motion.div>
+      </div>
+    </Section>
+  );
+}
+
+function HeaderCell({
+  children,
+  tone,
+  icon,
+  iconGap = 8,
+}: {
+  children: React.ReactNode;
+  tone: "frost" | "dim";
+  icon?: React.ReactNode;
+  iconGap?: number;
+}) {
+  return (
+    <div
+      role="columnheader"
+      className="flex h-[52px] items-center px-4 lg:px-6"
+      style={{ columnGap: iconGap }}
+    >
+      {icon}
+      <span
+        className="font-v1Mono text-[12px] uppercase leading-[14px] whitespace-nowrap lg:text-[16px] lg:leading-[18px]"
+        style={{
+          color:
+            tone === "dim"
+              ? "rgb(var(--color-v1-carbon-100) / 0.7)"
+              : "rgb(var(--color-v1-frost))",
+        }}
+      >
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function CapabilityCell({ children }: { children: React.ReactNode }) {
+  return (
+    <div role="cell" className="flex min-h-[52px] items-center px-4 py-3 lg:px-6">
+      <span className="font-v1Body text-[13px] leading-[18px] text-v1-frost lg:text-[15px] lg:leading-[22px]">
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function FeatureCell({ cell, muted }: { cell: Cell; muted?: boolean }) {
+  const { text, cross, check } = cell;
+  return (
+    <div
+      role="cell"
+      className="flex min-h-[52px] items-center gap-1 px-4 py-3 lg:gap-[10px] lg:px-6"
+    >
+      {check && <CheckIcon />}
+      {cross && <CrossIcon />}
+      {text && (
+        <span
+          className="font-v1Body text-[13px] leading-[18px] lg:text-[15px] lg:leading-[22px]"
+          style={{
+            color: muted
+              ? "rgb(var(--color-v1-carbon-100) / 0.7)"
+              : "rgb(var(--color-v1-frost))",
+          }}
+        >
+          {text}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/styles/v1-animations.css
+++ b/styles/v1-animations.css
@@ -627,3 +627,10 @@ button:focus-visible .v1-wipe-reveal {
     transition: none;
   }
 }
+
+/* ---------- Durable Execution / lifecycle glyphs ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .de-lifecycle-spark {
+    display: none;
+  }
+}


### PR DESCRIPTION
Add a definition-led hero, Temporal/queues comparison with a Compare CTA, lifecycle glyphs, scoring/experiments in observability, and tighter primitive copy.

@whatupjohnb i changed up the icons at the top... but they're not really on brand. I just wanted to get back to some more useful animations. Can you have a look?