### PR TITLE
Optimize /compare-to-temporal for Temporal alternatives SEO

### DIFF
--- a/app/(v1)/compare-to-temporal/page.tsx
+++ b/app/(v1)/compare-to-temporal/page.tsx
@@ -6,7 +6,7 @@ import CompareToTemporal from "@/components/v1/pages/CompareToTemporal";
 export const metadata: Metadata = generateMetadata({
   title: "Inngest vs Temporal: Durable execution that developers love",
   description:
-    "Discover a serverless, event-driven platform that developers love. Build faster, debug easier, and scale effortlessly with Inngest.",
+    "Comparing Temporal alternatives? See how Inngest delivers durable execution with no workers, cluster, or queue to run—just functions in your existing app.",
 });
 
 export default function Page() {

--- a/components/v1/sections/CompareTemporal/Faq.tsx
+++ b/components/v1/sections/CompareTemporal/Faq.tsx
@@ -7,6 +7,18 @@ import SharedFaq, { type Faq as FaqItem } from "@/components/v1/sections/AI/Faq"
 
 const FAQS: FaqItem[] = [
   {
+    id: "temporal-alternative",
+    question: "Is there a Temporal alternative?",
+    answer:
+      "Yes. Inngest is a Temporal alternative built for teams that want durable execution without running workers, a cluster, or a separate queue. You write normal async functions, wrap side effects in step.run(), and Inngest invokes your existing HTTP app. Among Temporal competitors, Inngest is the option that keeps your current deployment as the runtime instead of asking you to operate a new one.",
+  },
+  {
+    id: "inngest-vs-temporal-differences",
+    question: "What are the Inngest vs Temporal differences?",
+    answer:
+      "The core Inngest vs Temporal difference is architecture. Temporal requires workers that poll a cluster, either self-hosted or on Temporal Cloud. Inngest has no workers: it calls your existing deployment over HTTP. Temporal workflow code must be deterministic because it replays history. Inngest uses step memoization, so non-deterministic LLM calls do not need a separate Activity layer. Inngest also ships native rate limiting, per-key concurrency, and step-level traces that Temporal typically requires you to build.",
+  },
+  {
     id: "scale",
     question: "Can Inngest handle the same scale as Temporal?",
     answer:

--- a/components/v1/sections/CompareTemporal/FeatureComparison.tsx
+++ b/components/v1/sections/CompareTemporal/FeatureComparison.tsx
@@ -572,8 +572,9 @@ export default function FeatureComparison() {
 
   return (
     <Section
+      id="comparison"
       aria-labelledby="ct-table-heading"
-      className="relative"
+      className="relative scroll-mt-32"
     >
       <SectionHeader
         id="ct-table-heading"

--- a/components/v1/sections/CompareTemporal/Hero.tsx
+++ b/components/v1/sections/CompareTemporal/Hero.tsx
@@ -52,10 +52,6 @@ export default function Hero() {
       className="relative overflow-x-clip"
       style={{ backgroundColor: IVORY }}
     >
-      <h1 id="ct-hero-headline" className="sr-only">
-        The developer experience Temporal wishes it had.
-      </h1>
-
       {/* Fine sand-grain over the ivory — SVG fractal noise (clean, not
           pixelated) at low opacity via soft-light. */}
       <span
@@ -69,28 +65,43 @@ export default function Hero() {
             wide screens the padding grows to keep it level with the
             max-w-[1440px] sections elsewhere on the page. */}
         <div className="flex flex-col gap-8 px-6 pb-12 pt-[120px] sm:gap-10 sm:px-9 sm:pt-[140px] lg:flex-1 lg:py-[155px] lg:pl-[max(2rem,calc((100vw-1440px)/2+2rem))] lg:pr-[56px]">
-          <motion.p
-            aria-hidden="true"
-            className="text-v1-display-hero uppercase lg:!text-[clamp(2.5rem,5vw,4.75rem)] lg:leading-[1.02] lg:tracking-[-0.025em]"
-            {...entry(60, INK)}
+          <motion.h1
+            id="ct-hero-headline"
+            className="flex flex-col gap-5"
+            {...entry(60)}
           >
-            <span className="block">The DX</span>
-            <span className="block">Temporal</span>
-            <span className="block">wish it had.</span>
-          </motion.p>
-
-          <motion.p
-            className="max-w-[480px] text-v1-body-lg [font-size:clamp(0.95rem,1.2vw,1.0625rem)] [line-height:1.55]"
-            {...entry(280, SUBINK)}
-          >
-            Temporal might make code failures irrelevant, but not the
-            infrastructure required to make that a reality. Don&apos;t get
-            stuck with workers, queues, and a layer of management that&apos;ll
-            just slow you down.
-          </motion.p>
+            <span
+              className="text-v1-eyebrow uppercase"
+              style={{ color: SUBINK }}
+            >
+              Temporal alternatives
+            </span>
+            <span
+              className="text-v1-display-hero uppercase lg:!text-[clamp(2.5rem,5vw,4.75rem)] lg:leading-[1.02] lg:tracking-[-0.025em]"
+              style={{ color: INK }}
+            >
+              <span className="block">Inngest vs</span>
+              <span className="block">Temporal</span>
+            </span>
+          </motion.h1>
 
           <motion.div
-            className="flex flex-col gap-[18px] sm:flex-row sm:items-center"
+            className="flex max-w-[480px] flex-col gap-5 text-v1-body-lg [font-size:clamp(0.95rem,1.2vw,1.0625rem)] [line-height:1.55]"
+            {...entry(280, SUBINK)}
+          >
+            <p className="italic">
+              The developer experience Temporal wishes it had.
+            </p>
+            <p>
+              If you&apos;re evaluating Temporal alternatives, Inngest vs
+              Temporal is just a question about whether you want to spend more
+              time on code, or the infrastructure around it. Inngest lets you
+              ship faster, no matter how your code is written or where it lives.
+            </p>
+          </motion.div>
+
+          <motion.div
+            className="flex flex-col gap-[18px] sm:flex-row sm:flex-wrap sm:items-center"
             {...entry(460)}
           >
             <ButtonLink
@@ -108,6 +119,13 @@ export default function Hero() {
               className="!w-full sm:!w-auto"
             >
               Build for free
+            </ButtonLink>
+            <ButtonLink
+              href="#comparison"
+              variant="secondaryLight"
+              className="!w-full sm:!w-auto"
+            >
+              View full comparison
             </ButtonLink>
           </motion.div>
         </div>

--- a/components/v1/sections/CompareTemporal/Hero.tsx
+++ b/components/v1/sections/CompareTemporal/Hero.tsx
@@ -80,8 +80,8 @@ export default function Hero() {
               className="text-v1-display-hero uppercase lg:!text-[clamp(2.5rem,5vw,4.75rem)] lg:leading-[1.02] lg:tracking-[-0.025em]"
               style={{ color: INK }}
             >
-              <span className="block">Inngest vs</span>
-              <span className="block">Temporal</span>
+              <span className="block">The DX Temporal</span>
+              <span className="block">wish it had.</span>
             </span>
           </motion.h1>
 
@@ -89,9 +89,6 @@ export default function Hero() {
             className="flex max-w-[480px] flex-col gap-5 text-v1-body-lg [font-size:clamp(0.95rem,1.2vw,1.0625rem)] [line-height:1.55]"
             {...entry(280, SUBINK)}
           >
-            <p className="italic">
-              The developer experience Temporal wishes it had.
-            </p>
             <p>
               If you&apos;re evaluating Temporal alternatives, Inngest vs
               Temporal is just a question about whether you want to spend more


### PR DESCRIPTION
## Summary
- Put **Temporal alternatives** and **Inngest vs Temporal** in the H1 and intro copy on `/compare-to-temporal`.
- Add AEO FAQs for “Is there a Temporal alternative?” and “Inngest vs Temporal differences.”
- Add a **View full comparison** CTA that jumps to `#comparison` on the feature table.

## Test plan
- [x] Open `/compare-to-temporal` and confirm the H1, italic DX line, and intro copy.
- [x] Click **View full comparison** and confirm it scrolls to the table.
- [x] Confirm the two new FAQ items are first in the accordion.


Made with [Cursor](https://cursor.com)