### PR TITLE
Fix outdated SDK examples across the docs

### DIFF
--- a/pages/docs/apps/index.mdx
+++ b/pages/docs/apps/index.mdx
@@ -62,6 +62,7 @@ inngest_client = inngest.Inngest(app_id="flask_example", logger=logger)
     trigger=inngest.TriggerEvent(event="say-hello"),
 )
 def hello(ctx: inngest.ContextSync) -> str:
+    return "Hello, World!"
 
 inngest.flask.serve(
     app,

--- a/pages/docs/events/index.mdx
+++ b/pages/docs/events/index.mdx
@@ -254,9 +254,9 @@ const { ids } = await inngest.send([
 
 ```python
 await inngest_client.send([
-  { name: "storefront/cart.checkout.completed", data: { ... } },
-  { name: "storefront/coupon.used", data: { ... } },
-  { name: "storefront/loyalty.program.joined", data: { ... } },
+  inngest.Event(name="storefront/cart.checkout.completed", data={}),
+  inngest.Event(name="storefront/coupon.used", data={}),
+  inngest.Event(name="storefront/loyalty.program.joined", data={}),
 ])
 ```
 
@@ -265,12 +265,12 @@ This is especially useful if you have an array of data in your app and you want 
 ```python
 # This function call might return 10s or 100s of items, so we can use map
 # to transform the items into event payloads then pass that array to send:
-importedItems = await api.fetchAllItems();
+imported_items = await api.fetch_all_items()
 events = [
   inngest.Event(name="storefront/item.imported", data=item)
-  for item in importedItems
+  for item in imported_items
 ]
-await inngest_client.send(events);
+await inngest_client.send(events)
 ```
 
 ## Sending events from within functions

--- a/pages/docs/features/inngest-functions/error-retries/retries.mdx
+++ b/pages/docs/features/inngest-functions/error-retries/retries.mdx
@@ -351,13 +351,13 @@ from src.inngest.client import inngest_client
     trigger=inngest.TriggerEvent(event="user.created"),
 )
 def send_welcome_notification(ctx: inngest.ContextSync) -> None:
-	success, retryAfter, err = twilio.Messages.Create(twilio.MessageOpts{
-		To:   ctx.event.data["user"]["phoneNumber"],
-		Body: "Welcome to our service!",
-	})
+    success, retry_after = send_twilio_message(
+        to=ctx.event.data["user"]["phoneNumber"],
+        body="Welcome to our service!",
+    )
 
-	if not success and retryAfter is not None:
-		raise inngest.RetryAfterError("Hit Twilio rate limit", retryAfter)
+    if not success and retry_after is not None:
+        raise inngest.RetryAfterError("Hit Twilio rate limit", retry_after)
 ```
 
 </LanguageSection>

--- a/pages/docs/features/middleware/create.mdx
+++ b/pages/docs/features/middleware/create.mdx
@@ -163,8 +163,8 @@ As it's possible for an application to use multiple Inngest clients, it's recomm
       id = "my-middleware";
 
       // Observable hook: runs before the function handler on the first attempt
-      onRunStart({ ctx, functionInfo }: Middleware.OnRunStartArgs) {
-        console.log(`Starting ${functionInfo.id}`);
+      onRunStart({ ctx, fn }: Middleware.OnRunStartArgs) {
+        console.log(`Starting ${fn.id()}`);
       }
 
       // Wrapping hook: wraps function execution
@@ -237,7 +237,7 @@ It's common for middleware to require additional customization or options from d
     export function createMyMiddleware(logEventOutput: string) {
       return class MyMiddleware extends Middleware.BaseMiddleware {
         id = "my-middleware";
-        onRunComplete({ ctx, functionInfo, output }: Middleware.OnRunCompleteArgs) {
+        onRunComplete({ ctx, output }: Middleware.OnRunCompleteArgs) {
           if (ctx.event.name === logEventOutput) {
             console.log(
               `${logEventOutput} output: ${JSON.stringify(output)}`
@@ -339,4 +339,3 @@ Check out our pre-built middleware and examples:
 
 
 </LanguageSelector>
-

--- a/pages/docs/guides/background-jobs.mdx
+++ b/pages/docs/guides/background-jobs.mdx
@@ -44,11 +44,11 @@ const inngest = new Inngest({ id: "signup-flow" });
 
 export const sendSignUpEmail = inngest.createFunction(
   { id: "send-signup-email", triggers: { event: "app/user.created" } },
-  ({ event, step }) => {
+  async ({ event, step }) => {
     await step.run("send-the-user-a-signup-email", async () => {
       await sesclient.clientsendEmail({
-        to: event.data.user_email,
-        subject: "Welcome to Inngest!"
+        to: event.data.email,
+        subject: "Welcome to Inngest!",
         message: "...",
       });
     });

--- a/pages/docs/guides/handling-idempotency.mdx
+++ b/pages/docs/guides/handling-idempotency.mdx
@@ -59,15 +59,19 @@ inngest.Send(context.Background(), inngestgo.Event{
 
 
 ```python {{ title: "Python" }}
+import inngest
+
 cart_id = 'CGo5Q5ekAxilN92d27asEoDO'
-await inngest.send({
-  id: f'checkout-completed-{cart_id}', // <-- This is the idempotency key
-  name: 'cart/checkout.completed',
-  data: {
-    email: 'taylor@example.com',
-    cart_id: cart_id
-  }
-})
+await inngest_client.send(
+    inngest.Event(
+        id=f'checkout-completed-{cart_id}',  # This is the idempotency key
+        name='cart/checkout.completed',
+        data={
+            'email': 'taylor@example.com',
+            'cart_id': cart_id,
+        },
+    )
+)
 ```
 
 </CodeGroup>
@@ -212,7 +216,6 @@ const runGeneration = inngest.createFunction(
 ```
 
 </details>
-
 
 
 

--- a/pages/docs/guides/invoking-functions-directly.mdx
+++ b/pages/docs/guides/invoking-functions-directly.mdx
@@ -91,7 +91,8 @@ const square = await step.invoke("compute-square-value", {
 References can also be used to invoke local functions without needing to import them (and their dependencies) directly. This can be useful for frameworks like Next.js where edge and serverless handlers can be mixed together and require different sets of dependencies.
 
 ```ts
-import { inngest, referenceFunction } from "inngest";
+import { referenceFunction } from "inngest";
+import { inngest } from "@/inngest/client";
 import { type computeSquare } from "@/inngest/computeSquare"; // Import only the type
 
 const mainFunction = inngest.createFunction(

--- a/pages/docs/guides/multiple-triggers.mdx
+++ b/pages/docs/guides/multiple-triggers.mdx
@@ -81,24 +81,22 @@ Wildcards cannot be used following any characters other than `/` and `.` or in t
 To define types for wildcard triggers, you need to explicitly define
 
 ```ts
-import { eventType, Inngest } from "inngest";
+import { eventType, Inngest, staticSchema } from "inngest";
 
-const blogPostCreated = eventType({
-  name: "app/blog.post.created",
-  data: {} as {
+type BlogPostEventData =
+  | {
     postId: string;
     authorId: string;
     createdAt: string;
-  },
-});
-
-const blogPostPublished = eventType({
-  name: "app/blog.post.published",
-  data: {} as {
+  }
+  | {
     postId: string;
     authorId: string;
     publishedAt: string;
-  },
+  };
+
+const blogPostEvent = eventType("app/blog.post.*", {
+  schema: staticSchema<BlogPostEventData>(),
 });
 
 const inngest = new Inngest({
@@ -106,7 +104,7 @@ const inngest = new Inngest({
 });
 
 inngest.createFunction(
-  { id: "blog-updates-to-slack", triggers: [{ event: "app/blog.post.*" }] },
+  { id: "blog-updates-to-slack", triggers: [blogPostEvent] },
   async ({ event, step }) => {
     // ...
   },

--- a/pages/docs/guides/sending-events-from-functions.mdx
+++ b/pages/docs/guides/sending-events-from-functions.mdx
@@ -30,10 +30,14 @@ This is an example of a [scheduled function](/docs/guides/scheduled-functions) t
 First, the function fetches all users, then it maps over all users to create a `"app/weekly-email-activity.send"` event for each user, and finally it sends all events to Inngest.
 
 ```ts
-import { GetEvents, Inngest } from "inngest";
+import { eventType, Inngest, staticSchema } from "inngest";
 
 const inngest = new Inngest({ id: "signup-flow" });
-type Events = GetEvents<typeof inngest>;
+const weeklyEmailActivity = eventType("app/weekly-email-activity.send", {
+  schema: staticSchema<{
+    user: Awaited<ReturnType<typeof fetchUsers>>[number];
+  }>(),
+});
 
 export const loadCron = inngest.createFunction(
   { id: "weekly-activity-load-users", triggers: { cron: "0 12 * * 5" } },
@@ -45,17 +49,7 @@ export const loadCron = inngest.createFunction(
 
     // For each user, send us an event.  Inngest supports batches of events
     // as long as the entire payload is less than 512KB.
-    const events = users.map<Events["app/weekly-email-activity.send"]>(
-      (user) => {
-        return {
-          name: "app/weekly-email-activity.send",
-          data: {
-            ...user,
-          },
-          user,
-        };
-      }
-    );
+    const events = users.map((user) => weeklyEmailActivity.create({ user }));
 
     // Send all events to Inngest, which triggers any functions listening to
     // the given event names.
@@ -71,7 +65,7 @@ Next, create a function that listens for the `"app/weekly-email-activity.send"` 
 
 ```ts
 export const sendReminder = inngest.createFunction(
-  { id: "weekly-activity-send-email", triggers: { event: "app/weekly-email-activity.send" } },
+  { id: "weekly-activity-send-email", triggers: [weeklyEmailActivity] },
   async ({ event, step }) => {
     const data = await step.run("load-user-data", async () => {
       return loadUserData(event.data.user.id);
@@ -216,4 +210,3 @@ A related pattern is invoking external functions directly instead of just trigge
 * Sending events can be done in bulk, whereas invoke can only invoke one function at a time.
 * Sending events can be combined with [fan-out](/docs/guides/fan-out-jobs) to trigger multiple functions from a single event
 * Unlike invocation, sending events will not receive the result of the invoked function
-

--- a/pages/docs/guides/trigger-your-code-from-retool.mdx
+++ b/pages/docs/guides/trigger-your-code-from-retool.mdx
@@ -114,11 +114,13 @@ For this guide, we'll explain how to do this with an existing [Express.js](https
 
 ```js
 import { serve } from "inngest/express"
+import { inngest } from "../inngest/client"
 import runBackfillForUser from "../inngest/runBackfillForUser"
 
-app.use("/api/inngest", serve("My API", process.env.INNGEST_SIGNING_KEY, [
-  runBackfillForUser,
-]))
+app.use("/api/inngest", serve({
+  client: inngest,
+  functions: [runBackfillForUser],
+}))
 // your existing routes...
 app.get("/api/whatever", ...)
 app.post("/api/something_else", ...)

--- a/pages/docs/learn/serving-inngest-functions.mdx
+++ b/pages/docs/learn/serving-inngest-functions.mdx
@@ -929,7 +929,6 @@ import { Inngest, InngestCommHandler, type ServeHandlerOptions } from "inngest";
 const serve = (options: ServeHandlerOptions) => {
   const handler = new InngestCommHandler({
     frameworkName: "edge",
-    fetch: fetch.bind(globalThis),
     ...options,
     handler: (req: Request) => {
       return {
@@ -1026,6 +1025,7 @@ inngest_client = inngest.Inngest(app_id="flask_example", logger=logger)
     trigger=inngest.TriggerEvent(event="say-hello"),
 )
 def hello(ctx: inngest.ContextSync) -> str:
+    return "Hello, World!"
 
 inngest.flask.serve(
     app,

--- a/pages/docs/local-development.mdx
+++ b/pages/docs/local-development.mdx
@@ -129,12 +129,14 @@ await inngest.send({
 ```
 
 ```python {{ title: "Python" }}
-from inngest import Inngest
+import inngest
 
 inngest_client = inngest.Inngest(app_id="my_app")
 await inngest_client.send(
-  name="user.avatar.uploaded",
-  data={"url": "https://a-bucket.s3.us-west-2.amazonaws.com/..."},
+  inngest.Event(
+    name="user.avatar.uploaded",
+    data={"url": "https://a-bucket.s3.us-west-2.amazonaws.com/..."},
+  )
 )
 ```
 

--- a/pages/docs/reference/typescript/v4/functions/triggers.mdx
+++ b/pages/docs/reference/typescript/v4/functions/triggers.mdx
@@ -349,9 +349,7 @@ const computeSquare = inngest.createFunction(
     id: "compute-square",
     triggers: [
       { event: "calculate/square" },
-      invoke({
-        schema: z.object({ number: z.number() }),
-      }),
+      invoke(z.object({ number: z.number() })),
     ],
   },
   async ({ event }) => {
@@ -363,12 +361,8 @@ const computeSquare = inngest.createFunction(
 ### Parameters
 
 <Properties>
-  <Property name="options" type="object" required>
-    <Properties nested={true}>
-      <Property name="schema" type="StandardSchemaV1 | StaticSchema" required>
-        A schema defining the expected `data` shape when callers invoke this function via `step.invoke()`. Accepts any [Standard Schema](https://standardschema.dev/) compatible library or a [`staticSchema()`](#staticschema).
-      </Property>
-    </Properties>
+  <Property name="schema" type="StandardSchemaV1 | StaticSchema" required>
+    A schema defining the expected `data` shape when callers invoke this function via `step.invoke()`. Accepts any [Standard Schema](https://standardschema.dev/) compatible library or a [`staticSchema()`](#staticschema).
   </Property>
 </Properties>
 
@@ -387,12 +381,10 @@ Define the invoke schema on the target function, then call it with typed data:
         id: "process-image",
         triggers: [
           { event: "image/uploaded" },
-          invoke({
-            schema: z.object({
-              imageUrl: z.string().url(),
-              width: z.number(),
-            }),
-          }),
+          invoke(z.object({
+            imageUrl: z.string().url(),
+            width: z.number(),
+          })),
         ],
       },
       async ({ event }) => {
@@ -485,7 +477,7 @@ const resizeImage = inngest.createFunction(
   {
     id: "resize-image",
     triggers: [
-      invoke({ schema: staticSchema<ResizeInput>() }),
+      invoke(staticSchema<ResizeInput>()),
     ],
   },
   async ({ event }) => {

--- a/pages/docs/reference/typescript/v4/middleware/examples.mdx
+++ b/pages/docs/reference/typescript/v4/middleware/examples.mdx
@@ -85,27 +85,27 @@ import { Middleware } from "inngest";
 
 class ObservabilityMiddleware extends Middleware.BaseMiddleware {
   id = "o11y";
-  onRunStart({ functionInfo }: Middleware.OnRunStartArgs) {
-    console.log(`[run:start] ${functionInfo.id}`);
+  onRunStart({ fn }: Middleware.OnRunStartArgs) {
+    console.log(`[run:start] ${fn.id()}`);
   }
 
-  onRunComplete({ functionInfo, output }: Middleware.OnRunCompleteArgs) {
-    console.log(`[run:complete] ${functionInfo.id}`, output);
+  onRunComplete({ fn, output }: Middleware.OnRunCompleteArgs) {
+    console.log(`[run:complete] ${fn.id()}`, output);
   }
 
-  onRunError({ functionInfo, error, isFinalAttempt }: Middleware.OnRunErrorArgs) {
-    console.error(`[run:error] ${functionInfo.id}`, error);
+  onRunError({ fn, error, isFinalAttempt }: Middleware.OnRunErrorArgs) {
+    console.error(`[run:error] ${fn.id()}`, error);
     if (isFinalAttempt) {
       // Send to error tracking service
     }
   }
 
-  onStepComplete({ functionInfo, stepInfo }: Middleware.OnStepCompleteArgs) {
-    console.log(`[step:complete] ${functionInfo.id} > ${stepInfo.hashedId}`);
+  onStepComplete({ fn, stepInfo }: Middleware.OnStepCompleteArgs) {
+    console.log(`[step:complete] ${fn.id()} > ${stepInfo.hashedId}`);
   }
 
-  onStepError({ functionInfo, stepInfo, error }: Middleware.OnStepErrorArgs) {
-    console.error(`[step:error] ${functionInfo.id} > ${stepInfo.hashedId}`, error);
+  onStepError({ fn, stepInfo, error }: Middleware.OnStepErrorArgs) {
+    console.error(`[step:error] ${fn.id()} > ${stepInfo.hashedId}`, error);
   }
 }
 ```

--- a/pages/docs/reference/typescript/v4/middleware/lifecycle.mdx
+++ b/pages/docs/reference/typescript/v4/middleware/lifecycle.mdx
@@ -78,7 +78,7 @@ Will not call if the first attempt fails to reach the app (e.g. a network error)
   <Property required name="ctx">
     The function context.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function being executed.
   </Property>
 </Properties>
@@ -93,7 +93,7 @@ Called when a function completes successfully.
   <Property required name="ctx">
     The function context.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
   <Property required name="output">
@@ -114,7 +114,7 @@ Called each time a function throws an error.
   <Property required name="error">
     The error that was thrown.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
   <Property required name="isFinalAttempt">
@@ -132,7 +132,7 @@ Called before a step handler runs. Only called for `step.run` and `step.sendEven
   <Property required name="ctx">
     The function context.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
   <Property required name="stepInfo">
@@ -150,7 +150,7 @@ Called when a step succeeds. Only called for `step.run` and `step.sendEvent`. Ne
   <Property required name="ctx">
     The function context.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
   <Property required name="output">
@@ -174,7 +174,7 @@ Called when a step throws an error. Only called for `step.run` and `step.sendEve
   <Property required name="error">
     The error that was thrown.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
   <Property required name="isFinalAttempt">
@@ -197,7 +197,7 @@ Use cases for this hook are limited. It's primarily useful for logging or metric
   <Property required name="ctx">
     The function context.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
 </Properties>
@@ -229,7 +229,7 @@ Wraps the entire HTTP request
 Example use cases: auth, top-level metrics, or error boundaries.
 
 <Properties>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
   <Property required name="next">
@@ -259,7 +259,7 @@ Example use cases: `AsyncLocalStorage`, error transformation, timing, or [insert
   <Property required name="ctx">
     The function context.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
   <Property required name="next">
@@ -283,7 +283,7 @@ If the step is not memoized, `next()` never resolves for that request. The metho
   <Property required name="ctx">
     The function context.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
   <Property required name="next">
@@ -306,7 +306,7 @@ Example use cases: serialize step output, [error handling](/docs/reference/types
   <Property required name="ctx">
     The function context.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
   <Property required name="next">
@@ -329,7 +329,7 @@ Example use cases: backup on send failure, metrics.
   <Property required name="events">
     The events being sent.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function, or `null` if called outside a function (e.g. `inngest.send()`).
   </Property>
   <Property required name="next">
@@ -353,7 +353,7 @@ Example use cases: dependency injection, deserialize event data.
   <Property required name="ctx">
     The function context. Add properties here to inject them into the function handler.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
   <Property required name="steps">
@@ -370,7 +370,7 @@ Modify step options or input before a step runs.
 Example use cases: serialize `step.invoke` data, bust memoization cache (i.e. change step ID).
 
 <Properties>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function.
   </Property>
   <Property required name="stepInfo">
@@ -396,7 +396,7 @@ Example use cases: serialize event data, add metadata.
   <Property required name="events">
     The events being sent. Return a modified copy to change them.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function, or `null` if called outside a function.
   </Property>
 </Properties>
@@ -491,7 +491,7 @@ Example use cases: one-time setup.
 ```ts
 class MyMiddleware extends Middleware.BaseMiddleware {
   id = "my-middleware";
-  static onRegister({ client, functionInfo }: Middleware.OnRegisterArgs) {
+  static onRegister({ client, fn }: Middleware.OnRegisterArgs) {
     // One-time setup
   }
 }
@@ -501,7 +501,7 @@ class MyMiddleware extends Middleware.BaseMiddleware {
   <Property required name="client">
     The Inngest client instance.
   </Property>
-  <Property required name="functionInfo">
+  <Property required name="fn">
     Metadata about the function, or `null` for client-level middleware.
   </Property>
 </Properties>

--- a/pages/docs/typescript.mdx
+++ b/pages/docs/typescript.mdx
@@ -144,32 +144,9 @@ export default inngest.createFunction(
 
 The TS SDK exports some helper types to allow you to access the type of particular Inngest internals outside of an Inngest function.
 
-### GetEvents <VersionBadge version="v2.0.0+" />
-
-Get a record of all available events given an Inngest client.
-
-It's recommended to use this instead of directly reusing your own event types, as Inngest will add extra properties and internal events such as `ts` and `inngest/function.failed`.
-
-```ts
-import { type GetEvents } from "inngest";
-import { inngest } from "@/inngest";
-
-type Events = GetEvents<typeof inngest>;
-```
-
-By default, the returned events do not include internal events prefixed with
-`inngest/`, such as `inngest/function.finished`.
-
-To include these events in
-<VersionBadge version="v3.13.1+" />, pass a second `true` generic:
-
-```ts
-type Events = GetEvents<typeof inngest, true>;
-```
-
 ### GetFunctionInput <VersionBadge version="v3.3.0+" />
 
-Get the argument passed to Inngest functions given an Inngest client and, optionally, an event trigger.
+Get the argument passed to Inngest functions given an Inngest client.
 
 Useful for building function factories or other such abstractions.
 
@@ -178,12 +155,11 @@ import { type GetFunctionInput } from "inngest";
 import { inngest } from "@/inngest";
 
 type InputArg = GetFunctionInput<typeof inngest>;
-type InputArgWithTrigger = GetFunctionInput<typeof inngest, "app/user.created">;
 ```
 
 ### GetStepTools <VersionBadge version="v3.3.0+" />
 
-Get the `step` object passed to an Inngest function given an Inngest client and, optionally, an event trigger.
+Get the `step` object passed to an Inngest function given an Inngest client.
 
 Is a small shim over the top of `GetFunctionInput<...>["step"]`.
 
@@ -192,7 +168,6 @@ import { type GetStepTools } from "inngest";
 import { inngest } from "@/inngest";
 
 type StepTools = GetStepTools<typeof inngest>;
-type StepToolsWithTrigger = GetStepTools<typeof inngest, "app/user.created">;
 ```
 
 ### Inngest.Any / InngestFunction.Any <VersionBadge version="v3.10.0+" />


### PR DESCRIPTION
## Summary

Updates documentation examples that have drifted from the current TypeScript and Python SDKs:
- Update TypeScript examples to the current `eventType()`, `invoke()`, middleware, and `serve()` APIs
- Correct invalid Python event payloads and missing handler returns
- Fix missing imports, asynchronous handlers, and inconsistent event data shapes
- Remove references to SDK helpers and overloads that are no longer exported

These issues were found by validating the published examples against the current SDK contracts.

## Validation:
- `pnpm test:docs-markdown` - 12 tests passed
- Prettier checks passed for all changed MDX files
- TypeScript changes verified against `inngest@4.4.0`
- Python changes verified against the current Python SDK