### PR TITLE
Fix incorrect status labels in prometheus integration docs

### DIFF
--- a/pages/docs/platform/monitor/prometheus-metrics-export-integration.mdx
+++ b/pages/docs/platform/monitor/prometheus-metrics-export-integration.mdx
@@ -37,8 +37,8 @@ The following metrics are exported:
 ```yaml
 # HELP inngest_function_run_ended_total The total number of function runs ended
 # TYPE inngest_function_run_ended_total counter
-inngest_function_run_ended_total{date="2025-02-12",fn="my-app-my-function",status="Completed"} 480
-inngest_function_run_ended_total{date="2025-02-12",fn="my-app-my-function",status="Failed"} 20
+inngest_function_run_ended_total{date="2025-02-12",fn="my-app-my-function",status="completed"} 480
+inngest_function_run_ended_total{date="2025-02-12",fn="my-app-my-function",status="failed"} 20
 # HELP inngest_function_run_scheduled_total The total number of function runs scheduled
 # TYPE inngest_function_run_scheduled_total counter
 inngest_function_run_scheduled_total{date="2025-02-12",fn="my-app-my-function"} 500


### PR DESCRIPTION
The docs falsely uses capitalized "Completed" and "Failed" statuses for the `inngest_function_run_ended_total` metric. The actual values are "completed" and "failed", respectively.