### PR TITLE
Point eval webinar CTAs to docs recording

### DIFF
--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -58,7 +58,7 @@ const Banner: React.FC<Props> = ({ href, children, className, target, rel }) => 
 export default function AnnouncementBanner() {
   return (
     <Banner
-      href="https://events.zoom.us/e/recording?videoId=uKbFJoUhRQKS9V71ysKkLw&eventId=Z8vtvPiATTq_LQxwlO8_ZA&organizationId=Jm1kZRVvQC6tCNBq9FaDag"
+      href="https://www.inngest.com/docs/learn/agent-evals#ship-your-first-eval-webinar-recording"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/content/blog/introducing-agent-evals.mdx
+++ b/content/blog/introducing-agent-evals.mdx
@@ -9,7 +9,7 @@ category: product-updates
 sidebarCta:
   text: "You're already running agents in prod. Learn how to ship your first eval."
   buttonLabel: "Watch the recording"
-  href: "https://events.zoom.us/e/recording?videoId=uKbFJoUhRQKS9V71ysKkLw&eventId=Z8vtvPiATTq_LQxwlO8_ZA&organizationId=Jm1kZRVvQC6tCNBq9FaDag"
+  href: "https://www.inngest.com/docs/learn/agent-evals#ship-your-first-eval-webinar-recording"
 ---
 
 An agent returns a perfect answer. The user doesn't convert, the ticket reopens, the customer churns. The output scored well on every metric you have, and none of it mattered to your bottom line.

--- a/content/blog/introducing-group-experiment.mdx
+++ b/content/blog/introducing-group-experiment.mdx
@@ -9,7 +9,7 @@ category: product-updates
 sidebarCta:
   text: "You're already running agents in prod. Learn how to ship your first eval."
   buttonLabel: "Watch the recording"
-  href: "https://events.zoom.us/e/recording?videoId=uKbFJoUhRQKS9V71ysKkLw&eventId=Z8vtvPiATTq_LQxwlO8_ZA&organizationId=Jm1kZRVvQC6tCNBq9FaDag"
+  href: "https://www.inngest.com/docs/learn/agent-evals#ship-your-first-eval-webinar-recording"
 ---
 
 The data you need to actually judge a workflow experiment has never been reachable from where you run experiments today.

--- a/content/blog/introducing-scoring.mdx
+++ b/content/blog/introducing-scoring.mdx
@@ -9,7 +9,7 @@ category: product-updates
 sidebarCta:
   text: "You're already running agents in prod. Learn how to ship your first eval."
   buttonLabel: "Watch the recording"
-  href: "https://events.zoom.us/e/recording?videoId=uKbFJoUhRQKS9V71ysKkLw&eventId=Z8vtvPiATTq_LQxwlO8_ZA&organizationId=Jm1kZRVvQC6tCNBq9FaDag"
+  href: "https://www.inngest.com/docs/learn/agent-evals#ship-your-first-eval-webinar-recording"
 ---
 
 Durable execution ensures every step of your workflow or agent completes successfully. But how do you know whether the outcome was the one you actually wanted?

--- a/content/blog/online-vs-offline-ai-evals-when-to-use-each.mdx
+++ b/content/blog/online-vs-offline-ai-evals-when-to-use-each.mdx
@@ -16,7 +16,7 @@ author: Mitchell Alderson
 sidebarCta:
   text: "You're already running agents in prod. Learn how to ship your first eval."
   buttonLabel: "Watch the recording"
-  href: "https://events.zoom.us/e/recording?videoId=uKbFJoUhRQKS9V71ysKkLw&eventId=Z8vtvPiATTq_LQxwlO8_ZA&organizationId=Jm1kZRVvQC6tCNBq9FaDag"
+  href: "https://www.inngest.com/docs/learn/agent-evals#ship-your-first-eval-webinar-recording"
 ---
 
 AI agents excel at breaking things. They're non-deterministic: the same input can produce different outputs, some with bad consequences.


### PR DESCRIPTION
Update the global announcement banner and the four eval blog posts' sidebar CTAs to link to the webinar recording section in the docs instead of the Zoom recording URL.