### PR TITLE
Remove Connect beta labels from docs

### DIFF
--- a/pages/docs/setup/connect.mdx
+++ b/pages/docs/setup/connect.mdx
@@ -5,10 +5,6 @@ export const description = "Use connect() to create persistent outbound connecti
 
 # Connect (workers)
 
-<Info>
-  Connect is currently in Public Beta. Read more about the [Public Beta release phase here](/docs/release-phases#public-beta).
-</Info>
-
 The `connect` API allows your app to create an outbound persistent connection to Inngest. Each app can establish multiple connections to Inngest, which enable you to scale horizontally across multiple workers. The key benefits of using `connect` compared to [`serve`](/docs/learn/serving-inngest-functions) are:
 
 - **Lowest latency** - Persistent connections enable the lowest latency between your app and Inngest.
@@ -47,7 +43,7 @@ If using TypeScript, your runtime must support built-in WebSocket support (Node 
 
 ## Getting started
 
-Using `connect` with your app is simple. Using each SDK's "connect" method only requires a list of functions that are available to be executed. (Note: Python support is in beta)
+Using `connect` with your app is simple. Using each SDK's "connect" method only requires a list of functions that are available to be executed.
 
 Here is a one-file example of a fully-functioning app that connects to Inngest.
 

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -794,7 +794,6 @@ const sectionLearn: (NavGroup | NavLink)[] = [
           {
             title: "Connect (workers)",
             href: `/docs/setup/connect`,
-            tag: "beta",
           },
           {
             title: "Checkpointing",


### PR DESCRIPTION
## Summary
- Removes the Public Beta callout from `/docs/setup/connect`
- Removes the leftover “Python support is in beta” note
- Drops the `beta` tag from Connect in the docs sidebar

## Test plan
- [ ] Preview `/docs/setup/connect` — no beta banner at the top
- [ ] Confirm sidebar “Connect (workers)” has no beta badge
- [ ] Spot-check Getting started intro no longer mentions Python beta


Made with [Cursor](https://cursor.com)