### PR TITLE
chore: update documentation CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Documentation reviewers
 
-/pages/docs @djfarrelly @Benanna2019
+/pages/docs @Benanna2019

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Documentation reviewers
+
+/pages/docs @LCraigie @mitchellalderson

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-# Documentation reviewers
-
-/pages/docs @Benanna2019


### PR DESCRIPTION
## Summary

Replaces the previous documentation owners with @LCraigie and @mitchellalderson for `/pages/docs`. Both users have write access to the repository and are valid CODEOWNERS.

Tests are not applicable for this ownership-only change.