### PR TITLE
Fix clipped descenders in blog card descriptions

### DIFF
--- a/components/v1/sections/Learn/ResourceCard.tsx
+++ b/components/v1/sections/Learn/ResourceCard.tsx
@@ -47,7 +47,7 @@ export default function ResourceCard({ post }: { post: PostCard }) {
           {/* Description + CTA. The CTA is the shared RegisterCue
               (Label/Md, reacts to the card's group/card hover with a
               salmon + arrow nudge). */}
-          <p className="text-v1-body-sm line-clamp-2 text-white/80">
+          <p className="text-v1-body-sm-loose line-clamp-2 tracking-[-0.01em] text-white/80">
             {post.subtitle ?? ""}
           </p>
           <div className="mt-auto">


### PR DESCRIPTION
## Summary

- use untrimmed body typography for blog card descriptions so descenders remain visible before line-clamp ellipses
- preserve the original `-0.01em` letter spacing to keep wrapping unchanged

## Screenshots

### Full page — before

![Blog cards before the typography change](https://ampcode.com/user-content/artifacts/38f954d35ce0d00faffc125e7f49ba4a7911b13b1b73750fb9340ea4608801d6-file.png)

### Full page — after

![Blog cards after the typography change](https://ampcode.com/user-content/artifacts/924f497de9250350cbcc6e5091fb568ef41fb1fb3b7f673b0fd005c49a11afb2-file.png)

### `only…` comparison

![Before and after comparison of the descender in only](https://ampcode.com/user-content/artifacts/beabc5b435c1ad7e83eb63f1e13a2813d5f1d6a9ee51d8136b7e2eb3c3e1e2fc-file.png)

### `Celery` and `configs` comparison

![Before and after comparison of the descender in Celery](https://ampcode.com/user-content/artifacts/9b5d241d04078c1e32681255970559647108d9b9f10c961bc398fc22628f1557-file.png)
