### PR TITLE
Fix stale Upcoming Events and link August {AI} in Production recording

### DIFF
--- a/app/(v1)/events/page.tsx
+++ b/app/(v1)/events/page.tsx
@@ -8,6 +8,14 @@ import eventsDotsData from "@/public/assets/v1/events-hero/dots.json";
 // pattern paints on the first frame instead of after a fetch.
 const EVENTS_DOTS_JSON = JSON.stringify(eventsDotsData);
 
+// "Upcoming Events" is server-rendered, so its past/upcoming split gets
+// frozen into the prerendered HTML at build time — an event that ended
+// after the last deploy kept showing a live Register button. Regenerate
+// at most hourly so the section tracks the clock rather than the deploy
+// cadence. ("All Events" is a client component and self-corrects on
+// hydration, which is why only this section drifted.)
+export const revalidate = 3600;
+
 export const metadata: Metadata = generateMetadata({
   title: "Events - Conferences, Meetups & Talks",
   description:

--- a/components/v1/sections/Events/EventCard.tsx
+++ b/components/v1/sections/Events/EventCard.tsx
@@ -75,7 +75,9 @@ export default function EventCard({ ev, newTab }: { ev: EventItem; newTab?: bool
               single-line ellipsis. */}
           <p className="text-v1-body-sm truncate text-white/80">{ev.excerpt}</p>
           <div className="py-1">
-            <RegisterCue label={isPastEvent(ev) ? "View event details" : "Register"} />
+            <RegisterCue
+              label={ev.recording ? "Watch recording" : isPastEvent(ev) ? "View event details" : "Register"}
+            />
           </div>
         </div>
       </div>

--- a/components/v1/sections/Events/EventCardLarge.tsx
+++ b/components/v1/sections/Events/EventCardLarge.tsx
@@ -71,7 +71,9 @@ export default function EventCardLarge({ ev, newTab }: { ev: EventItem; newTab?:
         </div>
         <p className="text-v1-body-xs text-white/80">{ev.excerpt}</p>
         <div className="py-1">
-          <RegisterCue label={isPastEvent(ev) ? "View event details" : "Register"} />
+          <RegisterCue
+            label={ev.recording ? "Watch recording" : isPastEvent(ev) ? "View event details" : "Register"}
+          />
         </div>
       </div>
       </SpotlightFrame>

--- a/components/v1/sections/Events/UpcomingEvents.tsx
+++ b/components/v1/sections/Events/UpcomingEvents.tsx
@@ -4,6 +4,12 @@ import { UPCOMING, isPastEvent } from "@/components/v1/sections/Events/data";
 export default function UpcomingEvents() {
   const upcoming = UPCOMING.filter((ev) => !isPastEvent(ev));
 
+  // Once every event has started there is nothing to promote, so drop the
+  // whole section rather than leaving a bare "Upcoming Events" heading over
+  // an empty list. Mirrors the "Other upcoming events" rail on the event
+  // detail pages, which hides itself the same way.
+  if (upcoming.length === 0) return null;
+
   return (
     <section
       aria-labelledby="upcoming-events-heading"

--- a/components/v1/sections/Events/data.ts
+++ b/components/v1/sections/Events/data.ts
@@ -125,7 +125,8 @@ export const UPCOMING: EventItem[] = [
     topics: ["Meetups"],
     excerpt:
       "Lightning talks and real lessons learned from teams shipping AI in production — cohosted with Nebius Token Factory and Flox at Inngest HQ.",
-    href: "https://luma.com/inngest-77ls",
+    href: "https://www.youtube.com/watch?v=A5D939_aVEE",
+    recording: true,
     image: "/assets/v1/events/ai-in-production-aug-2026.png",
   },
   {
@@ -290,7 +291,8 @@ export const ALL_EVENTS: EventItem[] = sortEventsByDate([
     topics: ["Meetups"],
     excerpt:
       "Lightning talks and real lessons learned from teams shipping AI in production — cohosted with Nebius Token Factory and Flox at Inngest HQ.",
-    href: "https://luma.com/inngest-77ls",
+    href: "https://www.youtube.com/watch?v=A5D939_aVEE",
+    recording: true,
     image: "/assets/v1/events/ai-in-production-aug-2026.png",
   },
   {


### PR DESCRIPTION
## What changed

Two related fixes to the `/events` page, both about events that have already happened.

**1. Stop "Upcoming Events" from promoting events that already ended** (09065831)

`UpcomingEvents` is server-rendered, so its past/upcoming split was frozen into the prerendered HTML at build time. Any event that ended after the last deploy kept showing a live **Register** button until something else triggered a rebuild.

- `app/(v1)/events/page.tsx` — added `export const revalidate = 3600` so the section tracks the clock rather than the deploy cadence.
- `components/v1/sections/Events/UpcomingEvents.tsx` — return `null` when nothing is upcoming, instead of leaving a bare "Upcoming Events" heading over an empty list. This mirrors how the "Other upcoming events" rail on event detail pages already hides itself.

Worth noting: "All Events" never had this bug — it's a client component, so it self-corrects on hydration. Only the server-rendered section drifted.

**2. Link the August {AI} in Production event to its recording** (a3efb8de)

The August 25 meetup has passed, so its card pointed at a Luma RSVP page that no longer does anything useful.

- `components/v1/sections/Events/data.ts` — pointed both copies of the `ai-in-production-aug-2026` entry (it appears in `UPCOMING` and `ALL_EVENTS`) at `https://www.youtube.com/watch?v=A5D939_aVEE`, and set `recording: true`.
- `EventCard.tsx` / `EventCardLarge.tsx` — the CTA label now reads "Watch recording" when `recording` is set.

## For reviewers

- **`recording` is being used for the first time.** `EventItem` has had a `recording?: boolean` field that both cards already read to swap the "Past event" chip for a "Recording" chip, but no event had ever set it. No new field was added.
- **The Luma link is replaced, not supplemented.** The whole card is a single `<Link>`, so pointing it at YouTube drops `luma.com/inngest-77ls`. That seemed right for a past event; keeping both would need a separate `recordingUrl` field and a card layout that can hold two links.
- **`&feature=youtu.be` was stripped** from the YouTube URL.
- **Prettier was not run on the card files.** The `pnpm prettier` script only covers `pages/` and `shared/`, and the pinned prettier 2.8.1 reformats large unrelated chunks of `components/v1/sections/Events/*.tsx`. Edits follow the surrounding style by hand; the diff is 10 lines.

## Verification

Ran the dev server and loaded `/events`:

- The {AI} in Production card renders a **RECORDING** chip in place of "Past event".
- Its anchor resolves to `https://www.youtube.com/watch?v=A5D939_aVEE`, with `target="_blank"` and `rel="noopener noreferrer"`.
- The CTA reads "WATCH RECORDING".
- No console errors.

The `revalidate` behavior from the first commit is time-dependent and was not exercised locally — worth a look on the Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)