### PR TITLE
Remove site-wide announcement banner

### DIFF
--- a/app/(v0)/layout.tsx
+++ b/app/(v0)/layout.tsx
@@ -1,4 +1,3 @@
-import AnnouncementBanner from "src/components/AnnouncementBanner";
 import Header from "src/components/RedesignedLanding/Header/Header";
 import Footer from "src/components/RedesignedLanding/Footer";
 
@@ -12,7 +11,6 @@ export default function V0Layout({
 }) {
   return (
     <>
-      <AnnouncementBanner />
       <Header />
       <main className="text-basis">{children}</main>
       <Footer />

--- a/components/v1/Header.tsx
+++ b/components/v1/Header.tsx
@@ -13,7 +13,6 @@ import Link from "@/components/v1/Link";
 import Button from "@/components/v1/Button";
 import Logo from "@/components/v1/Logo";
 import MobileMenu from "@/components/v1/MobileMenu";
-import AnnouncementBanner from "src/components/AnnouncementBanner";
 import NavMenuPanel from "@/components/v1/NavMenuPanel";
 import {
   NAV_PRIMARY,
@@ -237,8 +236,6 @@ export default function Header() {
       style={wipeFillStyle}
       data-ink-nav={inkNav ? "" : undefined}
     >
-      {/* Promo banner — hidden on /blog (LCP risk) and when header is compacted */}
-      {!compact && !pathname?.startsWith("/blog") && <AnnouncementBanner />}
       {/* Full-bleed container: the bar spans the full page width with
           only the gutters insetting it, so the left group (logo + nav)
           anchors to the left edge and the right group (Open Source /

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,16 +23,10 @@ import {
 } from "../shared/CaseStudy/Layout";
 
 import type { PageProps } from "@/shared/types";
-import AnnouncementBanner from "src/components/AnnouncementBanner";
 import PatternsViewToggle from "../shared/Patterns/PatternsViewToggle";
 
 function DefaultLayout({ children }) {
-  return (
-    <>
-      <AnnouncementBanner />
-      {children}
-    </>
-  );
+  return <>{children}</>;
 }
 
 type DefaultProps = PageProps & DocsLayoutProps & CaseStudyLayoutProps;

--- a/shared/CaseStudy/Layout.tsx
+++ b/shared/CaseStudy/Layout.tsx
@@ -7,7 +7,6 @@ import Container from "src/shared/layout/Container";
 import Footer from "src/components/RedesignedLanding/Footer";
 import { Button } from "../Button";
 import { SectionProvider } from "shared/Docs/SectionProvider";
-import AnnouncementBanner from "src/components/AnnouncementBanner";
 
 export type Props = {
   children: React.ReactNode;
@@ -72,7 +71,6 @@ export function Layout({
           content={`https://www.inngest.com${ogImage}`}
         />
       </Head>
-      <AnnouncementBanner />
       <Header />
       <Container>
         <div className="mx-auto my-12 flex max-w-[1200px] flex-col items-start justify-between gap-8 lg:flex-row">


### PR DESCRIPTION
Removes the AnnouncementBanner render calls and imports from all four layout entry points (legacy v0 layout, pages-router _app, the v1 Header, and the case-study layout). The component file itself is left in place, unused, for potential future reuse.
