### PR TITLE
Durable execution hero copy updaate

### DIFF
--- a/components/v1/sections/DurableExecution/Hero.tsx
+++ b/components/v1/sections/DurableExecution/Hero.tsx
@@ -19,10 +19,10 @@ export default function Hero() {
         </>
       }
       bodyLines={[
-        "What is durable execution? Fault-tolerant code that",
-        "finishes even when APIs fail or servers restart.",
-        "Inngest checkpoints every step and retries",
-        "automatically—so workflows resume where they left off.",
+        "Durable execution means your code completes no",
+        "matter what. LLM outages, API timeouts, server",
+        "restarts, traffic spikes. Inngest makes every",
+        "function durable without leaving your codebase.",
       ]}
       docsHref="/docs/learn/how-functions-are-executed?ref=durable-execution"
       signupHref="/sign-up?ref=durable-execution"


### PR DESCRIPTION
Swaps the "What is durable execution?" definition-led hero body for copy that leads with the completes-no-matter-what framing and calls out LLM outages, API timeouts, server restarts, and traffic spikes.