### PR TITLE
Link case-study logos in the home strip

### DIFF
--- a/app/(v1)/customers/_story.tsx
+++ b/app/(v1)/customers/_story.tsx
@@ -44,6 +44,8 @@ export type Frontmatter = {
   companyIndustry?: string;
   companyUseCase?: string;
   ogImage?: string;
+  /** Optional secondary pill beside the "Customer story" chip. */
+  pill?: string;
 };
 
 export const listCustomerSlugs = cache((): string[] => {
@@ -118,6 +120,7 @@ function buildStoryData(data: Frontmatter, content: string): CustomerStoryData {
     .join(", ");
   return {
     tag: "Customer story",
+    pill: data.pill,
     title: data.title,
     author: data.quote?.attribution?.name,
     readTime: readingTime(content).text,

--- a/components/v1/sections/CustomerStory/Article.tsx
+++ b/components/v1/sections/CustomerStory/Article.tsx
@@ -20,9 +20,29 @@ export default function Article({
     <div className="flex flex-col gap-12 lg:col-span-2 lg:gap-16 lg:px-16">
       {/* Header block (162:17500) */}
       <div className="flex flex-col gap-6">
-        <Chip variant="gradient" size="sm" className="self-start">
-          {story.tag}
-        </Chip>
+        <div className="flex flex-col items-start gap-3">
+          <Chip variant="gradient" size="sm">
+            {story.tag}
+          </Chip>
+          {story.pill && (
+            <p
+              className="inline-flex max-w-full items-center gap-2.5 rounded-r-md bg-v1-accent-blue py-2.5 pl-6 pr-4 text-v1-body-sm text-white shadow-[0_0_0_1px_rgb(var(--color-v1-accent-blue)),0_8px_24px_-8px_rgb(var(--color-v1-accent-blue)/0.7)] [clip-path:polygon(0_50%,16px_0,100%_0,100%_100%,16px_100%)] sm:gap-3 sm:py-3 sm:pl-7 sm:pr-5 sm:text-v1-body-md"
+              role="note"
+            >
+              <span
+                aria-hidden="true"
+                className="size-1.5 shrink-0 rounded-full bg-white sm:size-2"
+              />
+              <span className="shrink-0 font-v1Label text-[11px] uppercase tracking-[0.08em] text-white/80 sm:text-[12px]">
+                Note
+              </span>
+              <span aria-hidden="true" className="text-white/50">
+                ·
+              </span>
+              <span className="min-w-0 font-medium">{story.pill}</span>
+            </p>
+          )}
+        </div>
         <h1
           id="customer-story-heading"
           className="text-v1-heading-md-cap max-w-[749px] text-white"

--- a/components/v1/sections/CustomerStory/types.ts
+++ b/components/v1/sections/CustomerStory/types.ts
@@ -4,6 +4,8 @@
 
 export interface CustomerStoryData {
   tag: string;
+  /** Optional secondary pill (e.g. acquisition note) shown beside `tag`. */
+  pill?: string;
   title: string;
   author?: string;
   readTime?: string;

--- a/components/v1/sections/Home/LogoStrip.tsx
+++ b/components/v1/sections/Home/LogoStrip.tsx
@@ -133,7 +133,7 @@ function LogoMark({
   decorative,
 }: {
   logo: CustomerLogo;
-  /** Second marquee copy — hide from a11y / focus. */
+  /** Second marquee copy — keep out of tab order / a11y tree. */
   decorative: boolean;
 }) {
   const img = (
@@ -161,10 +161,19 @@ function LogoMark({
   const className =
     "group/logo logo-item relative shrink-0 outline-none focus-visible:opacity-100";
 
-  // Shared visual chrome (dot + tooltip) for both the interactive link
-  // and the decorative duplicate so both marquee copies look identical.
-  const chrome = (
-    <>
+  // Both marquee copies must be real links — after the track translates
+  // past -50%, the duplicate set is what's under the cursor. The second
+  // copy stays out of the tab order / a11y tree via tabIndex + the
+  // parent `aria-hidden`.
+  return (
+    <Link
+      href={href}
+      className={className}
+      aria-label={
+        decorative ? undefined : `${logo.name} — Read the case study`
+      }
+      tabIndex={decorative ? -1 : undefined}
+    >
       {img}
       <span
         aria-hidden="true"
@@ -181,20 +190,6 @@ function LogoMark({
       >
         Read the case study
       </span>
-    </>
-  );
-
-  if (decorative) {
-    return <span className={className}>{chrome}</span>;
-  }
-
-  return (
-    <Link
-      href={href}
-      className={className}
-      aria-label={`${logo.name} — Read the case study`}
-    >
-      {chrome}
     </Link>
   );
 }

--- a/components/v1/sections/Home/LogoStrip.tsx
+++ b/components/v1/sections/Home/LogoStrip.tsx
@@ -35,6 +35,9 @@ interface CustomerLogo {
   /** When set, the logo shows an orange case-study indicator and links
    *  to that customer story. */
   caseStudyHref?: string;
+  /** Extra horizontal nudge (px) for the case-study dot — positive
+   *  pushes it further past the right edge of the wordmark. */
+  dotDx?: number;
 }
 
 // Heights are optically cheated per logo: very wide wordmarks
@@ -83,6 +86,9 @@ const LOGOS: CustomerLogo[] = [
     width: 118,
     height: 29,
     caseStudyHref: "/customers/resend",
+    // Wordmark sits flush to the SVG right edge, so the default
+    // -right-1.5 lands on the "d" — nudge the dot clear of the letter.
+    dotDx: 8,
   },
   { name: "Avoca", src: "/assets/v1/logos/avoca.svg", width: 118, height: 29 },
   {
@@ -163,6 +169,11 @@ function LogoMark({
       <span
         aria-hidden="true"
         className="absolute -right-1.5 -top-1 size-1.5 rounded-full bg-v1-accent-salmon shadow-[0_0_0_2px_rgb(var(--color-v1-bg-canvas-base))] sm:size-[7px]"
+        style={
+          logo.dotDx
+            ? { right: `-${6 + logo.dotDx}px` } // base -right-1.5 = 6px
+            : undefined
+        }
       />
       <span
         role="tooltip"

--- a/components/v1/sections/Home/LogoStrip.tsx
+++ b/components/v1/sections/Home/LogoStrip.tsx
@@ -6,6 +6,9 @@
  * Animation is gated by `motion-safe:` so it pauses for users with
  * `prefers-reduced-motion: reduce`.
  *
+ * Logos with a `caseStudyHref` show a small Inngest-orange indicator
+ * dot and link through to that customer story on hover/click.
+ *
  * Each logo is a flattened SVG saved at /public/assets/v1/logos/. Heights
  * vary per logo; SVGs ship with `fill="white"` since
  * `<img src>` does not inherit `currentColor`.
@@ -17,6 +20,8 @@
  * and inter-logo gap follow the same shrink-on-mobile pattern.
  */
 
+import Link from "next/link";
+
 interface CustomerLogo {
   name: string;
   src: string;
@@ -27,6 +32,9 @@ interface CustomerLogo {
    *  flex centering leaves their visual mass high — a small positive
    *  nudge re-centers the cap-height mass on the strip's midline. */
   dy?: number;
+  /** When set, the logo shows an orange case-study indicator and links
+   *  to that customer story. */
+  caseStudyHref?: string;
 }
 
 // Heights are optically cheated per logo: very wide wordmarks
@@ -35,27 +43,47 @@ interface CustomerLogo {
 // logo reads at roughly the same visual mass in the strip.
 const LOGOS: CustomerLogo[] = [
   { name: "Replit", src: "/assets/v1/logos/replit.svg", width: 116, height: 29, dy: 2 },
-  { name: "Cubic", src: "/assets/v1/logos/cubic.svg", width: 118, height: 29 },
+  {
+    name: "Cubic",
+    src: "/assets/v1/logos/cubic.svg",
+    width: 118,
+    height: 29,
+    caseStudyHref: "/customers/cubic",
+  },
   {
     name: "ElevenLabs",
     src: "/assets/v1/logos/elevenlabs.svg",
     width: 185,
     height: 24,
   },
-  { name: "Cohere", src: "/assets/v1/logos/cohere.svg", width: 169, height: 26 },
+  {
+    name: "Cohere",
+    src: "/assets/v1/logos/cohere.svg",
+    width: 169,
+    height: 26,
+    caseStudyHref: "/customers/otto",
+  },
   {
     name: "Soundcloud",
     src: "/assets/v1/logos/soundcloud.svg",
     width: 202,
     height: 24,
+    caseStudyHref: "/customers/soundcloud",
   },
   {
     name: "GitBook",
     src: "/assets/v1/logos/gitbook.svg",
     width: 127,
     height: 28,
+    caseStudyHref: "/customers/gitbook",
   },
-  { name: "Resend", src: "/assets/v1/logos/resend.svg", width: 118, height: 29 },
+  {
+    name: "Resend",
+    src: "/assets/v1/logos/resend.svg",
+    width: 118,
+    height: 29,
+    caseStudyHref: "/customers/resend",
+  },
   { name: "Avoca", src: "/assets/v1/logos/avoca.svg", width: 118, height: 29 },
   {
     name: "Tripadvisor",
@@ -69,14 +97,18 @@ const LOGOS: CustomerLogo[] = [
     src: "/assets/v1/logos/baerskin.svg",
     width: 176,
     height: 25,
+    caseStudyHref: "/customers/baerskin-tactical",
   },
   {
     name: "Outtake",
     src: "/assets/v1/logos/outtake.svg",
     width: 153,
     height: 27,
+    caseStudyHref: "/customers/outtake",
   },
 ];
+
+const REF = "logo-strip";
 
 interface LogoStripProps {
   /**
@@ -90,6 +122,72 @@ interface LogoStripProps {
   contained?: boolean;
 }
 
+function LogoMark({
+  logo,
+  decorative,
+}: {
+  logo: CustomerLogo;
+  /** Second marquee copy — hide from a11y / focus. */
+  decorative: boolean;
+}) {
+  const img = (
+    <img
+      src={logo.src}
+      alt={decorative ? "" : logo.name}
+      width={logo.width}
+      height={logo.height}
+      style={{
+        height: `clamp(${Math.round(logo.height * 0.6)}px, 4vw, ${logo.height}px)`,
+        width: "auto",
+        transform: logo.dy ? `translateY(${logo.dy}px)` : undefined,
+      }}
+      className="shrink-0 opacity-70 motion-safe:transition-opacity motion-safe:duration-300 motion-safe:ease-v1-out group-hover/logo:opacity-100"
+    />
+  );
+
+  if (!logo.caseStudyHref) {
+    return (
+      <span className="group/logo logo-item relative shrink-0">{img}</span>
+    );
+  }
+
+  const href = `${logo.caseStudyHref}?ref=${REF}`;
+  const className =
+    "group/logo logo-item relative shrink-0 outline-none focus-visible:opacity-100";
+
+  // Shared visual chrome (dot + tooltip) for both the interactive link
+  // and the decorative duplicate so both marquee copies look identical.
+  const chrome = (
+    <>
+      {img}
+      <span
+        aria-hidden="true"
+        className="absolute -right-1.5 -top-1 size-1.5 rounded-full bg-v1-accent-salmon shadow-[0_0_0_2px_rgb(var(--color-v1-bg-canvas-base))] sm:size-[7px]"
+      />
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute left-1/2 top-[calc(100%+8px)] z-10 -translate-x-1/2 whitespace-nowrap rounded-full bg-v1-surfaceElevated px-2.5 py-1 font-v1Label text-[10px] uppercase leading-none tracking-wide text-v1-frost opacity-0 shadow-[0_0_0_1px_rgb(var(--color-v1-border-subtle))] motion-safe:transition-opacity motion-safe:duration-200 motion-safe:ease-v1-out group-hover/logo:opacity-100 group-focus-visible/logo:opacity-100 sm:text-[11px]"
+      >
+        Read the case study
+      </span>
+    </>
+  );
+
+  if (decorative) {
+    return <span className={className}>{chrome}</span>;
+  }
+
+  return (
+    <Link
+      href={href}
+      className={className}
+      aria-label={`${logo.name} — Read the case study`}
+    >
+      {chrome}
+    </Link>
+  );
+}
+
 export default function LogoStrip({ contained = false }: LogoStripProps) {
   // Soft 120px fade at both horizontal edges so logos drift in/out of view
   // instead of hard-cutting. `[--mask]` keeps both the standard and the
@@ -100,7 +198,7 @@ export default function LogoStrip({ contained = false }: LogoStripProps) {
   const strip = (
     <section
       aria-label="Trusted by"
-      className="group/strip relative mt-2.5 overflow-hidden py-[26.5px] lg:mt-0 lg:py-12"
+      className="group/strip relative mt-2.5 overflow-hidden py-10 lg:mt-0 lg:py-14"
       // The horizontal edge gradient lives on this fixed-width clip window —
       // NOT on the moving track — so the 120px fade maps to the visible left/
       // right edges. On the track the mask would scroll with it and the fade
@@ -114,7 +212,7 @@ export default function LogoStrip({ contained = false }: LogoStripProps) {
         aria-hidden="true"
         className="pointer-events-none absolute inset-x-0 top-0 z-0 h-24 bg-gradient-to-b from-v1-canvasBase/40 to-transparent"
       />
-      {/* Pause is gated to hovering an actual logo (`group/strip:has(img:hover)`)
+      {/* Pause is gated to hovering an actual logo (`group/strip:has(.logo-item:hover)`)
           rather than anywhere in the section, so passive cursor
           travel across the strip doesn't freeze the marquee.
 
@@ -125,7 +223,7 @@ export default function LogoStrip({ contained = false }: LogoStripProps) {
           — a single flex-gap row would leave a half-gap of empty space at
           the seam since the duplicated track has one fewer gap than logos. */}
       <div
-        className="relative flex w-max items-center motion-safe:animate-[v1-logo-marquee_40s_linear_infinite] motion-safe:group-[:has(img:hover)]/strip:[animation-play-state:paused]"
+        className="relative flex w-max items-center motion-safe:animate-[v1-logo-marquee_40s_linear_infinite] motion-safe:group-[:has(.logo-item:hover)]/strip:[animation-play-state:paused]"
       >
         {[0, 1].map((copy) => (
           <div
@@ -134,18 +232,10 @@ export default function LogoStrip({ contained = false }: LogoStripProps) {
             className="flex shrink-0 items-center gap-x-[21px] pr-[21px] lg:gap-x-20 lg:pr-20"
           >
             {LOGOS.map((logo) => (
-              <img
+              <LogoMark
                 key={`${logo.name}-${copy}`}
-                src={logo.src}
-                alt={copy === 0 ? logo.name : ""}
-                width={logo.width}
-                height={logo.height}
-                style={{
-                  height: `clamp(${Math.round(logo.height * 0.6)}px, 4vw, ${logo.height}px)`,
-                  width: "auto",
-                  transform: logo.dy ? `translateY(${logo.dy}px)` : undefined,
-                }}
-                className="shrink-0 opacity-70 motion-safe:transition-opacity motion-safe:duration-300 motion-safe:ease-v1-out hover:opacity-100"
+                logo={logo}
+                decorative={copy === 1}
               />
             ))}
           </div>
@@ -157,7 +247,7 @@ export default function LogoStrip({ contained = false }: LogoStripProps) {
   if (!contained) return strip;
 
   // Centered to the shared page container so the row aligns with sibling
-  // sections; the section's own `overflow-hidden` clips the marquee to this
+  // sections; the section's own overflow clips the marquee to this
   // width and the edge gradient fades at the container boundary.
   return (
     <div className="mx-auto w-full max-w-[1440px] px-6 lg:px-8">

--- a/content/customers/cubic.mdx
+++ b/content/customers/cubic.mdx
@@ -3,7 +3,7 @@ title: >-
   How cubic reduced false positives by 51% by orchestrating their multi-agent
   system with Inngest
 companyName: cubic
-logo: /assets/customers/day-ai-logo-2.svg
+logo: /assets/customers/cubic/logo.svg
 companyEmployees: 2-20
 companyIndustry: SaaS / AI Agents
 companyUseCase: Coding Agents

--- a/content/customers/otto.mdx
+++ b/content/customers/otto.mdx
@@ -3,6 +3,7 @@ title: Leveraging multi-tenant concurrency to scale AI workflows
 companyName: Otto
 logo: /assets/customers/otto-logo.svg
 logoScale: 1
+pill: Otto was acquired by Cohere
 quote:
   text: >-
     Inngest completely transformed how we handle AI orchestration at Otto. Its


### PR DESCRIPTION
## Summary
- Add orange case-study indicator dots on the home logo strip for Cubic, Cohere (→ Otto), Soundcloud, GitBook, Resend, BAERskin, and Outtake, with a “Read the case study” hover tooltip and link
- Add a blue note tag on the Otto customer story for the Cohere acquisition
- Fix the Cubic customer story sidebar logo (was incorrectly using the Day AI mark)

## Test plan
- [x] On `/`, confirm orange dots appear only on the logos listed above
- [x] Hover a dotted logo: marquee pauses, “Read the case study” tooltip shows, click opens the matching `/customers/...` page with `?ref=logo-strip`
- [x] Cohere logo links to `/customers/otto`
- [x] On `/customers/otto`, confirm the blue “Note · Otto was acquired by Cohere” tag
- [x] On `/customers/cubic`, confirm the Cubic logo (square + wordmark) in the sidebar card


Made with [Cursor](https://cursor.com)