### PR TITLE
Unlist the September 4 incident report from the blog feed

### DIFF
--- a/app/(v1)/blog/[slug]/page.tsx
+++ b/app/(v1)/blog/[slug]/page.tsx
@@ -171,6 +171,7 @@ function loadRelated(currentSlug: string): RelatedPost[] {
     .map((p): RelatedPost | null => {
       const fm = p.data;
       if (fm.redirect) return null;
+      if (fm.hide) return null;
       if (fm.unreleased) return null;
       if (!fm.heading) return null;
       const date =

--- a/components/Blog/index.ts
+++ b/components/Blog/index.ts
@@ -26,7 +26,8 @@ export type BlogPost = {
   focus?: boolean;
   /** Hero CTA label on /blog when this post is `focus` (default: "Read article") */
   focusCta?: string;
-  // When hidden, the post will be available on at the URL, but not in any blog feed of RSS
+  // When hidden, the post will be available at the URL, but not in the blog
+  // index, related cards, RSS, blog.txt, or the .md mirror
   hide?: boolean;
   // When set, the post is gated behind ?unreleased=<label>: hidden from the blog
   // index, related cards, RSS, blog.txt, and the .md mirror, and its page 404s

--- a/content/blog/2026-09-04-incident-report-for-september-4-2026.md
+++ b/content/blog/2026-09-04-incident-report-for-september-4-2026.md
@@ -1,6 +1,7 @@
 ---
 focus: false
 featured: false
+hide: true
 heading: "Incident report for September 4, 2026 - Network connectivity issues"
 subtitle: A report on the network connectivity incident that temporarily disrupted Inngest services.
 image: /assets/blog/incident-post-mortem.svg


### PR DESCRIPTION
## Summary
- Hide the September 4 incident post-mortem from `/blog`, RSS, related content cards, and the agent blog index with `hide: true`.
- Leave the post live at `/blog/2026-09-04-incident-report-for-september-4-2026` so existing links still work.

## Test plan
- [ ] Confirm `/blog` no longer shows “Incident report for September 4, 2026”.
- [ ] Confirm related content on other posts (e.g. `/blog/the-queue-is-the-easy-part`) no longer includes the incident report.
- [ ] Confirm `/blog/2026-09-04-incident-report-for-september-4-2026` still loads.
- [ ] Confirm the post is absent from `/rss.xml`.