### PR TITLE
docs: explain multi-tenant flow control keys

### DIFF
--- a/pages/docs/guides/concurrency.mdx
+++ b/pages/docs/guides/concurrency.mdx
@@ -16,7 +16,7 @@ This means you may have many more function runs in progress than your concurrenc
 </Callout>
 
 {/* TODO - Link to updated keys section */}
-Step concurrency can be optionally configured using "keys" which applies the limit to each unique value of the key (ex. user id). The concurrency option can also be applied to different "scopes" which allows a concurrency limit to be shared across _multiple_ functions.
+Step concurrency can be optionally configured using "keys" which applies the limit to each unique value of the key (ex. user id). This creates separate queue groups that provide [best-effort fairness in multi-tenant systems](/docs/guides/multi-tenancy?ref=docs-concurrency). The concurrency option can also be applied to different "scopes" which allows a concurrency limit to be shared across _multiple_ functions.
 
 As compared to traditional queue and worker systems, Inngest manages the concurrency within the system so you do not need to implement additional worker-level logic or state.
 
@@ -97,7 +97,7 @@ inngest.createFunction(
 </CodeGroup>
 
 <Tip>
-  Concurrency keys are great for creating fair, multi-tenant systems. This can help prevent the noisy neighbor issue where one user triggers a lot of jobs and consumes far more resources that slow down your other users.
+  Concurrency keys are great for creating fair, multi-tenant systems. This can help prevent the noisy neighbor issue where one user triggers a lot of jobs and consumes far more resources that slow down your other users. [Learn how flow control keys reduce head-of-line blocking.](/docs/guides/multi-tenancy?ref=docs-concurrency)
 </Tip>
 
 ### Sharing limits across functions (scope)
@@ -217,7 +217,9 @@ The key insight is that your concurrency limit applies to _active execution_, no
 
 ### Queue ordering
 
-**Queues are ordered from oldest to newest jobs ([FIFO](https://en.wikipedia.org/wiki/FIFO))** across the same function.  Ordering amongst different functions is not guaranteed.  This means that within a specific function, Inngest prioritizes finishing older functions above starting newer functions - even if the older functions continue to schedule new steps to run.  Different functions, however, compete for capacity, with runs on the most backlogged function much more likely (but not guaranteed) to be scheduled first.
+Within the same function and flow control key, queues use **best-effort [FIFO](https://en.wikipedia.org/wiki/FIFO) ordering** from oldest to newest jobs. Ordering across different keys or functions is not guaranteed because the scheduler also considers capacity and fairness. This means Inngest generally prioritizes older work within a key while preventing one key's backlog from blocking other keys.
+
+If you change a key expression, existing jobs retain the key that was evaluated when they entered the queue. Only new jobs are grouped using the new expression. Learn more about [multi-tenancy and flow control keys](/docs/guides/multi-tenancy?ref=docs-concurrency#ordering-within-each-key).
 
 ### Additional information
 
@@ -293,8 +295,8 @@ Because functions are FIFO, function runs are more likely to be worked on the ol
 - Concurrency limits the number of steps executing at a single time. It does not _yet_ perform rate limiting over a given period of time.
 - Functions can specify up to 2 concurrency constraints at once
 - The maximum concurrency limit is defined by <a href="/pricing?ref=docs-concurrency" target="_blank" rel="nofollow">your account's plan</a>
-- Ordering amongst the same function is guaranteed (with the exception of retries)
-- Ordering amongst different functions is not guaranteed.  Functions compete with each other randomly to be scheduled.
+- Ordering within the same function and flow control key is best-effort FIFO (with the exception of retries).
+- Ordering across different keys or functions is not guaranteed. The scheduler also considers capacity and fairness.
 
 ## Concurrency reference
 

--- a/pages/docs/guides/flow-control.mdx
+++ b/pages/docs/guides/flow-control.mdx
@@ -4,6 +4,7 @@ import { CardGroup, Card, ImageTheme } from "src/shared/Docs/mdx";
 
 import {
   RiGitPullRequestFill,
+  RiGroupLine,
   RiSlowDownFill,
   RiSkipRightFill,
 } from "@remixicon/react";
@@ -20,6 +21,9 @@ There are several methods to manage flow control for each Inngest function. Lear
 
 
 <CardGroup cols={1}>
+  <Card title="Multi-tenancy" icon={<RiGroupLine className="text-basis h-4 w-4" />} href={'/docs/guides/multi-tenancy?ref=docs-flow-control'}>
+    Group queued work by tenant or resource to reduce head-of-line blocking and provide best-effort fairness.
+  </Card>
   <Card title="Concurrency" icon={<IconConcurrency className="text-basis h-4 w-4" />} href={'/docs/guides/concurrency'}>
     Limit the number of executing steps across your function runs. Ideal for limiting concurrent workloads by user, resource, or in general.
   </Card>

--- a/pages/docs/guides/multi-tenancy.mdx
+++ b/pages/docs/guides/multi-tenancy.mdx
@@ -1,0 +1,70 @@
+export const metaTitle = "Multi-tenant Flow Control with Keys"
+export const description = "Learn how Inngest groups queued work by flow control keys to reduce head-of-line blocking and provide best-effort fairness between tenants."
+
+# Multi-tenancy and flow control
+
+In a multi-tenant system, one tenant can create much more work than another. If every item waits in a single queue, a busy tenant can delay other tenants even when their work is ready to run. This is **head-of-line blocking**, often described as the noisy neighbor problem.
+
+Inngest reduces head-of-line blocking by grouping queued work with flow control **keys**. Each unique key value gets its own application of the configured flow control limit. These per-key groups are sometimes called **key queues**.
+
+## Why group work by key
+
+Consider a function serving two tenants:
+
+| Tenant | Queued work | Current state |
+| --- | ---: | --- |
+| Tenant A | 1,000 items | At its flow control limit |
+| Tenant B | 1 item | Ready to run |
+
+In a single FIFO queue, Tenant B's item can sit behind hundreds of items from Tenant A. Because Tenant A is already at its limit, repeatedly finding its items does not produce runnable work. The chance of reaching Tenant B's item is extremely low until the queue advances far enough.
+
+With a key such as `event.data.tenant_id`, Inngest groups Tenant A and Tenant B into separate key queues. The scheduler can consider Tenant B's ready queue without first moving through Tenant A's backlog. This provides **best-effort fairness** between keys while continuing to enforce each tenant's limit.
+
+Key queues are part of the scheduling and execution system described in the [Inngest Cloud architecture](/docs/architecture?ref=docs-multi-tenancy) overview. You configure the key in your function; Inngest manages the queue grouping and scheduling.
+
+## How flow control keys work
+
+Flow control features such as [concurrency](/docs/guides/concurrency?ref=docs-multi-tenancy) and [throttling](/docs/guides/throttling?ref=docs-multi-tenancy) accept an optional key expression. Inngest evaluates the expression for each item and applies the limit independently to each resulting value.
+
+For example, this function uses the tenant ID for both limits:
+
+```ts
+inngest.createFunction(
+  {
+    id: "sync-tenant-data",
+    triggers: { event: "app/tenant.sync.requested" },
+    concurrency: {
+      key: "event.data.tenant_id",
+      limit: 5,
+    },
+    throttle: {
+      key: "event.data.tenant_id",
+      limit: 100,
+      period: "1m",
+    },
+  },
+  async ({ event, step }) => {
+    await step.run("sync-data", async () => {
+      await syncTenantData(event.data.tenant_id);
+    });
+  }
+);
+```
+
+If events contain `tenant_id` values of `tenant-a` and `tenant-b`, each tenant receives its own concurrency limit of five executing steps and its own throttle limit of 100 run starts per minute. A backlog for one tenant does not consume the other tenant's per-key limit.
+
+Choose a stable key that represents the resource or tenant you want to isolate, such as an account ID, workspace ID, or user ID. Keys are [expressions evaluated from event data](/docs/guides/writing-expressions?ref=docs-multi-tenancy), so the same function can create groups dynamically without you provisioning queues.
+
+## Ordering within each key
+
+Inngest applies [best-effort FIFO ordering](/docs/guides/concurrency?ref=docs-multi-tenancy#queue-ordering) within each key queue. Older work for a key is generally selected before newer work for that same key. Scheduling across different keys favors fairness rather than a single global FIFO order.
+
+If you change a function's key expression, already queued items remain grouped by the key value that was evaluated when they entered the queue. Their relative ordering stays stable. Only newly queued items are grouped using the new key expression.
+
+Best-effort fairness and FIFO ordering are scheduling goals, not strict execution-order guarantees. Retries, available capacity, and other flow control constraints can affect which item runs next.
+
+## Next steps
+
+- [Configure multi-tenant concurrency](/docs/guides/concurrency?ref=docs-multi-tenancy#concurrency-keys-multi-tenant-concurrency)
+- [Configure throttling by key](/docs/guides/throttling?ref=docs-multi-tenancy#how-to-configure-throttling)
+- [Learn how queue items are scheduled and executed](/docs/architecture?ref=docs-multi-tenancy#from-event-to-function-execution)

--- a/pages/docs/guides/throttling.mdx
+++ b/pages/docs/guides/throttling.mdx
@@ -77,7 +77,7 @@ You can configure throttling on each function using the optional `throttle` para
 - `limit`: The total number of runs allowed to start within the given `period`.
 - `period`: The period within the limit will be applied.
 - `burst`: The number of runs allowed to start in the given window in a single burst on top of `limit`.
-- `key`: An optional expression which returns a throttling key using event data. This allows you to apply unique throttle limits specific to a user.
+- `key`: An optional expression which returns a throttling key using event data. This applies the throttle independently to each key value, which can [reduce head-of-line blocking in multi-tenant systems](/docs/guides/multi-tenancy?ref=docs-throttling).
 
 <Callout>
   GCRA breaks down the provided `period` into smaller windows based on the `limit`.

--- a/shared/Docs/navigationStructure.ts
+++ b/shared/Docs/navigationStructure.ts
@@ -612,6 +612,7 @@ const sectionLearn: (NavGroup | NavLink)[] = [
         title: "Flow control",
         links: [
           { title: "Overview", href: `/docs/guides/flow-control` },
+          { title: "Multi-tenancy", href: `/docs/guides/multi-tenancy` },
           { title: "Concurrency", href: `/docs/guides/concurrency` },
           { title: "Throttling", href: `/docs/guides/throttling` },
           { title: "Batching", href: `/docs/guides/batching` },


### PR DESCRIPTION
## Summary

- add a Flow Control explanation page for multi-tenancy and key queues
- explain per-key limits, best-effort FIFO and fairness, key configuration changes, and head-of-line blocking with a two-tenant example
- add the page to navigation and cross-link it from the Flow Control overview, concurrency, and throttling guides
- align the concurrency queue-ordering language with best-effort per-key FIFO behavior

## Context

- Product behavior: supplied in the docs request
- Existing docs: architecture, concurrency, and throttling guides
- Implementation terminology: https://github.com/inngest/inngest/blob/main/pkg/execution/queue/key_queues.go

## Validation

- `git diff --check`
- `pnpm test:docs-markdown` (12 tests passed)
- `pnpm exec tsc --noEmit --pretty false`
- verified all new internal link targets and anchors locally