### PR TITLE
Fix The AI Conference card art and event ordering on /events

### DIFF
--- a/app/(v1)/events/the-ai-conference-2026/page.tsx
+++ b/app/(v1)/events/the-ai-conference-2026/page.tsx
@@ -5,7 +5,7 @@ import TheAIConference2026 from "@/components/v1/pages/TheAIConference2026";
 export const metadata: Metadata = generateMetadata({
   title: "Meet Inngest at The AI Conference 2026",
   description:
-    "Inngest is agent infrastructure that lives in your codebase. Find us at booth #136 at Pier 48 in San Francisco, September 30 – October 1, 2026.",
+    "Inngest is agent infrastructure that lives in your codebase. The AI Conference runs September 29 – October 1, 2026 at Pier 48 in San Francisco — find us at booth #136 on September 30 and October 1.",
 });
 
 export default function Page() {

--- a/components/v1/pages/TheAIConference2026.tsx
+++ b/components/v1/pages/TheAIConference2026.tsx
@@ -17,7 +17,7 @@ const EVENT = {
   endsAt: "2026-10-01T18:00:00-07:00",
   location: "Pier 48, San Francisco, CA | Booth #136",
   description:
-    "Inngest is agent infrastructure that lives in your codebase—write your logic as functions and get retries, flow control, and full observability with zero extra infra.\n\nWe're sponsoring The AI Conference at Pier 48. Come by booth #136 to see Inngest running, talk through the agent or workflow you're building, and grab some swag while you're there.",
+    "Inngest is agent infrastructure that lives in your codebase—write your logic as functions and get retries, flow control, and full observability with zero extra infra.\n\nWe're sponsoring The AI Conference at Pier 48, which runs September 29 – October 1. Our booth is open on the 30th and the 1st — come by #136 to see Inngest running, talk through the agent or workflow you're building, and grab some swag while you're there.",
 };
 
 const REGISTER_URL = "https://aiconference.com/";

--- a/components/v1/sections/Events/EventCard.tsx
+++ b/components/v1/sections/Events/EventCard.tsx
@@ -29,7 +29,7 @@ export default function EventCard({ ev, newTab }: { ev: EventItem; newTab?: bool
           style={{
             backgroundImage: `url(${ev.image ?? "/assets/v1/events/event-placeholder.png"})`,
             backgroundSize: ev.imageFit ?? "cover",
-            backgroundPosition: "center",
+            backgroundPosition: ev.imagePosition ?? "center",
             backgroundRepeat: "no-repeat",
           }}
         />

--- a/components/v1/sections/Events/EventCard.tsx
+++ b/components/v1/sections/Events/EventCard.tsx
@@ -21,7 +21,15 @@ export default function EventCard({ ev, newTab }: { ev: EventItem; newTab?: bool
         aria-hidden="true"
         // Image area is 204px tall. The placeholder lives here at 10%
         // opacity.
-        className={`relative h-[204px] w-full shrink-0 overflow-hidden${ev.imageFit === "contain" ? " bg-black" : ""}`}
+        //
+        // No fill of its own: `contain` images letterbox whenever their
+        // aspect doesn't match this box (~1.909), and painting the box
+        // black put a hard black band beside art that sits on the
+        // frame's #212121→#020202 gradient. Leaving it transparent lets
+        // that gradient show through, so the letterbox area is the card
+        // surface and the bars can't be seen — whatever aspect the art
+        // arrives at.
+        className="relative h-[204px] w-full shrink-0 overflow-hidden"
       >
         <div
           aria-hidden="true"

--- a/components/v1/sections/Events/EventCardLarge.tsx
+++ b/components/v1/sections/Events/EventCardLarge.tsx
@@ -22,10 +22,16 @@ export default function EventCardLarge({ ev, newTab }: { ev: EventItem; newTab?:
       {/* Image column — placeholder stretched to cover. Desktop width
           is the fixed 32.51% column and height comes from the row
           stretch; mobile uses 16/9 so the image still has a visible area
-          when the columns stack. */}
+          when the columns stack.
+
+          Carries no fill of its own: because the height is content-driven
+          the column's aspect is arbitrary, so a `contain` image nearly
+          always letterboxes. Painting it black put a hard black band
+          above and below the art; transparent lets the frame's gradient
+          show through instead, so the bars read as card surface. */}
       <div
         aria-hidden="true"
-        className={`relative aspect-[16/9] w-full shrink-0 sm:aspect-auto sm:w-[32.513%]${ev.image ? "" : " opacity-10"}${ev.imageFit === "contain" ? " bg-black" : ""}`}
+        className={`relative aspect-[16/9] w-full shrink-0 sm:aspect-auto sm:w-[32.513%]${ev.image ? "" : " opacity-10"}`}
         style={{
           backgroundImage: `url(${ev.image ?? "/assets/v1/events/event-placeholder.png"})`,
           backgroundSize: ev.imageFit ?? "cover",

--- a/components/v1/sections/Events/EventCardLarge.tsx
+++ b/components/v1/sections/Events/EventCardLarge.tsx
@@ -29,7 +29,7 @@ export default function EventCardLarge({ ev, newTab }: { ev: EventItem; newTab?:
         style={{
           backgroundImage: `url(${ev.image ?? "/assets/v1/events/event-placeholder.png"})`,
           backgroundSize: ev.imageFit ?? "cover",
-          backgroundPosition: "center",
+          backgroundPosition: ev.imagePosition ?? "center",
           backgroundRepeat: "no-repeat",
         }}
       >

--- a/components/v1/sections/Events/UpcomingEvents.tsx
+++ b/components/v1/sections/Events/UpcomingEvents.tsx
@@ -1,8 +1,11 @@
 import EventCardLarge from "@/components/v1/sections/Events/EventCardLarge";
-import { UPCOMING, isPastEvent } from "@/components/v1/sections/Events/data";
+import { UPCOMING, isPastEvent, sortEventsByDate } from "@/components/v1/sections/Events/data";
 
 export default function UpcomingEvents() {
-  const upcoming = UPCOMING.filter((ev) => !isPastEvent(ev));
+  // Sort rather than trust the array order: UPCOMING is hand-edited, so a
+  // newly added event gets appended to the end and would otherwise render
+  // last no matter when it actually happens.
+  const upcoming = sortEventsByDate(UPCOMING.filter((ev) => !isPastEvent(ev)));
 
   // Once every event has started there is nothing to promote, so drop the
   // whole section rather than leaving a bare "Upcoming Events" heading over

--- a/components/v1/sections/Events/data.ts
+++ b/components/v1/sections/Events/data.ts
@@ -40,6 +40,13 @@ export interface EventItem {
   image?: string;
   /** Tile/card image fit. Use `contain` for text-heavy graphics. */
   imageFit?: "cover" | "contain";
+  /**
+   * `background-position` for the tile/card image. Defaults to `center`.
+   * Set this when a `cover` crop would eat content that sits off-centre —
+   * e.g. artwork with all its type on the left and a bleed pattern on the
+   * right, which wants `left center` so the crop lands on the pattern.
+   */
+  imagePosition?: string;
 }
 
 // An event stays "upcoming" until it is actually over: multi-day events
@@ -52,16 +59,19 @@ export function isPastEvent(ev: {
   return new Date(ev.endsAt ?? ev.startsAt).getTime() < Date.now();
 }
 
-// Past events first (most recently completed leads), then upcoming
-// events after (soonest leads).
+// Upcoming events first (soonest leads), then past events after (most
+// recently completed leads). Anything still open to register for is what
+// the page is promoting, so it belongs above the archive — otherwise a
+// newly added event lands at the very bottom of "All Events", behind
+// every event that has already happened.
 export function sortEventsByDate(events: EventItem[]): EventItem[] {
-  const past = events
-    .filter((ev) => isPastEvent(ev))
-    .sort((a, b) => b.startsAt.localeCompare(a.startsAt));
   const upcoming = events
     .filter((ev) => !isPastEvent(ev))
     .sort((a, b) => a.startsAt.localeCompare(b.startsAt));
-  return [...past, ...upcoming];
+  const past = events
+    .filter((ev) => isPastEvent(ev))
+    .sort((a, b) => b.startsAt.localeCompare(a.startsAt));
+  return [...upcoming, ...past];
 }
 
 export const UPCOMING: EventItem[] = [
@@ -178,8 +188,13 @@ export const UPCOMING: EventItem[] = [
     excerpt:
       "Find us at booth #136 at Pier 48. Come see how teams run agents and workflows on infrastructure that lives in their own codebase.",
     href: "/events/the-ai-conference-2026",
+    // Full-bleed 16:9 artwork, so it fills the card — `contain`
+    // letterboxed it against the frame gradient. The large card's image
+    // column is narrower than 16:9 and so crops the sides: anchor left,
+    // because all the type lives in the left panel and the crop then
+    // lands on the bleed pattern instead.
     image: "/assets/v1/events/the-ai-conference-2026.png",
-    imageFit: "contain",
+    imagePosition: "left center",
   },
 ];
 
@@ -358,8 +373,13 @@ export const ALL_EVENTS: EventItem[] = sortEventsByDate([
     excerpt:
       "Find us at booth #136 at Pier 48. Come see how teams run agents and workflows on infrastructure that lives in their own codebase.",
     href: "/events/the-ai-conference-2026",
+    // Full-bleed 16:9 artwork, so it fills the card — `contain`
+    // letterboxed it against the frame gradient. The large card's image
+    // column is narrower than 16:9 and so crops the sides: anchor left,
+    // because all the type lives in the left panel and the crop then
+    // lands on the bleed pattern instead.
     image: "/assets/v1/events/the-ai-conference-2026.png",
-    imageFit: "contain",
+    imagePosition: "left center",
   },
 ]);
 

--- a/components/v1/sections/Events/data.ts
+++ b/components/v1/sections/Events/data.ts
@@ -161,8 +161,10 @@ export const UPCOMING: EventItem[] = [
     excerpt:
       "Swing by the Inngest office for pastries, espresso, and good conversation — drop in anytime, no fixed schedule.",
     href: "/events/innhouse-sf-coffee-chats",
+    // Photograph, so it fills the card: `contain` floated it with card
+    // showing either side, and the overlaid text sits well inside the
+    // ~3% top/bottom that `cover` crops off a 16:9 image in this box.
     image: "/assets/v1/events/innhouse-sf-coffee.png",
-    imageFit: "contain",
   },
   {
     id: "inngest-supper-club-sf",
@@ -346,8 +348,10 @@ export const ALL_EVENTS: EventItem[] = sortEventsByDate([
     excerpt:
       "Swing by the Inngest office for pastries, espresso, and good conversation — drop in anytime, no fixed schedule.",
     href: "/events/innhouse-sf-coffee-chats",
+    // Photograph, so it fills the card: `contain` floated it with card
+    // showing either side, and the overlaid text sits well inside the
+    // ~3% top/bottom that `cover` crops off a 16:9 image in this box.
     image: "/assets/v1/events/innhouse-sf-coffee.png",
-    imageFit: "contain",
   },
   {
     id: "inngest-supper-club-sf",


### PR DESCRIPTION
Three fixes to `/events`, all surfaced by the AI Conference entry. Split out of #1892, which had one of them committed alongside the long-run landing page work.

### The AI Conference card art

The entry was set to `imageFit: "contain"`, which letterboxed the full-bleed 16:9 artwork against the card's gradient. Plain `cover` fixed the letterbox but clipped the type on the left, because the featured card's image column is ~1.56 and crops the sides rather than the top and bottom.

It's now `cover` anchored left, so the crop lands on the bleed pattern on the right and the whole left panel survives. That needed a new optional `imagePosition` on `EventItem`, wired into both card components and defaulting to `center`, so no other card changes.

### Upcoming events sorted above past ones

`sortEventsByDate` returned `[...past, ...upcoming]`, so anything still open to register for sorted below every event that had already happened — the AI Conference sat at the very bottom of "All Events". Now `[...upcoming, ...past]`: upcoming soonest-first, then past newest-first.

`UpcomingEvents` was also rendering `UPCOMING` in raw array order, which looks right today only because the AI Conference is the sole non-past entry; the next event appended would render last regardless of date. It sorts now too.

The detail-page "Other upcoming events" rails filter to non-past before sorting, so they're unaffected.

### Conference vs. booth dates

The artwork reads "September 29 - October 1" because that's the conference; the site said "September 30 - October 1" because that's when our booth is staffed. Neither was wrong, so the metadata and page copy now state both instead of contradicting the graphic.

The displayed date and `startsAt`/`endsAt` stay on the booth dates, so the card keeps its live Register CTA through the last day we're there and flips to "past" only after.

### Also included

The `contain` letterbox fix for the event cards generally (`bg-black` behind `contain` images, and the Innhouse photo switched to `cover`). This was previously commit `9c455537` on #1892; that branch has been rewritten to contain only long-run changes, so the two PRs no longer share files.

### Verification

`tsc --noEmit` clean. `/events` and `/events/the-ai-conference-2026` checked in the dev server: card art fills with all type intact at both card sizes, AI Conference leads both sections, past events follow newest-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)