### PR TITLE
docs: clarify key queue availability

### DIFF
--- a/pages/docs/guides/multi-tenancy.mdx
+++ b/pages/docs/guides/multi-tenancy.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "src/shared/Docs/mdx";
+
 export const metaTitle = "Multi-tenant Flow Control with Keys"
 export const description = "Learn how Inngest groups queued work by flow control keys to reduce head-of-line blocking and provide best-effort fairness between tenants."
 
@@ -6,6 +8,10 @@ export const description = "Learn how Inngest groups queued work by flow control
 In a multi-tenant system, one tenant can create much more work than another. If every item waits in a single queue, a busy tenant can delay other tenants even when their work is ready to run. This is **head-of-line blocking**, often described as the noisy neighbor problem.
 
 Inngest reduces head-of-line blocking by grouping queued work with flow control **keys**. Each unique key value gets its own application of the configured flow control limit. These per-key groups are sometimes called **key queues**.
+
+<Callout variant="info">
+  **Availability:** The key queue scheduling system described on this page is currently available to Enterprise customers on request. [Contact our team](/contact?ref=docs-multi-tenancy) to request access. We plan to make key queues more broadly available in the future.
+</Callout>
 
 ## Why group work by key
 


### PR DESCRIPTION
## Summary

- add an availability callout to the multi-tenancy and flow control guide
- clarify that the key queue scheduling system is currently available to Enterprise customers on request
- note that broader availability is planned and link readers to the contact page

## Context

- Follow-up to #1895
- Product availability: supplied in the docs request
- Account-level implementation gate: https://github.com/inngest/inngest/blob/main/pkg/execution/queue/key_queues.go

## Validation

- `git diff --check`
- `pnpm test:docs-markdown` (12 tests passed)
- `pnpm exec tsc --noEmit --pretty false`